### PR TITLE
stat: fix char-boundary panic on an invalid directive after a multibyte char

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -82,10 +82,13 @@ struct Flags {
 /// where `beg` & `end` is the beginning and end index of sub-string, respectively
 fn check_bound(slice: &str, bound: usize, beg: usize, end: usize) -> UResult<()> {
     if end >= bound {
+        // `beg`/`end` are char indices, so take the directive by chars: byte-slicing
+        // `slice` could land mid-UTF-8 when a multibyte char precedes the directive.
+        let directive: String = slice.chars().skip(beg).take(end - beg).collect();
         return Err(USimpleError::new(
             1,
             StatError::InvalidDirective {
-                directive: slice[beg..end].quote().to_string(),
+                directive: directive.quote().to_string(),
             }
             .to_string(),
         ));

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -583,6 +583,17 @@ fn test_printf_invalid_directive() {
 }
 
 #[test]
+fn test_invalid_directive_after_multibyte_char() {
+    let ts = TestScenario::new(util_name!());
+    for (fmt, directive) in [("€%-", "%-"), ("ä%0", "%0"), ("€%.", "%.")] {
+        ts.ucmd()
+            .args(&["-c", fmt, "."])
+            .fails_with_code(1)
+            .stderr_only(format!("stat: '{directive}': invalid directive\n"));
+    }
+}
+
+#[test]
 #[cfg(all(
     feature = "feat_selinux",
     any(target_os = "linux", target_os = "android")


### PR DESCRIPTION
Fixes #12616

`stat -c '€%-'` (a multibyte char before an invalid `%` directive) aborted with "byte index N is not a char boundary": `check_bound` byte-sliced the format string using char indices, splitting the multibyte char.

Build the directive substring by chars instead of byte-slicing, so the invalid directive is reported (exit 1) like GNU instead of crashing. Adds a regression test.
