### PR TITLE
GNUmakefile: don't try to install libstdbuf for Windows target

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -335,7 +335,7 @@ jobs:
           x86_64-pc-cygwin.tar.zst
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: "`make build`"
+    - name: "`make install`"
       shell: bash
       run: |
         set -x

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -340,9 +340,10 @@ jobs:
       run: |
         set -x
         # Check that we exclude unix programs to avoid build failure
-        make PREFIX=/tmp/usr MULTICALL=y COMPLETIONS=n MANPAGES=n LOCALES=n \
-         SKIP_UTILS="arch b2sum base32 base64 basename basenc cat cksum comm cp csplit cut date dd df dir dircolors dirname du echo env expand expr factor false fmt fold head hostname join link ln ls md5sum mkdir mktemp more mv nl nproc numfmt od paste pathchk pr printenv printf ptx pwd readlink realpath rm rmdir seq sha1sum sha224sum sha256sum sha384sum sha512sum shred shuf sleep sort split sum sync tac tail tee test touch tr truncate tsort tty uname unexpand uniq unlink vdir wc whoami yes"
-        target/debug/coreutils.exe true
+        # Windows's stdbuf depends on Cygwin's libstdbuf. So make should not try to install libstdbuf
+        make install DESTDIR=/tmp/w PREFIX=/tmp/usr MULTICALL=y COMPLETIONS=n MANPAGES=n LOCALES=n \
+         SKIP_UTILS="arch b2sum base32 base64 basename basenc cat cksum comm cp csplit cut date dd df dir dircolors dirname du echo env expand expr factor false fmt fold head hostname join link ln ls md5sum mkdir mktemp more mv nl nproc numfmt od paste pathchk pr printenv printf ptx pwd readlink realpath rm rmdir seq sha1sum sha224sum sha256sum sha384sum sha512sum shred shuf sleep sort split sum sync tac tail tee test touch tr true truncate tsort tty uname unexpand uniq unlink vdir wc whoami yes"
+        target/release/coreutils.exe stdbuf --version
 
   test_busybox:
     name: Tests/BusyBox test suite

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -273,10 +273,13 @@ endif
 install: build install-manpages install-completions install-locales
 	$(INSTALL) -d $(INSTALLDIR_BIN)
 ifneq (,$(and $(findstring stdbuf,$(UTILS)),$(findstring feat_external_libstdbuf,$(CARGOFLAGS))))
-	$(INSTALL) -d $(DESTDIR)$(LIBSTDBUF_DIR)
 ifneq (,$(findstring cygwin,$(OS)))
+	$(INSTALL) -d $(DESTDIR)$(LIBSTDBUF_DIR)
 	$(INSTALL) -m 755 $(BUILDDIR)/deps/stdbuf.dll $(DESTDIR)$(LIBSTDBUF_DIR)/libstdbuf.dll
+else ifneq (,$(findstring windows,$(OS)))
+	@echo "NOTE: Windows stdbuf depends on Cygwin's libstdbuf.dll"
 else
+	$(INSTALL) -d $(DESTDIR)$(LIBSTDBUF_DIR)
 	$(INSTALL) -m 755 $(BUILDDIR)/deps/libstdbuf.* $(DESTDIR)$(LIBSTDBUF_DIR)/
 endif
 endif


### PR DESCRIPTION
https://github.com/uutils/coreutils/pull/12329 broke GNUmakefile on Windows.