### PR TITLE
sum: read ahead for perf for 1st run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,6 +4185,7 @@ version = "0.9.0"
 dependencies = [
  "clap",
  "fluent",
+ "rustix",
  "uucore",
 ]
 

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
+rustix = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -89,6 +89,8 @@ fn open(name: &OsString) -> UResult<Box<dyn Read>> {
             ));
         }
         let f = File::open(path).map_err_context(String::new)?;
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        let _ = rustix::fs::fadvise(&f, 0, None, rustix::fs::Advice::Sequential);
         Ok(Box::new(f) as Box<dyn Read>)
     }
 }


### PR DESCRIPTION
Improve performance without pre-generated page caches.
Use slow device e.g. USB 2.0 drive and run `echo 1 | run0 tee /proc/sys/vm/drop_caches` before bench which is rejected by `hyperfine`.
```
> time taskset -c 1 target/release/sum-nofadv /run/media/a/E4/chromium
35378 309140 /run/media/a/E4/chromium

________________________________________________________
Executed in   10.06 secs      fish           external
   usr time  231.06 millis    0.28 millis  230.77 millis
   sys time  125.59 millis    1.01 millis  124.58 millis

> time taskset -c 1 target/release/sum-fadv /run/media/a/E4/chromium
35378 309140 /run/media/a/E4/chromium

________________________________________________________
Executed in    9.81 secs      fish           external
   usr time  218.40 millis    0.00 millis  218.40 millis
   sys time  133.31 millis    1.32 millis  131.99 millis
```