### PR TITLE
CICD: add ppc64le (linux-gnu) targets to release pipeline

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -373,7 +373,6 @@ jobs:
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-latest  , target: riscv64gc-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-latest  , target: powerpc64le-unknown-linux-gnu , features: feat_os_unix , use-cross: use-cross , skip-tests: true }
-          - { os: ubuntu-latest  , target: powerpc64le-unknown-linux-musl, features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl , use-cross: use-cross }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -372,6 +372,8 @@ jobs:
           - { os: ubuntu-24.04-arm  , target: aarch64-unknown-linux-gnu   , features: feat_os_unix_gnueabihf }
           - { os: ubuntu-latest  , target: aarch64-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           - { os: ubuntu-latest  , target: riscv64gc-unknown-linux-musl  , features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-latest  , target: powerpc64le-unknown-linux-gnu , features: feat_os_unix , use-cross: use-cross , skip-tests: true }
+          - { os: ubuntu-latest  , target: powerpc64le-unknown-linux-musl, features: feat_os_unix_musl , use-cross: use-cross , skip-tests: true }
           # - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , features: feat_selinux           , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , features: "feat_os_unix,test_risky_names", use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , features: feat_os_unix_musl , use-cross: use-cross }
@@ -536,6 +538,10 @@ jobs:
           riscv64gc-unknown-linux-*)
             sudo apt-get -y update
             sudo apt-get -y install gcc-riscv64-linux-gnu
+          ;;
+          powerpc64le-unknown-linux-*)
+            sudo apt-get -y update
+            sudo apt-get -y install gcc-powerpc64le-linux-gnu
           ;;
           *-redox*)
             sudo apt-get -y update

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -48,9 +48,10 @@ jobs:
           # Clean up disk space before installing packages
           df -h
           pkg_add curl sudo-- jq coreutils bash rust rust-clippy rust-rustfmt llvm-- python3
-          rm -rf /usr/share/relink/* /usr/X11R6/* /usr/share/doc/* /usr/share/man/* &
+          # Run cleanup synchronously (no '&'): backgrounding races into the build phase
+          rm -rf /usr/share/relink/* /usr/X11R6/* /usr/share/doc/* /usr/share/man/*
           # Clean up package cache after installation
-          pkg_delete -a &
+          pkg_delete -a
           df -h
         run: |
           ## Prepare, build, and test
@@ -140,15 +141,16 @@ jobs:
         usesh: true
         sync: rsync
         copyback: false
-        mem: 6144
+        mem: 8192
         # Install rust and build dependencies from OpenBSD packages (llvm provides libclang for bindgen)
         prepare: |
           # Clean up disk space before installing packages
           df -h
-          rm -rf /usr/share/relink/* /usr/X11R6/* /usr/share/doc/* /usr/share/man/* &
+          # Run cleanup synchronously (no '&'): backgrounding races into the build phase
+          rm -rf /usr/share/relink/* /usr/X11R6/* /usr/share/doc/* /usr/share/man/*
           pkg_add curl gmake sudo-- jq rust llvm--
           # Clean up package cache after installation
-          pkg_delete -a &
+          pkg_delete -a
           df -h
         run: |
           ## Prepare, build, and test

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -48,7 +48,6 @@ jobs:
           # Clean up disk space before installing packages
           df -h
           pkg_add curl sudo-- jq coreutils bash rust rust-clippy rust-rustfmt llvm-- python3
-          # Run cleanup synchronously (no '&'): backgrounding races into the build phase
           rm -rf /usr/share/relink/* /usr/X11R6/* /usr/share/doc/* /usr/share/man/*
           # Clean up package cache after installation
           pkg_delete -a

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -646,21 +646,15 @@ fn print_terminal_size(
 
     let mut printer = WrappedPrinter::new(window_size);
 
-    // BSDs and Linux (not ppc/big-endian ppc64) use a u32 for the baud rate, so we can simply
+    // BSDs and Linux (not ppc/ppc64) use a u32 for the baud rate, so we can simply
     // print it.
     #[cfg(any(target_os = "linux", bsd))]
-    #[cfg(all(
-        not(target_arch = "powerpc"),
-        not(all(target_arch = "powerpc64", target_endian = "big"))
-    ))]
+    #[cfg(all(not(target_arch = "powerpc"), not(target_arch = "powerpc64")))]
     printer.print(&translate!("stty-output-speed", "speed" => speed));
 
-    // Big-endian Linux PowerPC uses BaudRate enum, need to convert to display format
+    // Linux PowerPC uses the BaudRate enum, need to convert to display format
     #[cfg(target_os = "linux")]
-    #[cfg(any(
-        target_arch = "powerpc",
-        all(target_arch = "powerpc64", target_endian = "big")
-    ))]
+    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
     {
         // On PowerPC, find the corresponding baud rate string for display
         let speed_str = BAUD_RATES


### PR DESCRIPTION
Having binaries in Release would greatly benefit PPC64 packagers for example Linuxbrew and further encourage adoption in enterprise sector. 

## Related PR

https://github.com/cross-rs/cross/pull/1777