### PR TITLE
chown: -h on symlink to directory operates on link, not target

### DIFF
--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -309,7 +309,8 @@ impl ChownExecutor {
         let ret = if self.matched(meta.uid(), meta.gid()) {
             // Use safe syscalls for root directory to prevent TOCTOU attacks on Linux
             #[cfg(target_os = "linux")]
-            let chown_result = if path.is_dir() {
+            // We cannot check path.is_dir() here, as this would resolve symlinks
+            let chown_result = if meta.is_dir() {
                 // For directories on Linux, use safe traversal from the start
                 match DirFd::open(path, SymlinkBehavior::Follow) {
                     Ok(dir_fd) => self

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) agroupthatdoesntexist auserthatdoesntexist cuuser groupname notexisting passgrp
 
+use std::os::unix::fs::MetadataExt;
 use uutests::util::{CmdResult, TestScenario, is_ci, run_ucmd_as_root};
 use uutests::util_name;
 use uutests::{at_and_ucmd, new_ucmd};
@@ -896,4 +897,43 @@ fn test_chown_reference_file() {
         .succeeds()
         .stderr_contains("ownership of 'b' retained as")
         .no_stdout();
+}
+
+#[test]
+#[cfg(unix)]
+fn test_chown_no_dereference_symlink_to_dir() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let result = scene.cmd("whoami").run();
+    if skipping_test_is_okay(&result, "whoami: cannot find name for user ID") {
+        return;
+    }
+    let user_name = String::from(result.stdout_str().trim());
+    assert!(!user_name.is_empty());
+
+    at.mkdir("dir");
+    at.symlink_dir("dir", "link_to_dir");
+
+    let link_meta_before = std::fs::symlink_metadata(at.plus("link_to_dir")).unwrap();
+    let link_ctime_before = (link_meta_before.ctime(), link_meta_before.ctime_nsec());
+
+    let dir_meta_before = std::fs::metadata(at.plus("dir")).unwrap();
+    let dir_ctime_before = (dir_meta_before.ctime(), dir_meta_before.ctime_nsec());
+
+    scene
+        .ucmd()
+        .arg("--no-dereference")
+        .arg(&user_name)
+        .arg("link_to_dir")
+        .succeeds();
+
+    let link_meta_after = std::fs::symlink_metadata(at.plus("link_to_dir")).unwrap();
+    let link_ctime_after = (link_meta_after.ctime(), link_meta_after.ctime_nsec());
+
+    let dir_meta_after = std::fs::metadata(at.plus("dir")).unwrap();
+    let dir_ctime_after = (dir_meta_after.ctime(), dir_meta_after.ctime_nsec());
+
+    assert_ne!(link_ctime_before, link_ctime_after, "link's ctime should have advanced");
+    assert_eq!(dir_ctime_before, dir_ctime_after, "dir's ctime should not have changed");
 }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -934,6 +934,12 @@ fn test_chown_no_dereference_symlink_to_dir() {
     let dir_meta_after = std::fs::metadata(at.plus("dir")).unwrap();
     let dir_ctime_after = (dir_meta_after.ctime(), dir_meta_after.ctime_nsec());
 
-    assert_ne!(link_ctime_before, link_ctime_after, "link's ctime should have advanced");
-    assert_eq!(dir_ctime_before, dir_ctime_after, "dir's ctime should not have changed");
+    assert_ne!(
+        link_ctime_before, link_ctime_after,
+        "link's ctime should have advanced"
+    );
+    assert_eq!(
+        dir_ctime_before, dir_ctime_after,
+        "dir's ctime should not have changed"
+    );
 }


### PR DESCRIPTION
Fixes #11887

`chown -h` on a symlink-to-directory chowned the target instead of the link. The Linux fast path used `Path::is_dir()`, which resolves symlinks and routed the call into the directory-traversal branch.

Switch to `Metadata::is_dir()` on the already-`lstat`'d metadata so the `--no-dereference` contract is preserved. Added regression test `test_chown_no_dereference_symlink_to_dir` that creates a symlink to a directory, runs `chown --no-dereference`, and asserts via `ctime` that the syscall touched the symlink's inode (link's ctime advances) and not the target's (directory's ctime is unchanged). Confirmed the test fails on the unfixed code and passes with the fix.

#### Repro (from #11887)
```sh
$ chown -h nobody root                 # symlink: root -> /root
$ ls -ld /root root
drwx------ nobody root  /root          # ← bug: target chowned
lrwxrwxrwx root   root  root -> /root  # ← bug: link untouched

# GNU does the opposite
$ gnuchown -h nobody root
drwx------ root   root  /root
lrwxrwxrwx nobody root  root -> /root
```