### PR TITLE
numfmt: don't panic on a value that rounds past the largest suffix

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -533,6 +533,12 @@ fn consider_suffix(
 
     // check if rounding pushed us into the next base
     if v.abs() >= bases[1] {
+        // Rounding promoted the value to the next base. When already at the
+        // largest base there is no suffix above it, so the value is too large
+        // to represent (rather than indexing `suffixes` out of bounds).
+        if i >= suffixes.len() {
+            return Err(translate!("numfmt-error-number-too-big"));
+        }
         Ok((v / bases[1], Some((suffixes[i], with_i))))
     } else {
         Ok((v, Some((suffixes[i - 1], with_i))))

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -100,6 +100,26 @@ fn test_to_si() {
 }
 
 #[test]
+fn test_to_si_rounding_past_top_suffix_is_too_big() {
+    new_ucmd!()
+        .args(&["--to=si", "999500000000000000000000000000000"])
+        .fails_with_code(2)
+        .stderr_only("numfmt: Number is too big and unsupported\n");
+}
+
+#[test]
+fn test_to_si_top_suffix_value_still_renders() {
+    new_ucmd!()
+        .args(&[
+            "--to=si",
+            "--round=down",
+            "999500000000000000000000000000000",
+        ])
+        .succeeds()
+        .stdout_only("999Q\n");
+}
+
+#[test]
 fn test_to_iec() {
     new_ucmd!()
         .args(&["--to=iec"])


### PR DESCRIPTION
Fixes #12581.

## Problem

`numfmt --to=si` / `--to=iec` panics with an index-out-of-bounds for a value in the top decade whose scaled magnitude rounds up to the next base.

```console
$ numfmt --to=si 999500000000000000000000000000000
thread 'main' panicked at src/uu/numfmt/src/format.rs:536:33:
index out of bounds: the len is 10 but the index is 10
$ echo $?
134
```

`consider_suffix` builds `suffixes = [K, M, G, T, P, E, Z, Y, R, Q]` (length 10, indices 0..=9), but the index match can yield `i == 10` for `abs_n ∈ [bases[10], bases[10]*1000)`. Normally the scaled value then falls below `bases[1]` and the `else` branch (`suffixes[i - 1]` = the top suffix) is taken. But when rounding lifts the scaled value to `>= bases[1]` (e.g. `999.5 -> 1000` with the default `--round=from-zero`), the promote-to-next-suffix branch runs `suffixes[i]` with `i == 10` — out of bounds.

With the default `from-zero` rounding the affected range is the whole top decade `(≈9.99e32, 1e33)`; `--round=down`/`towards-zero` are unaffected.

## Fix

Treat "rounded past the largest suffix" as too large and return the existing `numfmt-error-number-too-big` error (exit 2) — the same result numfmt already gives for `>= bases[10]*1000`. Values that stay within the top suffix are unaffected:

```console
$ numfmt --to=si 1000000000000000000000000000000     # 1.0Q  (unchanged)
$ numfmt --to=si 999000000000000000000000000000000   # 999Q  (unchanged)
$ numfmt --to=si --round=down 999500000000000000000000000000000   # 999Q (unchanged)
$ numfmt --to=si 999500000000000000000000000000000   # now: "Number is too big and unsupported", exit 2
```

(For reference, GNU coreutils 9.4 prints the placeholder `1.0(error)` with exit 0 in this case — a known limitation; this errors cleanly instead.)

## Tests

Added `test_to_si_rounding_past_top_suffix_is_too_big` (errors, exit 2) and `test_to_si_top_suffix_value_still_renders` (`--round=down` still yields `999Q`). Full numfmt suite passes; `cargo fmt`/`clippy` clean.
