### PR TITLE
tail: treat a watched file replaced by a symlink as untailable

### DIFF
--- a/src/uu/tail/locales/en-US.ftl
+++ b/src/uu/tail/locales/en-US.ftl
@@ -58,6 +58,7 @@ tail-status-has-appeared-following-new-file = { $file } has appeared;  following
 tail-status-has-been-replaced-following-new-file = { $file } has been replaced;  following new file
 tail-status-file-truncated = { $file }: file truncated
 tail-status-replaced-with-untailable-file = { $file } has been replaced with an untailable file
+tail-status-replaced-with-untailable-symlink = { $file } has been replaced with an untailable symbolic link
 tail-status-replaced-with-untailable-file-giving-up = { $file } has been replaced with an untailable file; giving up on this name
 tail-status-directory-containing-watched-file-removed = directory containing watched file was removed
 tail-status-backend-cannot-be-used-reverting-to-polling = { $backend } cannot be used, reverting to polling

--- a/src/uu/tail/locales/fr-FR.ftl
+++ b/src/uu/tail/locales/fr-FR.ftl
@@ -57,6 +57,7 @@ tail-status-has-appeared-following-new-file = { $file } est apparu ; suivi du no
 tail-status-has-been-replaced-following-new-file = { $file } a été remplacé ; suivi du nouveau fichier
 tail-status-file-truncated = { $file } : fichier tronqué
 tail-status-replaced-with-untailable-file = { $file } a été remplacé par un fichier non suivable
+tail-status-replaced-with-untailable-symlink = { $file } a été remplacé par un lien symbolique non suivable
 tail-status-replaced-with-untailable-file-giving-up = { $file } a été remplacé par un fichier non suivable ; abandon de ce nom
 tail-status-directory-containing-watched-file-removed = le répertoire contenant le fichier surveillé a été supprimé
 tail-status-backend-cannot-be-used-reverting-to-polling = { $backend } ne peut pas être utilisé, retour au sondage

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -310,7 +310,15 @@ impl Observer {
             EventKind::Modify(ModifyKind::Metadata(MetadataKind::Any | MetadataKind::WriteTime) | ModifyKind::Data(DataChange::Any) | ModifyKind::Name(RenameMode::To)) |
             EventKind::Create(CreateKind::File | CreateKind::Folder | CreateKind::Any) => {
                 if let Ok(new_md) = event_path.metadata() {
-                    let is_tailable = new_md.is_tailable();
+                    // `metadata()` follows symlinks, so under --follow=name a
+                    // watched file swapped for a symlink would otherwise be
+                    // silently followed to its target. GNU treats such a
+                    // replacement as untailable.
+                    let replaced_by_symlink = self.follow_name()
+                        && event_path
+                            .symlink_metadata()
+                            .is_ok_and(|m| m.file_type().is_symlink());
+                    let is_tailable = !replaced_by_symlink && new_md.is_tailable();
                     let pd = self.files.get(event_path);
                     if let Some(old_md) = &pd.metadata {
                         if is_tailable {
@@ -345,7 +353,13 @@ impl Observer {
                             }
                             paths.push(event_path.clone());
                         } else if !is_tailable && old_md.is_tailable() {
-                            if pd.reader.is_some() {
+                            if replaced_by_symlink {
+                                show_error!(
+                                    "{}",
+                                    translate!("tail-status-replaced-with-untailable-symlink", "file" => display_name.quote())
+                                );
+                                self.files.reset_reader(event_path);
+                            } else if pd.reader.is_some() {
                                 self.files.reset_reader(event_path);
                             } else {
                                 show_error!(

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1610,6 +1610,43 @@ fn test_retry7() {
     }
 }
 
+/// Under `--follow=name`, a watched file replaced by a symlink must be reported
+/// as untailable, not silently followed to the link target (which would
+/// exfiltrate its contents).
+#[test]
+#[cfg(unix)]
+#[cfg(not(target_os = "android"))]
+fn test_follow_name_replaced_by_symlink_is_untailable() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.write("secret", "secret-must-not-leak\n");
+    at.write("watched", "visible\n");
+
+    let mut p = ts
+        .ucmd()
+        .args(&[
+            "-F",
+            "-s.1",
+            "--max-unchanged-stats=1",
+            "--use-polling",
+            "watched",
+        ])
+        .run_no_wait();
+    p.make_assertion_with_delay(500).is_alive();
+
+    // Swap the watched file for a symlink pointing at a secret file.
+    at.remove("watched");
+    at.symlink_file("secret", "watched");
+    p.delay(1000);
+
+    p.kill()
+        .make_assertion()
+        .with_all_output()
+        .stdout_does_not_contain("secret-must-not-leak")
+        .stderr_contains("has been replaced with an untailable symbolic link");
+}
+
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),


### PR DESCRIPTION
Under --follow=name, handle_event used metadata() (which follows symlinks), so a watched file swapped for a symlink was silently followed to the link target, exfiltrating its contents. Check symlink_metadata() and report the replacement as an untailable symbolic link, matching GNU.

Fixes CVE-2026-35345.