### PR TITLE
touch: fix char-boundary panic on a multibyte char in a -t timestamp

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -741,7 +741,10 @@ fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
 /// - 68 and before is interpreted as 20xx
 /// - 69 and after is interpreted as 19xx
 fn prepend_century(s: &str) -> UResult<String> {
-    let first_two_digits = s[..2].parse::<u32>().map_err(|_| {
+    // Take the first two chars rather than byte-slicing `s[..2]`: a leading
+    // multibyte char would otherwise split a UTF-8 boundary and panic.
+    let first_two: String = s.chars().take(2).collect();
+    let first_two_digits = first_two.parse::<u32>().map_err(|_| {
         USimpleError::new(
             1,
             translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -979,6 +979,16 @@ fn test_touch_invalid_date_format() {
 }
 
 #[test]
+fn test_touch_invalid_timestamp_leading_multibyte_char() {
+    for ts in ["€123456789", "€23456789012"] {
+        new_ucmd!()
+            .args(&["-t", ts, "f"])
+            .fails_with_code(1)
+            .stderr_only(format!("touch: invalid date ts format '{ts}'\n"));
+    }
+}
+
+#[test]
 #[cfg(not(target_os = "freebsd"))]
 fn test_touch_symlink_with_no_deref() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Fixes #12618

`touch -t '€123456789'` (a leading multibyte char in a 10- or 13-char timestamp) aborted with "byte index N is not a char boundary": `prepend_century` byte-sliced `s[..2]` to read the YY digits, splitting the multibyte char.

Take the first two chars instead of byte-slicing, so a multibyte/non-digit prefix yields the invalid-date error (exit 1) like GNU instead of crashing. Adds a regression test.
