### PR TITLE
dircolors: turn integration test into unit test & remove unsafe code

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -34,24 +34,23 @@ enum OutputFmt {
     Shell,
     CShell,
     Display,
-    Unknown,
 }
 
-fn guess_syntax<T: AsRef<Path>>(path: T) -> OutputFmt {
+fn guess_syntax<T: AsRef<Path>>(path: T) -> Option<OutputFmt> {
     let shell_path = path.as_ref();
 
     if shell_path.as_os_str().is_empty() {
-        return OutputFmt::Unknown;
+        return None;
     }
 
     if let Some(name) = shell_path.file_name() {
         if name == "csh" || name == "tcsh" {
-            OutputFmt::CShell
+            Some(OutputFmt::CShell)
         } else {
-            OutputFmt::Shell
+            Some(OutputFmt::Shell)
         }
     } else {
-        OutputFmt::Shell
+        Some(OutputFmt::Shell)
     }
 }
 
@@ -60,14 +59,12 @@ fn get_colors_format_strings(fmt: &OutputFmt) -> (String, String) {
         OutputFmt::Shell => "LS_COLORS='".to_string(),
         OutputFmt::CShell => "setenv LS_COLORS '".to_string(),
         OutputFmt::Display => String::new(),
-        OutputFmt::Unknown => unreachable!(),
     };
 
     let suffix = match fmt {
         OutputFmt::Shell => "';\nexport LS_COLORS".to_string(),
         OutputFmt::CShell => "'".to_string(),
         OutputFmt::Display => String::new(),
-        OutputFmt::Unknown => unreachable!(),
     };
 
     (prefix, suffix)
@@ -161,17 +158,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else if matches.get_flag(options::PRINT_LS_COLORS) {
         OutputFmt::Display
     } else {
-        let guessed_fmt = env::var_os("SHELL").map(|path| guess_syntax(&path));
-
-        match guessed_fmt {
-            Some(OutputFmt::Unknown) | None => {
-                return Err(USimpleError::new(
-                    1,
-                    translate!("dircolors-error-no-shell-environment"),
-                ));
-            }
-            Some(fmt) => fmt,
-        }
+        env::var_os("SHELL")
+            .and_then(|path| guess_syntax(&path))
+            .ok_or_else(|| {
+                USimpleError::new(1, translate!("dircolors-error-no-shell-environment"))
+            })?
     };
 
     let result;
@@ -537,12 +528,12 @@ mod tests {
 
     #[test]
     fn test_guess_syntax() {
-        assert_eq!(OutputFmt::CShell, guess_syntax("/path/csh"));
-        assert_eq!(OutputFmt::CShell, guess_syntax("csh"));
-        assert_eq!(OutputFmt::Shell, guess_syntax("/path/bash"));
-        assert_eq!(OutputFmt::Shell, guess_syntax("bash"));
-        assert_eq!(OutputFmt::Shell, guess_syntax("/asd/bar"));
-        assert_eq!(OutputFmt::Shell, guess_syntax("foo"));
-        assert_eq!(OutputFmt::Unknown, guess_syntax(""));
+        assert_eq!(Some(OutputFmt::CShell), guess_syntax("/path/csh"));
+        assert_eq!(Some(OutputFmt::CShell), guess_syntax("csh"));
+        assert_eq!(Some(OutputFmt::Shell), guess_syntax("/path/bash"));
+        assert_eq!(Some(OutputFmt::Shell), guess_syntax("bash"));
+        assert_eq!(Some(OutputFmt::Shell), guess_syntax("/asd/bar"));
+        assert_eq!(Some(OutputFmt::Shell), guess_syntax("foo"));
+        assert_eq!(None, guess_syntax(""));
     }
 }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) clrtoeol dircolors eightbit endcode fnmatch leftcode multihardlink rightcode setenv sgid suid colorterm disp
+// spell-checker:ignore (ToDO) dircolors eightbit fnmatch setenv colorterm disp cshell
 
 use std::borrow::Borrow;
 use std::env;
@@ -43,12 +43,10 @@ fn guess_syntax<T: AsRef<Path>>(path: T) -> Option<OutputFmt> {
         return None;
     }
 
-    if let Some(name) = shell_path.file_name() {
-        if name == "csh" || name == "tcsh" {
-            Some(OutputFmt::CShell)
-        } else {
-            Some(OutputFmt::Shell)
-        }
+    let is_cshell = |name| name == "csh" || name == "tcsh";
+
+    if shell_path.file_name().is_some_and(is_cshell) {
+        Some(OutputFmt::CShell)
     } else {
         Some(OutputFmt::Shell)
     }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -30,14 +30,14 @@ mod options {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub enum OutputFmt {
+enum OutputFmt {
     Shell,
     CShell,
     Display,
     Unknown,
 }
 
-pub fn guess_syntax() -> OutputFmt {
+fn guess_syntax() -> OutputFmt {
     match env::var("SHELL") {
         Ok(ref s) if !s.is_empty() => {
             let shell_path: &Path = s.as_ref();

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -527,7 +527,7 @@ fn generate_dircolors_config() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::escape;
+    use super::*;
 
     #[test]
     fn test_escape() {
@@ -535,5 +535,49 @@ mod tests {
         assert_eq!("'\\''", escape("'"));
         assert_eq!("\\:", escape(":"));
         assert_eq!("\\:", escape("\\:"));
+    }
+
+    #[test]
+    fn test_guess_syntax() {
+        use std::env;
+        let last = env::var("SHELL");
+        unsafe {
+            env::set_var("SHELL", "/path/csh");
+        }
+        assert_eq!(OutputFmt::CShell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "csh");
+        }
+        assert_eq!(OutputFmt::CShell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "/path/bash");
+        }
+        assert_eq!(OutputFmt::Shell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "bash");
+        }
+        assert_eq!(OutputFmt::Shell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "/asd/bar");
+        }
+        assert_eq!(OutputFmt::Shell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "foo");
+        }
+        assert_eq!(OutputFmt::Shell, guess_syntax());
+        unsafe {
+            env::set_var("SHELL", "");
+        }
+        assert_eq!(OutputFmt::Unknown, guess_syntax());
+        unsafe {
+            env::remove_var("SHELL");
+        }
+        assert_eq!(OutputFmt::Unknown, guess_syntax());
+
+        if let Ok(s) = last {
+            unsafe {
+                env::set_var("SHELL", s);
+            }
+        }
     }
 }

--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -37,21 +37,21 @@ enum OutputFmt {
     Unknown,
 }
 
-fn guess_syntax() -> OutputFmt {
-    match env::var("SHELL") {
-        Ok(ref s) if !s.is_empty() => {
-            let shell_path: &Path = s.as_ref();
-            if let Some(name) = shell_path.file_name() {
-                if name == "csh" || name == "tcsh" {
-                    OutputFmt::CShell
-                } else {
-                    OutputFmt::Shell
-                }
-            } else {
-                OutputFmt::Shell
-            }
+fn guess_syntax<T: AsRef<Path>>(path: T) -> OutputFmt {
+    let shell_path = path.as_ref();
+
+    if shell_path.as_os_str().is_empty() {
+        return OutputFmt::Unknown;
+    }
+
+    if let Some(name) = shell_path.file_name() {
+        if name == "csh" || name == "tcsh" {
+            OutputFmt::CShell
+        } else {
+            OutputFmt::Shell
         }
-        _ => OutputFmt::Unknown,
+    } else {
+        OutputFmt::Shell
     }
 }
 
@@ -154,27 +154,25 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     }
 
-    let mut out_format = if matches.get_flag(options::C_SHELL) {
+    let out_format = if matches.get_flag(options::C_SHELL) {
         OutputFmt::CShell
     } else if matches.get_flag(options::BOURNE_SHELL) {
         OutputFmt::Shell
     } else if matches.get_flag(options::PRINT_LS_COLORS) {
         OutputFmt::Display
     } else {
-        OutputFmt::Unknown
-    };
+        let guessed_fmt = env::var_os("SHELL").map(|path| guess_syntax(&path));
 
-    if out_format == OutputFmt::Unknown {
-        match guess_syntax() {
-            OutputFmt::Unknown => {
+        match guessed_fmt {
+            Some(OutputFmt::Unknown) | None => {
                 return Err(USimpleError::new(
                     1,
                     translate!("dircolors-error-no-shell-environment"),
                 ));
             }
-            fmt => out_format = fmt,
+            Some(fmt) => fmt,
         }
-    }
+    };
 
     let result;
     if files.is_empty() {
@@ -539,45 +537,12 @@ mod tests {
 
     #[test]
     fn test_guess_syntax() {
-        use std::env;
-        let last = env::var("SHELL");
-        unsafe {
-            env::set_var("SHELL", "/path/csh");
-        }
-        assert_eq!(OutputFmt::CShell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "csh");
-        }
-        assert_eq!(OutputFmt::CShell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "/path/bash");
-        }
-        assert_eq!(OutputFmt::Shell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "bash");
-        }
-        assert_eq!(OutputFmt::Shell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "/asd/bar");
-        }
-        assert_eq!(OutputFmt::Shell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "foo");
-        }
-        assert_eq!(OutputFmt::Shell, guess_syntax());
-        unsafe {
-            env::set_var("SHELL", "");
-        }
-        assert_eq!(OutputFmt::Unknown, guess_syntax());
-        unsafe {
-            env::remove_var("SHELL");
-        }
-        assert_eq!(OutputFmt::Unknown, guess_syntax());
-
-        if let Ok(s) = last {
-            unsafe {
-                env::set_var("SHELL", s);
-            }
-        }
+        assert_eq!(OutputFmt::CShell, guess_syntax("/path/csh"));
+        assert_eq!(OutputFmt::CShell, guess_syntax("csh"));
+        assert_eq!(OutputFmt::Shell, guess_syntax("/path/bash"));
+        assert_eq!(OutputFmt::Shell, guess_syntax("bash"));
+        assert_eq!(OutputFmt::Shell, guess_syntax("/asd/bar"));
+        assert_eq!(OutputFmt::Shell, guess_syntax("foo"));
+        assert_eq!(OutputFmt::Unknown, guess_syntax(""));
     }
 }

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -7,7 +7,7 @@
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
-use dircolors::{OutputFmt, StrUtils, guess_syntax};
+use dircolors::StrUtils;
 
 #[test]
 #[cfg(target_os = "linux")]
@@ -28,50 +28,6 @@ fn test_dircolors_non_utf8_paths() {
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
-}
-
-#[test]
-fn test_shell_syntax() {
-    use std::env;
-    let last = env::var("SHELL");
-    unsafe {
-        env::set_var("SHELL", "/path/csh");
-    }
-    assert_eq!(OutputFmt::CShell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "csh");
-    }
-    assert_eq!(OutputFmt::CShell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "/path/bash");
-    }
-    assert_eq!(OutputFmt::Shell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "bash");
-    }
-    assert_eq!(OutputFmt::Shell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "/asd/bar");
-    }
-    assert_eq!(OutputFmt::Shell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "foo");
-    }
-    assert_eq!(OutputFmt::Shell, guess_syntax());
-    unsafe {
-        env::set_var("SHELL", "");
-    }
-    assert_eq!(OutputFmt::Unknown, guess_syntax());
-    unsafe {
-        env::remove_var("SHELL");
-    }
-    assert_eq!(OutputFmt::Unknown, guess_syntax());
-
-    if let Ok(s) = last {
-        unsafe {
-            env::set_var("SHELL", s);
-        }
-    }
 }
 
 #[test]


### PR DESCRIPTION
This PR does the following changes:
* turns an integration test into an unit test
* makes a function and an enum private
* removes unsafe code in the unit test (changes are adapted from https://github.com/uutils/coreutils/pull/12228 and so I added @oech3 and @xtqqczze as co-authors)
* removes the `OutputFmt::Unknown` variant

Closes https://github.com/uutils/coreutils/pull/12228