### PR TITLE
chown: restrict no-dereference symlink ctime test to Linux

### DIFF
--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (words) agroupthatdoesntexist auserthatdoesntexist cuuser groupname notexisting passgrp
-
+#[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
 use uutests::util::{CmdResult, TestScenario, is_ci, run_ucmd_as_root};
 use uutests::util_name;
@@ -900,7 +900,7 @@ fn test_chown_reference_file() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn test_chown_no_dereference_symlink_to_dir() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 // spell-checker:ignore (words) agroupthatdoesntexist auserthatdoesntexist cuuser groupname notexisting passgrp
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(target_os = "openbsd")))]
 use std::os::unix::fs::MetadataExt;
 use uutests::util::{CmdResult, TestScenario, is_ci, run_ucmd_as_root};
 use uutests::util_name;
@@ -900,7 +900,7 @@ fn test_chown_reference_file() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(target_os = "openbsd")))]
 fn test_chown_no_dereference_symlink_to_dir() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
Fixes https://github.com/uutils/coreutils/issues/12546

`test_chown_no_dereference_symlink_to_dir` fails on OpenBSD CI.

The test chowns a symlink to its current owner (a no-op) and asserts the
symlink's `ctime` advanced. Linux bumps `ctime` on a same-owner `chown`;
while OpenBSD doesn't, so the test fails.