### PR TITLE
dircolors: remove commented out code & make two functions private

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -180,18 +180,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if files.is_empty() {
         writeln!(stdout(), "{}", generate_ls_colors(&out_format, ":"))?;
         return Ok(());
-        /*
-        // Check if data is being piped into the program
-        if std::io::stdin().is_terminal() {
-            // No data piped, use default behavior
-            writeln!(stdout(), "{}", generate_ls_colors(&out_format, ":"))?;
-            return Ok(());
-        } else {
-            // Data is piped, process the input from stdin
-            let fin = BufReader::new(std::io::stdin());
-            result = parse(fin.lines().map_while(Result::ok), &out_format, "-");
-        }
-         */
     } else if files.len() > 1 {
         return Err(UUsageError::new(
             1,

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -73,7 +73,7 @@ fn get_colors_format_strings(fmt: &OutputFmt) -> (String, String) {
     (prefix, suffix)
 }
 
-pub fn generate_type_output(fmt: &OutputFmt) -> String {
+fn generate_type_output(fmt: &OutputFmt) -> String {
     match fmt {
         OutputFmt::Display => FILE_TYPES
             .iter()
@@ -473,7 +473,7 @@ fn escape(s: &str) -> String {
     result
 }
 
-pub fn generate_dircolors_config() -> String {
+fn generate_dircolors_config() -> String {
     let mut config = String::new();
 
     config.push_str(


### PR DESCRIPTION
This PR removes some commented out code that was added almost three years ago (https://github.com/uutils/coreutils/pull/5611/changes/b0fdb1edef1a197c95faf83ffbb325190dfee9c3) and is probably not needed. I also sneaked in another trivial change that makes two functions private.