### PR TITLE
numfmt: report oversized --padding instead of aborting

### DIFF
--- a/src/uu/numfmt/locales/en-US.ftl
+++ b/src/uu/numfmt/locales/en-US.ftl
@@ -57,6 +57,7 @@ numfmt-help-zero-terminated = line delimiter is NUL, not newline
 numfmt-error-unsupported-unit = Unsupported unit is specified
 numfmt-error-invalid-unit-size = invalid unit size: { $size }
 numfmt-error-invalid-padding = invalid padding value { $value }
+numfmt-error-memory-exhausted = memory exhausted
 numfmt-error-invalid-header = invalid header value { $value }
 numfmt-error-grouping-cannot-be-combined-with-format = --grouping cannot be combined with --format
 numfmt-error-grouping-cannot-be-combined-with-to = grouping cannot be combined with --to

--- a/src/uu/numfmt/locales/fr-FR.ftl
+++ b/src/uu/numfmt/locales/fr-FR.ftl
@@ -56,6 +56,7 @@ numfmt-help-zero-terminated = le délimiteur de ligne est NUL, pas retour à la 
 numfmt-error-unsupported-unit = Une unité non prise en charge est spécifiée
 numfmt-error-invalid-unit-size = taille d'unité invalide : { $size }
 numfmt-error-invalid-padding = valeur de remplissage invalide { $value }
+numfmt-error-memory-exhausted = mémoire épuisée
 numfmt-error-invalid-header = valeur d'en-tête invalide { $value }
 numfmt-error-grouping-cannot-be-combined-with-format = --grouping ne peut pas être combiné avec --format
 numfmt-error-grouping-cannot-be-combined-with-to = le groupement ne peut pas être combiné avec --to

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -397,6 +397,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
     let options = parse_options(&matches).map_err(NumfmtError::IllegalArgument)?;
 
+    // A `--padding` whose buffer cannot be allocated must fail up front (before
+    // reading any input), matching GNU's "memory exhausted" (exit 1) rather than
+    // aborting mid-stream when `pad_string` calls `String::with_capacity`.
+    let max_padding = options
+        .padding
+        .unsigned_abs()
+        .max(options.format.padding.map_or(0, isize::unsigned_abs));
+    if max_padding != 0 {
+        String::new()
+            .try_reserve_exact(max_padding)
+            .map_err(|_| NumfmtError::IoError(translate!("numfmt-error-memory-exhausted")))?;
+    }
+
     if options.debug {
         print_debug_warnings(&options, &matches);
     }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -144,6 +144,19 @@ fn test_negative_padding() {
 }
 
 #[test]
+fn test_padding_too_large_fails_cleanly() {
+    let padding = if std::env::var("UUTESTS_WASM_RUNNER").is_ok() {
+        i32::MIN.to_string()
+    } else {
+        isize::MIN.to_string()
+    };
+    new_ucmd!()
+        .arg(format!("--padding={padding}"))
+        .fails()
+        .stderr_only("numfmt: memory exhausted\n");
+}
+
+#[test]
 fn test_header() {
     new_ucmd!()
         .args(&["--from=si", "--header=2"])


### PR DESCRIPTION
Fixes #12560.

## Problem

A large `--padding` makes `pad_string` (added to handle widths beyond
`format!`'s u16 cap) call `String::with_capacity(width)` with an unbounded,
user-controlled width, crashing the process:

```console
$ numfmt --padding=9000000000000000000 1
memory allocation of 9000000000000000000 bytes failed
Aborted (core dumped)            # exit 134

$ numfmt --padding=-9223372036854775808 1
thread 'main' panicked at .../alloc/src/string.rs: capacity overflow
Aborted (core dumped)            # exit 134
```

(`-9223372036854775808` is `isize::MIN`; its magnitude is `isize::MAX + 1`,
which overflows `with_capacity`'s capacity check deterministically.)

GNU reports this cleanly and exits 1:

```console
$ numfmt --padding=9000000000000000000 1
numfmt: memory exhausted         # exit 1
```

## Fix

Validate the padding up front in `uumain` — before reading any input — with a
fallible `try_reserve_exact`, and fail with `memory exhausted` (exit 1) on
overflow/allocation failure.

Doing the check up front (rather than lazily inside `pad_string`) also matches
GNU's observable behavior:

- it fails immediately and does **not** block on stdin
  (`numfmt --padding=-9223372036854775808` no longer waits for input);
- it does **not** silently exit 0 when there is no input.

`memory exhausted` is surfaced as `NumfmtError::IoError`, which exits 1 —
consistent with how uutils numfmt already matches GNU's other exit codes
(option errors → 1, input-conversion errors → 2).

## Tests

Added `test_padding_too_large_fails_cleanly`. Full numfmt suite passes
(152 integration + unit tests); `cargo fmt`/`clippy` clean.
