### PR TITLE
sort: fix locale collation strength for hyphen ordering

### DIFF
--- a/src/uucore/src/lib/features/i18n/collator.rs
+++ b/src/uucore/src/lib/features/i18n/collator.rs
@@ -70,6 +70,7 @@ pub fn init_locale_collation() -> bool {
     // UTF-8 locale - initialize collator with Shifted mode to match GNU behavior
     let mut opts = CollatorOptions::default();
     opts.alternate_handling = Some(AlternateHandling::Shifted);
+    opts.strength = Some(Strength::Quaternary);
 
     try_init_collator(opts)
 }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -3017,4 +3017,23 @@ fn test_consistent_sorting_with_i18n_collate() {
         .stdout_is(expected_output);
 }
 
+#[test]
+fn test_sort_locale_punctuation_weights() {
+    // Test for issue #12542
+    let input = "file10\nfile-10\n";
+    let expected_output = "file-10\nfile10\n";
+
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(expected_output);
+
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is(expected_output);
+}
+
 /* spell-checker: enable */


### PR DESCRIPTION
## Problem

In locale mode (`LC_ALL=en_US.UTF-8`), `sort` was ordering `file10` before `file-10`, but GNU sort places the hyphen first.

The collator was initialized with `AlternateHandling::Shifted` but without `Strength::Quaternary`. In Shifted mode, punctuation is moved to the quaternary weight level, but with the default `Tertiary` strength only three levels are compared, so punctuation weights are never consulted. `file-10` and `file10` produce identical sort keys.

The tiebreaker in `sort.rs:2658-2660` then runs a reversed byte comparison (`b.line.cmp(a.line)`), which puts `file10` first because `'1'` (0x31) > `'-'` (0x2D) and the reversal flips the winner.

## Fix

Add `Strength::Quaternary` to the collator in `init_locale_collation` so that shifted punctuation weights are actually compared.

Fixes #12542