### PR TITLE
dircolors: turn integration test into unit tests

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -261,7 +261,7 @@ pub fn uu_app() -> Command {
         )
 }
 
-pub trait StrUtils {
+trait StrUtils {
     /// Remove comments and trim whitespace
     fn purify(&self) -> &Self;
     /// Like `split_whitespace()` but only produce 2 parts

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -534,4 +534,24 @@ mod tests {
         assert_eq!(Some(OutputFmt::Shell), guess_syntax("foo"));
         assert_eq!(None, guess_syntax(""));
     }
+
+    #[test]
+    fn test_purify() {
+        let s = "  asd#zcv #hk\t\n  ";
+        assert_eq!("asd#zcv", s.purify());
+    }
+
+    #[test]
+    fn test_fnmatch() {
+        let s = "con256asd";
+        assert!(s.fnmatch("*[2][3-6][5-9]?sd")); // spell-checker:disable-line
+    }
+
+    #[test]
+    fn test_split_two() {
+        let s = "zxc \t\nqwe jlk    hjl"; // spell-checker:disable-line
+        let (k, v) = s.split_two();
+        assert_eq!("zxc", k);
+        assert_eq!("qwe jlk    hjl", v);
+    }
 }

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -2,12 +2,12 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+
 // spell-checker:ignore overridable colorterm
+
 #[cfg(target_os = "linux")]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
-
-use dircolors::StrUtils;
 
 #[test]
 #[cfg(target_os = "linux")]
@@ -28,20 +28,6 @@ fn test_dircolors_non_utf8_paths() {
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
-}
-
-#[test]
-fn test_str_utils() {
-    let s = "  asd#zcv #hk\t\n  ";
-    assert_eq!("asd#zcv", s.purify());
-
-    let s = "con256asd";
-    assert!(s.fnmatch("*[2][3-6][5-9]?sd")); // spell-checker:disable-line
-
-    let s = "zxc \t\nqwe jlk    hjl"; // spell-checker:disable-line
-    let (k, v) = s.split_two();
-    assert_eq!("zxc", k);
-    assert_eq!("qwe jlk    hjl", v);
 }
 
 #[test]


### PR DESCRIPTION
This PR turns an integration test into three unit tests, allowing us to make the `StrUtils` trait private.

There is another integration test that isn't an integration test. To keep this PR small, I left it for a future PR as it also should integrate changes from https://github.com/uutils/coreutils/pull/12228