### PR TITLE
tee: do not retry on EINTR

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -249,26 +249,23 @@ enum Writer {
 
 impl Writer {
     pub fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        let mut buf = buf;
-        while !buf.is_empty() {
-            match self {
-                Self::File(f) => match f.write(buf) {
-                    Ok(0) => return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer")),
-                    Ok(n) => buf = &buf[n..],
-                    Err(e) => return Err(e),
-                },
-                Self::Stdout(s) => match s.write(buf) {
-                    Ok(0) => return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer")),
-                    Ok(n) => {
-                        buf = &buf[n..];
-                        #[cfg(not(any(unix, target_os = "wasi")))]
-                        s.flush()?;
-                    }
-                    Err(e) => return Err(e),
-                },
+        #[cfg(any(unix, target_os = "wasi"))]
+        use uucore::io::AsFdExt as _;
+        match self {
+            // File does not have line buffering
+            #[cfg(any(unix, target_os = "wasi"))]
+            Self::File(f) => f.write_all_no_retry(buf),
+            #[cfg(not(any(unix, target_os = "wasi")))]
+            Self::File(f) => f.write_all(buf),
+            #[cfg(any(unix, target_os = "wasi"))]
+            Self::Stdout(s) => s.0.write_all_no_retry(buf),
+            #[cfg(not(any(unix, target_os = "wasi")))]
+            Self::Stdout(s) => {
+                s.write_all(buf)?;
+                // needs unsafe to remove buffering... flush after write_all to keep overhead minimal
+                s.flush()
             }
         }
-        Ok(())
     }
 }
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -249,18 +249,31 @@ enum Writer {
 
 impl Writer {
     pub fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        match self {
-            // File does not have line buffering
-            Self::File(f) => f.write_all(buf),
-            #[cfg(any(unix, target_os = "wasi"))]
-            Self::Stdout(s) => s.write_all(buf),
-            #[cfg(not(any(unix, target_os = "wasi")))]
-            Self::Stdout(s) => {
-                s.write_all(buf)?;
-                // needs unsafe to remove buffering... flush after write_all to keep overhead minimal
-                s.flush()
+        let mut buf = buf;
+        let writer: &mut dyn Write = match self {
+            Self::File(f) => f,
+            Self::Stdout(s) => s,
+        };
+        while !buf.is_empty() {
+            match writer.write(buf) {
+                Ok(0) => {
+                    return Err(Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
+                Ok(n) => {
+                    buf = &buf[n..];
+                    #[cfg(not(any(unix, target_os = "wasi")))]
+                    if let Self::Stdout(s) = self {
+                        // needs unsafe to remove buffering... flush after write_all to keep overhead minimal
+                        writer.flush()?;
+                    }
+                }
+                Err(e) => return Err(e),
             }
         }
+        Ok(())
     }
 }
 

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -250,27 +250,22 @@ enum Writer {
 impl Writer {
     pub fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         let mut buf = buf;
-        let writer: &mut dyn Write = match self {
-            Self::File(f) => f,
-            Self::Stdout(s) => s,
-        };
         while !buf.is_empty() {
-            match writer.write(buf) {
-                Ok(0) => {
-                    return Err(Error::new(
-                        ErrorKind::WriteZero,
-                        "failed to write whole buffer",
-                    ));
-                }
-                Ok(n) => {
-                    buf = &buf[n..];
-                    #[cfg(not(any(unix, target_os = "wasi")))]
-                    if let Self::Stdout(s) = self {
-                        // needs unsafe to remove buffering... flush after write_all to keep overhead minimal
-                        writer.flush()?;
+            match self {
+                Self::File(f) => match f.write(buf) {
+                    Ok(0) => return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer")),
+                    Ok(n) => buf = &buf[n..],
+                    Err(e) => return Err(e),
+                },
+                Self::Stdout(s) => match s.write(buf) {
+                    Ok(0) => return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer")),
+                    Ok(n) => {
+                        buf = &buf[n..];
+                        #[cfg(not(any(unix, target_os = "wasi")))]
+                        s.flush()?;
                     }
-                }
-                Err(e) => return Err(e),
+                    Err(e) => return Err(e),
+                },
             }
         }
         Ok(())

--- a/src/uucore/src/lib/mods/io.rs
+++ b/src/uucore/src/lib/mods/io.rs
@@ -53,6 +53,31 @@ impl<T: AsFd> io::Write for RawWriter<T> {
     }
 }
 
+// write_all retries with EINTR which is sometimes not compatible with GNU
+#[cfg(any(unix, target_os = "wasi"))]
+pub trait AsFdExt {
+    fn write_all_no_retry(&self, buf: &[u8]) -> io::Result<()>;
+}
+#[cfg(any(unix, target_os = "wasi"))]
+impl<T: AsFd> AsFdExt for T {
+    fn write_all_no_retry(&self, mut buf: &[u8]) -> io::Result<()> {
+        let fd = self.as_fd();
+        while !buf.is_empty() {
+            match rustix::io::write(fd, buf) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+}
+
 /// abstraction wrapper for native file handle / file descriptor
 // todo: remove clone introducing additional syscall dependency
 pub struct OwnedFileDescriptorOrHandle {

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -700,6 +700,7 @@ mod linux_only {
 
     #[test]
     fn test_eintr_on_write_is_not_retried() {
+        use std::io::Write;
         if std::process::Command::new("strace")
             .arg("--version")
             .output()
@@ -707,8 +708,6 @@ mod linux_only {
         {
             return;
         }
-
-        use std::io::Write;
 
         let mut child = std::process::Command::new("strace")
             .args([

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -697,6 +697,53 @@ mod linux_only {
         assert_eq!(at.read(file_out_b), content);
         assert!(result.stderr_str().contains("No space left on device"));
     }
+
+    #[test]
+    fn test_eintr_on_write_is_not_retried() {
+        if std::process::Command::new("strace")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+
+        use std::io::Write;
+
+        let mut child = std::process::Command::new("strace")
+            .args([
+                "-o",
+                "/dev/null", // suppress strace's own output
+                "-e",
+                "inject=write:error=EINTR:when=1",
+                env!("CARGO_BIN_EXE_coreutils"),
+                "tee",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn strace");
+
+        // Write something so tee actually calls write()
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(b"hello\n");
+            // drop stdin to send EOF
+        }
+
+        let result = child.wait_with_output().expect("failed to wait");
+
+        let stderr = String::from_utf8_lossy(&result.stderr);
+
+        assert!(
+            !result.status.success(),
+            "tee should have failed on EINTR but exited zero.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("Interrupted system call"),
+            "expected 'Interrupted system call' in stderr, got: {stderr}"
+        );
+    }
 }
 
 // Additional cross-platform tee tests to cover GNU compatibility around --output-error


### PR DESCRIPTION
Related to #12469

`Writer::write_all` was delegating to the standard library's `write_all`, which unconditionally retries on EINTR.

Replaces the `write_all` delegation with a manual loop that calls `write()` directly and propagates `EINTR` immediately without retrying.