### PR TITLE
expr(fix): capacity overflow

### DIFF
--- a/src/uu/expr/src/locale_aware.rs
+++ b/src/uu/expr/src/locale_aware.rs
@@ -79,7 +79,7 @@ fn substr_with_locale(
         UEncoding::Utf8 => {
             // Create a buffer with the heuristic that all the chars are ASCII
             // and are 1-byte long.
-            let mut string = MaybeNonUtf8String::with_capacity(len);
+            let mut string = MaybeNonUtf8String::with_capacity(s.len().min(len));
             let mut buf = [0; 4];
 
             // Iterate on char-bytes, and skip them accordingly.

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -572,6 +572,14 @@ fn test_invalid_substr() {
 }
 
 #[test]
+fn test_substr_large_length_capacity_overflow_issue12574() {
+    new_ucmd!()
+        .args(&["substr", "abc", "1", &usize::MAX.to_string()])
+        .succeeds()
+        .stdout_only("abc\n");
+}
+
+#[test]
 fn test_escape() {
     new_ucmd!().args(&["+", "1"]).succeeds().stdout_only("1\n");
 


### PR DESCRIPTION
The fix limits the memory allocation to the size of the input string.

Fixed: #12574
