### PR TITLE
simplify pipe wrapper

### DIFF
--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -51,7 +51,7 @@ fn count_bytes_using_splice(fd: &impl AsFd) -> Result<usize, usize> {
             Err(_) => break, // input is not pipe. needs additional pipe...
         }
     }
-    let (pipe_rd, pipe_wr) = pipe::<false>(MAX_ROOTLESS_PIPE_SIZE).map_err(|_| byte_count)?;
+    let (pipe_rd, pipe_wr) = pipe::<false>().map_err(|_| byte_count)?;
     while let s @ 1.. = splice(fd, &pipe_wr, MAX_ROOTLESS_PIPE_SIZE).map_err(|_| byte_count)? {
         byte_count += s;
         // pipe to null is not blocked. So this returns the same length at most cases

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -117,7 +117,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
     // improve throughput
     let _ = rustix::pipe::fcntl_setpipe_size(stdout, MAX_ROOTLESS_PIPE_SIZE);
     // don't show any error from fast-path and fallback to write for proper message
-    if let Ok((p_read, mut p_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE)
+    if let Ok((p_read, mut p_write)) = pipe::<true>()
         && p_write.write_all(bytes).is_ok()
     {
         // tee() cannot control offset. But omit splice if it is possible
@@ -125,7 +125,7 @@ pub fn exec(mut bytes: Vec<u8>) -> io::Result<()> {
             // fails if stdout is not a pipe
             while tee(&p_read, &stdout, MAX_ROOTLESS_PIPE_SIZE).is_ok() {}
         }
-        if let Ok((broker_read, broker_write)) = pipe::<true>(MAX_ROOTLESS_PIPE_SIZE) {
+        if let Ok((broker_read, broker_write)) = pipe::<true>() {
             'splice: while let Ok(mut remain) = tee(&p_read, &broker_write, MAX_ROOTLESS_PIPE_SIZE)
             {
                 debug_assert!(remain == bytes.len(), "splice() should cleanup pipe");

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -25,20 +25,19 @@ const KERNEL_DEFAULT_PIPE_SIZE: usize = 64 * 1024;
 /// use rustix::io::Result for functions without read/write fallback
 type PipeRes = std::io::Result<Result<(), ()>>;
 
-/// return pipe larger than given size
+/// return pipe and try to extend its size
 /// SIZE_REQUIRED should be true if you want to fail when changing pipe size failed
 /// e.g. writing size to pipe should not hang
+/// SIZE_REQUIRED=false allows to continue unbuffered splice I/O with default pipe size even if fcntl failed
 ///
 /// used for resolving the limitation for splice: one of a input or output should be pipe
 #[inline]
-pub fn pipe<const SIZE_REQUIRED: bool>(s: usize) -> std::io::Result<(PipeReader, PipeWriter)> {
+pub fn pipe<const SIZE_REQUIRED: bool>() -> std::io::Result<(PipeReader, PipeWriter)> {
     let pair = std::io::pipe()?;
-    // guard unnecessary syscall
-    if s > KERNEL_DEFAULT_PIPE_SIZE {
-        let r = fcntl_setpipe_size(&pair.0, s);
-        if SIZE_REQUIRED {
-            r?;
-        }
+    // pipe size is not RAM consumed by pipe with zero-copy. So we never use other size
+    let r = fcntl_setpipe_size(&pair.0, MAX_ROOTLESS_PIPE_SIZE);
+    if SIZE_REQUIRED {
+        r?;
     }
 
     Ok(pair)
@@ -107,9 +106,7 @@ pub fn splice_unbounded(source: &impl AsFd, dest: &mut impl AsFd) -> rustix::io:
 #[inline]
 pub fn splice_unbounded_broker(source: &impl AsFd, dest: &mut impl AsFd) -> PipeRes {
     static PIPE_CACHE: OnceLock<Option<(PipeReader, PipeWriter)>> = OnceLock::new();
-    let Some((pipe_rd, pipe_wr)) =
-        PIPE_CACHE.get_or_init(|| pipe::<false>(MAX_ROOTLESS_PIPE_SIZE).ok())
-    else {
+    let Some((pipe_rd, pipe_wr)) = PIPE_CACHE.get_or_init(|| pipe::<false>().ok()) else {
         return Ok(Err(()));
     };
     // improve throughput
@@ -147,9 +144,8 @@ pub fn splice_unbounded_auto(source: &impl AsFd, dest: &mut impl AsFd) -> PipeRe
 pub fn send_n_bytes(input: impl AsFd, target: impl AsFd, n: u64) -> std::io::Result<u64> {
     static PIPE_CACHE: OnceLock<Option<(PipeReader, PipeWriter)>> = OnceLock::new();
     let pipe_size = MAX_ROOTLESS_PIPE_SIZE.min(n as usize);
-    // improve throughput or save RAM usage
+    // improve throughput if output is pipe
     // expected that input is already extended if it is coming from splice
-    // we can use pipe_size * N with some case e.g. head -c N inputs, but we need N splice call anyway
     if pipe_size > KERNEL_DEFAULT_PIPE_SIZE {
         let _ = fcntl_setpipe_size(&target, pipe_size);
     }
@@ -171,7 +167,14 @@ pub fn send_n_bytes(input: impl AsFd, target: impl AsFd, n: u64) -> std::io::Res
     };
     let succeed_or_fuse = succeed_or_fuse
         || if let Some((broker_r, broker_w)) = PIPE_CACHE
-            .get_or_init(|| pipe::<false>(pipe_size).ok())
+            .get_or_init(|| {
+                // use std::io::pipe to avoid unnecessary fcntl
+                let pair = std::io::pipe().ok()?;
+                if pipe_size > KERNEL_DEFAULT_PIPE_SIZE {
+                    let _ = fcntl_setpipe_size(&pair.0, pipe_size);
+                }
+                Some(pair)
+            })
             .as_ref()
         {
             // todo: create fn splice_bounded_broker


### PR DESCRIPTION
Drop an arg to choice any pipe size because it does not save RAM usage. RAM usage does not match with pipe size if we use zero-copy.