### PR TITLE
b2sum: report malformed status input

### DIFF
--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -951,9 +951,7 @@ fn process_checksum_file(
     // not a single line correctly formatted found
     // return an error
     if res.total_properly_formatted() == 0 {
-        if opts.verbose.over_status() {
-            log_no_properly_formatted(filename_display());
-        }
+        log_no_properly_formatted(filename_display());
         return Err(FileCheckError::Failed);
     }
 

--- a/tests/by-util/test_b2sum.rs
+++ b/tests/by-util/test_b2sum.rs
@@ -159,6 +159,23 @@ fn test_check_b2sum_length_option_8() {
 }
 
 #[test]
+fn test_check_b2sum_status_reports_no_properly_formatted_lines() {
+    let invalid_checksum = concat!(
+        "bedfbb90d858c2d67b7ee8f7523be3d3b54004ef9e4f02f2",
+        "ad79a1d05bfdfe49b81e3c92ebf99b504102b6bf003fa342",
+        "587f5b3124c205f55204e8c4b4ce7d7c",
+    );
+
+    new_ucmd!()
+        .arg("-c")
+        .arg("--status")
+        .pipe_in(invalid_checksum)
+        .fails()
+        .no_stdout()
+        .stderr_contains("b2sum: 'standard input': no properly formatted checksum lines found");
+}
+
+#[test]
 fn test_invalid_b2sum_length_option_not_multiple_of_8() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
## What changed

`b2sum -c --status` now still reports the structural error when the checksum input contains no properly formatted checksum lines.

The change is in the shared checksum validator: the `no properly formatted checksum lines found` diagnostic is no longer hidden by `ChecksumVerbose::Status`. Regular checksum mismatches under `--status` remain silent; only the “there was nothing valid to check” diagnostic is surfaced.

## Why

GNU `b2sum -c --status` reports this case because it is not a per-file mismatch result, it is an invalid checksum-list input. The previous logic treated it like other status-mode output and suppressed the diagnostic, leaving only the exit code.

Fixes #12590.