### PR TITLE
cksum family: read ahead file

### DIFF
--- a/src/uucore/src/lib/features/checksum/compute.rs
+++ b/src/uucore/src/lib/features/checksum/compute.rs
@@ -261,7 +261,15 @@ where
                 Box::new(stdin_buf) as Box<dyn io::Read>
             } else {
                 file_buf = match File::open(filepath) {
-                    Ok(file) => file,
+                    Ok(file) => {
+                        #[cfg(any(
+                            target_os = "linux",
+                            target_os = "android",
+                            target_os = "freebsd"
+                        ))]
+                        let _ = rustix::fs::fadvise(&file, 0, None, rustix::fs::Advice::Sequential);
+                        file
+                    }
                     Err(err) => {
                         show!(err.map_err_context(|| filepath.to_string_lossy().into()));
                         continue;


### PR DESCRIPTION
Most people does not calc checksum many times for the same file.
So page caches are missing when `cksum` is called.