### PR TITLE
build: migrate pre-commit hooks to prek

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,5 +32,5 @@ RUN apt-get update \
         python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# pre-commit
-RUN pip3 install --break-system-packages pre-commit
+# prek
+RUN pip3 install --break-system-packages prek

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         }
     },
     "onCreateCommand": {
-        "install pre-commit hooks": "pre-commit install",
+        "install prek hooks": "prek install",
         "update permissions for gnu coreutils volume": "sudo chown vscode:vscode ${containerWorkspaceFolder}/../gnu"
     },
 	"mounts": [

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -211,8 +211,8 @@ jobs:
         run: |
           python3 -m unittest util/test_compare_test_results.py util/test_compare_size_results.py
 
-  pre_commit:
-    name: Pre-commit hooks
+  prek:
+    name: Prek hooks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -234,19 +234,19 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install prek
+        run: pip install prek
 
       - name: Install cspell
         run: npm install -g cspell
 
-      - name: Cache pre-commit environments
+      - name: Cache prek environments
         uses: actions/cache@v5
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: prek-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            pre-commit-${{ runner.os }}-
+            prek-${{ runner.os }}-
 
-      - name: Run pre-commit
-        run: pre-commit run
+      - name: Run prek
+        run: prek run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+# See https://prek.j178.dev for more information
 exclude: ^tests/fixtures/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -74,6 +74,7 @@ rustc
 rustfmt
 rustup
 rustdoc
+prek
 #
 bitor # BitOr trait function
 bitxor # BitXor trait function

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,16 +50,17 @@ You will need these to [run uutils against the GNU test suite locally](#comparin
 
 For MacOS and Windows platform specific setup please check [MacOS GNU utils](#macos-gnu-utils) and [Windows GNU utils](#windows-gnu-utils) sections respectfully.
 
-### pre-commit hooks
+### prek hooks
 
-A configuration for `pre-commit` is provided in the repository. It allows
-automatically checking every git commit you make to ensure it compiles, and
-passes `clippy` and `rustfmt` without warnings.
+A configuration for `prek` is provided in the repository. It reads the existing
+`.pre-commit-config.yaml` natively and allows automatically checking every git
+commit you make to ensure it compiles, and passes `clippy` and `rustfmt`
+without warnings.
 
 To use the provided hook:
 
-1. [Install `pre-commit`](https://pre-commit.com/#install)
-1. Run `pre-commit install` while in the repository directory
+1. [Install `prek`](https://prek.j178.dev/installation/)
+1. Run `prek install` while in the repository directory
 
 Your git commits will then automatically be checked. If a check fails, an error
 message will explain why, and your commit will be canceled. You can then make
@@ -290,7 +291,7 @@ brew install \
   gnu-sed \
   m4 \
   bison \
-  pre-commit \
+  prek \
   findutils
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           llvmPackages.bintools
           rustup
 
-          pre-commit
+          prek
           nodePackages.cspell
 
           # debugging


### PR DESCRIPTION
## Summary

This switches our hook runner from `pre-commit` to [`prek`](https://github.com/j178/prek). The existing `.pre-commit-config.yaml` stays in place because `prek` reads it directly.

## Why

`prek` is a Rust-based drop-in replacement for `pre-commit`, it is noticeably faster in normal use and comes with useful improvements around monorepo support, shared hook environments, and concurrent execution. The upstream README has a good overview of its [features](https://github.com/j178/prek#features).

`prek` is already used by projects such as CPython, Ruff, FastAPI, and Airflow; the upstream README keeps a longer list of [adopted projects](https://github.com/j178/prek#who-is-using-prek).
