### PR TITLE
Dockerfile: Test glibc newer than GitHub runner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+# Revert this to legacy Ubuntu version after GitHub added 26.04. Then we can cover 2 glibc versions
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-26.04
 
 # install gnu coreutils test dependencies
 RUN apt-get update \


### PR DESCRIPTION
We currently cannot catch regression for https://github.com/uutils/coreutils/issues/8474 since GitHUb does not have newer glibc.
Revert this to legacy Ubuntu version after GitHub added 26.04. Then we can cover 2 glibc versions.