### PR TITLE
baseNM: read ahead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,6 +3214,7 @@ version = "0.9.0"
 dependencies = [
  "clap",
  "fluent",
+ "rustix",
  "uucore",
 ]
 

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
+rustix = { workspace = true }
 uucore = { workspace = true, features = ["encoding"] }
 fluent = { workspace = true }
 

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -152,6 +152,8 @@ pub fn get_input(config: &Config) -> UResult<Box<dyn BufRead>> {
         Some(path_buf) => {
             let file =
                 File::open(path_buf).map_err_context(|| path_buf.maybe_quote().to_string())?;
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+            let _ = rustix::fs::fadvise(&file, 0, None, rustix::fs::Advice::Sequential);
             Ok(Box::new(BufReader::with_capacity(DEFAULT_BUF_SIZE, file)))
         }
         None => {


### PR DESCRIPTION
About 10.94 s -> 10.54 s `base64>/dev/null` under similar condition with https://github.com/uutils/coreutils/pull/12569#issue-4576638488 .