### PR TITLE
printf: avoid formatter panic on large widths

### DIFF
--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -127,10 +127,8 @@ impl Display for FormatError {
     }
 }
 
-/// Maximum width for formatting to prevent memory allocation panics.
-/// Rust's formatter will panic when trying to allocate memory for very large widths.
-/// This limit is somewhat arbitrary but should be well above any practical use case
-/// while still preventing formatter panics.
+/// Maximum padding width for formatting to prevent pathological output requests.
+/// This limit is somewhat arbitrary but should be well above any practical use case.
 const MAX_FORMAT_WIDTH: usize = 1_000_000;
 
 /// Check if a width is too large for formatting.
@@ -144,6 +142,19 @@ fn check_width(width: usize) -> std::io::Result<()> {
     } else {
         Ok(())
     }
+}
+
+fn write_padding(mut writer: impl Write, byte: u8, len: usize) -> std::io::Result<()> {
+    check_width(len)?;
+
+    let buffer = [byte; 1024];
+    let mut remaining = len;
+    while remaining > 0 {
+        let count = remaining.min(buffer.len());
+        writer.write_all(&buffer[..count])?;
+        remaining -= count;
+    }
+    Ok(())
 }
 
 /// A single item to format

--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -724,19 +724,26 @@ fn write_output(
     // Using min() because self.width could be 0, 0usize - 1usize should be avoided
     let remaining_width = width - min(width, sign_indicator.len());
 
-    // Check if the width is too large for formatting
-    super::check_width(remaining_width)?;
-
     match alignment {
-        NumberAlignment::Left => write!(writer, "{sign_indicator}{s:<remaining_width$}"),
+        NumberAlignment::Left => {
+            writer.write_all(sign_indicator.as_bytes())?;
+            writer.write_all(s.as_bytes())?;
+            let padding = remaining_width.saturating_sub(s.len());
+            super::write_padding(writer, b' ', padding)
+        }
         NumberAlignment::RightSpace => {
             let is_sign = sign_indicator.starts_with('-') || sign_indicator.starts_with('+'); // When sign_indicator is in ['-', '+']
             if is_sign && remaining_width > 0 {
                 // Make sure sign_indicator is just next to number, e.g. "% +5.1f" 1 ==> $ +1.0
-                let s = sign_indicator + s.as_str();
-                write!(writer, "{s:>width$}", width = remaining_width + 1) // Since we now add sign_indicator and s together, plus 1
+                let padding = width.saturating_sub(sign_indicator.len().saturating_add(s.len()));
+                super::write_padding(&mut writer, b' ', padding)?;
+                writer.write_all(sign_indicator.as_bytes())?;
+                writer.write_all(s.as_bytes())
             } else {
-                write!(writer, "{sign_indicator}{s:>remaining_width$}")
+                writer.write_all(sign_indicator.as_bytes())?;
+                let padding = remaining_width.saturating_sub(s.len());
+                super::write_padding(&mut writer, b' ', padding)?;
+                writer.write_all(s.as_bytes())
             }
         }
         NumberAlignment::RightZero => {
@@ -747,7 +754,11 @@ fn write_output(
                 ("", s.as_str())
             };
             let remaining_width = remaining_width.saturating_sub(prefix.len());
-            write!(writer, "{sign_indicator}{prefix}{rest:0>remaining_width$}")
+            writer.write_all(sign_indicator.as_bytes())?;
+            writer.write_all(prefix.as_bytes())?;
+            let padding = remaining_width.saturating_sub(rest.len());
+            super::write_padding(&mut writer, b'0', padding)?;
+            writer.write_all(rest.as_bytes())
         }
     }
 }

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -551,14 +551,11 @@ fn write_padded(
 ) -> Result<(), FormatError> {
     let padlen = width.saturating_sub(text.len());
 
-    // Check if the padding length is too large for formatting
-    super::check_width(padlen).map_err(FormatError::IoError)?;
-
     if left {
         writer.write_all(text)?;
-        write!(writer, "{: <padlen$}", "")
+        super::write_padding(writer, b' ', padlen)
     } else {
-        write!(writer, "{: >padlen$}", "")?;
+        super::write_padding(&mut writer, b' ', padlen)?;
         writer.write_all(text)
     }
     .map_err(FormatError::IoError)

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1486,6 +1486,29 @@ fn test_large_width_format() {
 }
 
 #[test]
+fn test_large_but_allowed_width_format() {
+    let width = 111_111;
+
+    let expected_char = format!("{}x", " ".repeat(width - 1));
+    new_ucmd!()
+        .args(&["%111111c", "x"])
+        .succeeds()
+        .stdout_only(expected_char);
+
+    let expected_int = format!("{}1", " ".repeat(width - 1));
+    new_ucmd!()
+        .args(&["%111111.1d", "1"])
+        .succeeds()
+        .stdout_only(expected_int);
+
+    let expected_float = format!("{}1.0", " ".repeat(width - 3));
+    new_ucmd!()
+        .args(&["%111111.1f", "1"])
+        .succeeds()
+        .stdout_only(expected_float);
+}
+
+#[test]
 fn test_extreme_field_width_overflow() {
     // Test the specific case that was causing panic due to integer overflow
     // in the field width parsing.


### PR DESCRIPTION
## What changed

This replaces the remaining dynamic-width padding calls in the shared printf formatting code with bounded manual padding writes.

The affected paths were:
- string/character padding in `spec.rs`, which panicked for `%111111c`
- numeric output padding in `num_format.rs`, which panicked for `%111111.1d` and `%111111.1f`

## Why

The existing guard rejects clearly pathological output widths above `1_000_000`, but these reports use widths around `111_111`: large, but still below that guard. The panic came from feeding those widths into Rust's dynamic formatting machinery, which has a smaller internal bound and panics with `Formatting argument out of range`.

Lowering the project guard to that internal formatter limit would avoid the panic, but it would also reject valid finite `printf` widths that GNU accepts. Writing padding in chunks keeps the intended behavior: valid large widths can be emitted, while absurd padding requests still return the existing write error through `check_width`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --no-default-features --features printf --test tests test_printf::test_large_but_allowed_width_format -- --nocapture`
- `cargo test --no-default-features --features printf --test tests test_printf::test_large_width_format -- --nocapture`
- `cargo test --no-default-features --features printf --test tests test_printf::test_extreme_field_width_overflow -- --nocapture`
- `cargo test --no-default-features --features printf --test tests test_printf -- --nocapture`
- `cargo test -p uucore --features format format -- --nocapture`
- `cargo clippy -p uucore --features format -- -D warnings`
- `cargo clippy --no-default-features --features printf --test tests -- -D warnings`

Fixes #12592.
Fixes #12593.
