### PR TITLE
tee: fix incorrect comment about flush

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -94,7 +94,7 @@ fn tee(options: &Options) -> Result<()> {
         return Ok(());
     }
 
-    // We cannot use std::io::copy here as it doesn't flush the output buffer
+    // don't use io::copy since content of 1 read should be immediately written for posix requirement
     let res = match output.copy_unbuffered() {
         // ErrorKind::Other is raised by MultiWriter when all writers
         // have exited, so that copy will abort. It's equivalent to


### PR DESCRIPTION
"flush is needed" is misleading because flush after `io::copy` is possible. Needed to write content of 1 read call for posix requirement.