### PR TITLE
uucore: fix C.UTF-8 locale incorrectly detected as ASCII

### DIFF
--- a/src/uucore/src/lib/features/i18n/collator.rs
+++ b/src/uucore/src/lib/features/i18n/collator.rs
@@ -61,9 +61,9 @@ pub fn should_use_locale_collation() -> bool {
 pub fn init_locale_collation() -> bool {
     use crate::i18n::{UEncoding, get_locale_encoding};
 
-    // Check if we need locale-aware collation
-    if get_locale_encoding() != UEncoding::Utf8 {
-        // C/POSIX locale - no collator needed
+    // Use ICU collation only for UTF-8 locales that are NOT C/POSIX
+    // (e.g. en_US.UTF-8, but not C.UTF-8 — C still uses byte comparison)
+    if get_locale_encoding() != UEncoding::Utf8 || !should_use_locale_collation() {
         return false;
     }
 

--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -51,7 +51,8 @@ pub fn get_locale_from_env(locale_name: &str) -> (Locale, UEncoding) {
             let locale = Locale::try_from_str(&bcp47).unwrap_or(DEFAULT_LOCALE);
 
             // Determine encoding from the locale suffix (e.g. en_US.UTF-8, C.UTF-8).
-            let encoding = split.next()
+            let encoding = split
+                .next()
                 .filter(|enc| {
                     let lower = enc.to_lowercase();
                     lower == "utf-8" || lower == "utf8"

--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -44,29 +44,19 @@ pub fn get_locale_from_env(locale_name: &str) -> (Locale, UEncoding) {
         let mut split = locale_var_str.split(&['.', '@']);
 
         if let Some(simple) = split.next() {
-            // Handle explicit C and POSIX locales - these should always use byte comparison
-            if simple == "C" || simple == "POSIX" {
-                return (DEFAULT_LOCALE, UEncoding::Ascii);
-            }
-
             // Naively convert the locale name to BCP47 tag format.
             //
             // See https://en.wikipedia.org/wiki/IETF_language_tag
             let bcp47 = simple.replace('_', "-");
             let locale = Locale::try_from_str(&bcp47).unwrap_or(DEFAULT_LOCALE);
 
-            // If locale parsing failed, parse the encoding part of the
-            // locale. Treat the special case of the given locale being "C"
-            // which becomes the default locale.
-            let encoding = if (locale != DEFAULT_LOCALE || bcp47 == "C")
-                && split.next().is_some_and(|enc| {
+            // Determine encoding from the locale suffix (e.g. en_US.UTF-8, C.UTF-8).
+            let encoding = split.next()
+                .filter(|enc| {
                     let lower = enc.to_lowercase();
                     lower == "utf-8" || lower == "utf8"
-                }) {
-                UEncoding::Utf8
-            } else {
-                UEncoding::Ascii
-            };
+                })
+                .map_or(UEncoding::Ascii, |_| UEncoding::Utf8);
             return (locale, encoding);
         }
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3315,6 +3315,30 @@ mod quoting {
                 .stdout_only(utf_8_ref);
         }
     }
+
+    #[test]
+    fn test_c_dot_utf8_renders_utf8() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        let filename = "é";
+        at.touch(filename);
+
+        // C (no UTF-8): bytes 0xC3 0xA9 replaced with ??
+        scene
+            .ucmd()
+            .env("LC_ALL", "C")
+            .args(&["--quoting-style=literal", "--hide-control-chars"])
+            .succeeds()
+            .stdout_is("??\n");
+
+        // C.UTF-8: multi-byte UTF-8 character rendered literally
+        scene
+            .ucmd()
+            .env("LC_ALL", "C.UTF-8")
+            .args(&["--quoting-style=literal", "--hide-control-chars"])
+            .succeeds()
+            .stdout_is("é\n");
+    }
 }
 
 #[test]


### PR DESCRIPTION
C.UTF-8 was treated as a byte-comparison locale because of an early return that matched on "C" before checking the ".UTF-8" encoding suffix. This caused `ls` to escape non-ASCII filename characters and expr to use byte-level operations on multi-byte data.

Remove the early return so C.UTF-8 and POSIX.UTF-8 are correctly detected as UTF-8 encoding. Add a locale-name guard to init_locale_collation() so sort still uses byte comparison for these locales (C/POSIX collation rules apply regardless of encoding).