### PR TITLE
pr: reject a non-positive expand-tab width (-e0)

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -582,22 +582,43 @@ fn build_options(
     let expand_tabs = matches
         .get_one::<String>(options::EXPAND_TABS)
         .map(|s| {
-            s.chars().next().map_or(Ok(ExpandTabsOptions::default()), |c| {
-                if c.is_ascii_digit() {
-                    s
-                        .parse()
-                        .map_err(|_e| PrError::EncounteredErrors { msg: format!("{}\n{}", translate!("pr-error-invalid-expand-tab-argument", "arg" => s), translate!("pr-try-help-message")) })
-                        .map(|width| ExpandTabsOptions{input_char: TAB, width})
-                } else if s.len() > 1 {
-                    s[1..]
-                        .parse()
-                        .map_err(|_e| PrError::EncounteredErrors { msg: format!("{}\n{}", translate!("pr-error-invalid-expand-tab-argument", "arg" => &s[1..]), translate!("pr-try-help-message")) })
-                        .map(|width| ExpandTabsOptions{input_char: c, width})
-                } else {
-                    Ok(ExpandTabsOptions{input_char: c, width: 8})
-                }
-            })
-        }).transpose()?;
+            s.chars()
+                .next()
+                .map_or(Ok(ExpandTabsOptions::default()), |c| {
+                    let invalid = |arg: &str| PrError::EncounteredErrors {
+                        msg: format!(
+                            "{}\n{}",
+                            translate!("pr-error-invalid-expand-tab-argument", "arg" => arg),
+                            translate!("pr-try-help-message")
+                        ),
+                    };
+                    if c.is_ascii_digit() {
+                        let width: i32 = s.parse().map_err(|_e| invalid(s))?;
+                        if width <= 0 {
+                            return Err(invalid(s));
+                        }
+                        Ok(ExpandTabsOptions {
+                            input_char: TAB,
+                            width,
+                        })
+                    } else if s.len() > 1 {
+                        let width: i32 = s[1..].parse().map_err(|_e| invalid(&s[1..]))?;
+                        if width <= 0 {
+                            return Err(invalid(&s[1..]));
+                        }
+                        Ok(ExpandTabsOptions {
+                            input_char: c,
+                            width,
+                        })
+                    } else {
+                        Ok(ExpandTabsOptions {
+                            input_char: c,
+                            width: 8,
+                        })
+                    }
+                })
+        })
+        .transpose()?;
 
     let double_space = matches.get_flag(options::DOUBLE_SPACE);
 

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -889,3 +889,16 @@ fn test_zero_columns_shortcut() {
         .fails_with_code(1)
         .stderr_contains("pr: invalid --column argument '0'");
 }
+
+#[test]
+fn test_zero_expand_tab_width() {
+    let expected = "pr: '-e' extra characters or invalid number in the argument: ‘0’\nTry 'pr --help' for more information.\n";
+    new_ucmd!()
+        .arg("-e0")
+        .fails_with_code(1)
+        .stderr_only(expected);
+    new_ucmd!()
+        .arg("-eX0")
+        .fails_with_code(1)
+        .stderr_only(expected);
+}


### PR DESCRIPTION
Fixes #12614

`pr -e0` on tabbed input aborted with a remainder-by-zero panic in `apply_expand_tab`: the `-e[char][width]` parser accepted a width of `0` (and a negative width via `-eX-5`) without validation.

Reject `width <= 0` while parsing `-e`, emitting GNU's invalid-argument error (`pr: '-e' extra characters or invalid number in the argument: '0'`, exit 1). Adds a regression test.
