### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,6 +5,10 @@ name: Security audit
 on:
   schedule:
     - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-toml.yml
+++ b/.github/workflows/check-toml.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - "**.toml"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,9 @@ on:
       - 'src/uu/*/locales/en-US.ftl'
       - 'Cargo.toml'
 
+permissions:
+  contents: read
+
 jobs:
   check-doc:
     name: Verify uudoc generates correct documentation

--- a/.github/workflows/manpage-lint.yml
+++ b/.github/workflows/manpage-lint.yml
@@ -22,6 +22,9 @@ on:
       - 'GNUmakefile'
       - '.github/workflows/manpage-lint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   manpage-lint:
     name: Validate manpages with mandoc


### PR DESCRIPTION
Potential fix for [https://github.com/uutils/coreutils/security/code-scanning/5](https://github.com/uutils/coreutils/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/check-toml.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This supports `actions/checkout` and read-only repository access while preventing unintended write capabilities. No other workflow behavior needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
