### PR TITLE
fmt: match GNU wrapping for explicit widths

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -129,7 +129,7 @@ impl FmtOptions {
             None
         };
 
-        let (width, goal) = match (width_opt, goal_opt) {
+        let (mut width, mut goal) = match (width_opt, goal_opt) {
             (Some(w), Some(g)) => {
                 if g > w {
                     return Err(FmtError::GoalGreaterThanWidth.into());
@@ -153,14 +153,22 @@ impl FmtOptions {
             }
             (None, None) => (DEFAULT_WIDTH, DEFAULT_GOAL),
         };
-        debug_assert!(
-            width >= goal,
-            "GOAL {goal} should not be greater than WIDTH {width} when given {width_opt:?} and {goal_opt:?}."
-        );
 
         if width > MAX_WIDTH {
             return Err(FmtError::WidthOutOfRange(width).into());
         }
+
+        if width_opt.is_some() && width > 0 {
+            // GNU fmt counts the terminating newline against an explicit width,
+            // so the line-breaking budget for visible content is one column lower.
+            width -= 1;
+            goal = goal.saturating_sub(1).min(width);
+        }
+
+        debug_assert!(
+            width >= goal,
+            "GOAL {goal} should not be greater than WIDTH {width} when given {width_opt:?} and {goal_opt:?}."
+        );
 
         let mut tabwidth = 8;
         if let Some(s) = matches.get_one::<String>(options::TAB_WIDTH) {

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -57,12 +57,27 @@ fn test_fmt_width_max_display_width() {
         .args(&["-w", "8"])
         .pipe_in(input)
         .succeeds()
-        .stdout_is("aa bb cc\ndd ee\n");
+        .stdout_is("aa\nbb cc\ndd ee\n");
     new_ucmd!()
         .args(&["-w", "7"])
         .pipe_in(input)
         .succeeds()
         .stdout_is("aa\nbb cc\ndd ee\n");
+}
+
+#[test]
+fn test_fmt_width_matches_gnu_newline_budget() {
+    new_ucmd!()
+        .args(&["-w", "10"])
+        .pipe_in("漢 字 test 日 本 語")
+        .succeeds()
+        .stdout_is("漢 字\ntest 日\n本 語\n");
+
+    new_ucmd!()
+        .args(&["-w", "15"])
+        .pipe_in("漢字 test 日本語")
+        .succeeds()
+        .stdout_is("漢字 test\n日本語\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #10095.

GNU `fmt` counts the terminating newline against an explicit `-w`/`--width` value, so the visible line content budget is one column lower than the user-supplied width. uutils was using the full width as visible content budget, which allowed lines such as `aa bb cc` at `-w 8` and kept some wide-character examples on one line where GNU wraps earlier.

This keeps validation against the user-supplied width first, then adjusts only the internal line-breaking width/goal for explicit widths. The default width path stays unchanged.

The regression coverage uses the ASCII and Unicode examples from the issue so the intended GNU-compatible wrapping is visible in tests.