### PR TITLE
cp: propagate the --attributes-only destination open error

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2386,7 +2386,7 @@ fn handle_copy_mode(
                 .truncate(false)
                 .create(true)
                 .open(dest)
-                .unwrap();
+                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
         }
     }
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -4413,6 +4413,16 @@ fn test_cp_attributes_only() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_cp_attributes_only_dest_open_error() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("s.txt", "hi");
+    ucmd.args(&["--attributes-only", "s.txt", "/dev/null/n.txt"])
+        .fails_with_code(1)
+        .stderr_contains("cp: 's.txt' -> '/dev/null/n.txt'");
+}
+
+#[test]
 fn test_cp_seen_file() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;


### PR DESCRIPTION
Fixes #12624

`cp --attributes-only SRC DEST` aborted with a `Result::unwrap()` panic when opening the destination failed (e.g. EACCES on an unwritable parent, ENOTDIR on a non-directory parent): the `CopyMode::AttrOnly` branch unwrapped the open result.

Propagate the open error with the existing `'src' -> 'dest'` context via `CpError::IoErrContext`, like the other I/O sites in `handle_copy_mode`, so cp reports the error and exits 1 instead of crashing. Adds a regression test.
