### PR TITLE
shred: fix --remove=unlink with relative paths

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -719,7 +719,7 @@ fn wipe_file(
     }
 
     if remove_method != RemoveMethod::None {
-        do_remove(path, path_str, verbose, remove_method).map_err_context(
+        do_remove(path, verbose, remove_method).map_err_context(
             || translate!("shred-failed-to-remove-file", "file" => path.maybe_quote()),
         )?;
     }
@@ -824,21 +824,16 @@ fn wipe_name(orig_path: &Path, verbose: bool, remove_method: RemoveMethod) -> Pa
     last_path
 }
 
-fn do_remove(
-    path: &Path,
-    orig_filename: &OsString,
-    verbose: bool,
-    remove_method: RemoveMethod,
-) -> Result<(), io::Error> {
+fn do_remove(path: &Path, verbose: bool, remove_method: RemoveMethod) -> Result<(), io::Error> {
     if verbose {
         show_error!(
             "{}",
-            translate!("shred-removing", "file" => orig_filename.maybe_quote())
+            translate!("shred-removing", "file" => path.maybe_quote())
         );
     }
 
     let remove_path = if remove_method == RemoveMethod::Unlink {
-        path.with_file_name(orig_filename)
+        path.to_path_buf()
     } else {
         wipe_name(path, verbose, remove_method)
     };
@@ -848,7 +843,7 @@ fn do_remove(
     if verbose {
         show_error!(
             "{}",
-            translate!("shred-removed", "file" => orig_filename.maybe_quote())
+            translate!("shred-removed", "file" => path.maybe_quote())
         );
     }
 

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -75,6 +75,20 @@ fn test_shred_remove_unlink() {
 }
 
 #[test]
+fn test_shred_remove_unlink_relative_path() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.mkdir_all("dir1/dir2");
+    at.write("dir1/dir2/file1", "test data");
+
+    ucmd.arg("--remove=unlink")
+        .arg("dir1/dir2/file1")
+        .succeeds();
+
+    assert!(!at.file_exists("dir1/dir2/file1"));
+}
+
+#[test]
 fn test_shred_remove_wipe() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
Fixes #12504.

`shred --remove=unlink` failed when given a relative path with directory components.

`do_remove` was calling `path.with_file_name(orig_filename)` where `orig_filename` was the full relative path, causing the directory components to be duplicated.

Since `path` already contains the correct full path, use it directly instead of reconstructing it.
