### PR TITLE
split: read ahead input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
  "codspeed-divan-compat",
  "fluent",
  "memchr",
+ "rustix",
  "tempfile",
  "thiserror 2.0.18",
  "uucore",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2066,6 +2066,7 @@ dependencies = [
  "clap",
  "fluent",
  "memchr",
+ "rustix",
  "thiserror",
  "uucore",
 ]

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 memchr = { workspace = true }
+rustix = { workspace = true }
 uucore = { workspace = true, features = ["fs", "parser-size"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1539,6 +1539,8 @@ fn split(settings: &Settings) -> UResult<()> {
         let r = File::open(Path::new(&settings.input)).map_err_context(
             || translate!("split-error-cannot-open-for-reading", "file" => settings.input.quote()),
         )?;
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        let _ = rustix::fs::fadvise(&r, 0, None, rustix::fs::Advice::Sequential);
         Box::new(r) as Box<dyn Read>
     };
     let mut reader = if let Some(c) = settings.io_blksize {


### PR DESCRIPTION
The most usecase for `split` is splitting large file. So provide a hint to the kernal as same as `cat`, `*sum`, etc...