### PR TITLE
ls: apply two-line --time-style format to old/recent files correctly

### DIFF
--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -1057,13 +1057,17 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                 // `field` can be empty here (e.g. --time-style=posix-), so test
                 // the prefix instead of unwrapping the first char.
                 _ if field.starts_with('+') => {
-                    // recent/older formats are (optionally) separated by a newline
+                    // Formats are (optionally) separated by a newline:
+                    // FORMAT1 NEWLINE FORMAT2 -> FORMAT1 for older files, FORMAT2 for recent.
+                    // A single format applies to all files (stored as recent).
                     let mut it = field[1..].split('\n');
-                    let recent = it.next().unwrap_or_default();
-                    let older = it.next();
+                    let first = it.next().unwrap_or_default();
                     match it.next() {
-                        None => ok((recent, older)),
-                        Some(_) => Err(LsError::TimeStyleParseError(String::from(field))),
+                        None => ok((first, None)),
+                        Some(second) => match it.next() {
+                            None => ok((second, Some(first))),
+                            Some(_) => Err(LsError::TimeStyleParseError(String::from(field))),
+                        },
                     }
                 }
                 _ => Err(LsError::TimeStyleParseError(String::from(field))),

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -1074,13 +1074,17 @@ fn parse_time_style(options: &clap::ArgMatches) -> Result<(String, Option<String
                 // `field` can be empty here (e.g. --time-style=posix-), so test
                 // the prefix instead of unwrapping the first char.
                 _ if field.starts_with('+') => {
-                    // recent/older formats are (optionally) separated by a newline
+                    // Formats are (optionally) separated by a newline:
+                    // FORMAT1 NEWLINE FORMAT2 -> FORMAT1 for older files, FORMAT2 for recent.
+                    // A single format applies to all files (stored as recent).
                     let mut it = field[1..].split('\n');
-                    let recent = it.next().unwrap_or_default();
-                    let older = it.next();
+                    let first = it.next().unwrap_or_default();
                     match it.next() {
-                        None => ok((recent, older)),
-                        Some(_) => Err(LsError::TimeStyleParseError(String::from(field))),
+                        None => ok((first, None)),
+                        Some(second) => match it.next() {
+                            None => ok((second, Some(first))),
+                            Some(_) => Err(LsError::TimeStyleParseError(String::from(field))),
+                        },
                     }
                 }
                 _ => Err(LsError::TimeStyleParseError(String::from(field))),

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2344,15 +2344,17 @@ fn test_ls_time_styles() {
         .stdout_matches(&re_custom_format_recent)
         .stdout_matches(&re_custom_format_old);
 
-    //+FORMAT_RECENT\nFORMAT_OLD
+    //+FORMAT_OLD\nFORMAT_RECENT: FORMAT1 applies to old files, FORMAT2 to recent files.
+    let re_custom_format_recent_2 =
+        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}--\d{2} test\n").unwrap();
     let re_custom_format_old =
-        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}--\d{2} test-old\n").unwrap();
+        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}__\d{2} test-old\n").unwrap();
     scene
         .ucmd()
         .arg("-l")
         .arg("--time-style=+%Y__%M\n%Y--%M")
         .succeeds()
-        .stdout_matches(&re_custom_format_recent)
+        .stdout_matches(&re_custom_format_recent_2)
         .stdout_matches(&re_custom_format_old);
 
     // Also fails due to not having full clap support for time_styles
@@ -2480,13 +2482,13 @@ fn test_ls_time_recent_future() {
         .succeeds()
         .stdout_matches(&re_iso_old);
 
-    // Also test that we can set a format that varies for recent of older files.
-    //+FORMAT_RECENT\nFORMAT_OLD
+    // A two-line format assigns FORMAT1 to old files and FORMAT2 to recent files.
+    //+FORMAT_OLD\nFORMAT_RECENT
     f.set_modified(SystemTime::now()).unwrap();
     scene
         .ucmd()
         .arg("-l")
-        .arg("--time-style=+RECENT\nOLD")
+        .arg("--time-style=+OLD\nRECENT")
         .succeeds()
         .stdout_contains("RECENT");
 
@@ -2496,11 +2498,11 @@ fn test_ls_time_recent_future() {
     scene
         .ucmd()
         .arg("-l")
-        .arg("--time-style=+RECENT\nOLD")
+        .arg("--time-style=+OLD\nRECENT")
         .succeeds()
         .stdout_contains("OLD");
 
-    // RECENT format is still used if no "OLD" one provided.
+    // The single format is used for all files when no second one is provided.
     scene
         .ucmd()
         .arg("-l")

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2364,15 +2364,17 @@ fn test_ls_time_styles() {
         .stdout_matches(&re_custom_format_recent)
         .stdout_matches(&re_custom_format_old);
 
-    //+FORMAT_RECENT\nFORMAT_OLD
+    //+FORMAT_OLD\nFORMAT_RECENT: FORMAT1 applies to old files, FORMAT2 to recent files.
+    let re_custom_format_recent_2 =
+        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}--\d{2} test\n").unwrap();
     let re_custom_format_old =
-        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}--\d{2} test-old\n").unwrap();
+        Regex::new(r"[a-z-]* \d* [\w.]* [\w.]* \d* \d{4}__\d{2} test-old\n").unwrap();
     scene
         .ucmd()
         .arg("-l")
         .arg("--time-style=+%Y__%M\n%Y--%M")
         .succeeds()
-        .stdout_matches(&re_custom_format_recent)
+        .stdout_matches(&re_custom_format_recent_2)
         .stdout_matches(&re_custom_format_old);
 
     // Also fails due to not having full clap support for time_styles
@@ -2500,13 +2502,13 @@ fn test_ls_time_recent_future() {
         .succeeds()
         .stdout_matches(&re_iso_old);
 
-    // Also test that we can set a format that varies for recent of older files.
-    //+FORMAT_RECENT\nFORMAT_OLD
+    // A two-line format assigns FORMAT1 to old files and FORMAT2 to recent files.
+    //+FORMAT_OLD\nFORMAT_RECENT
     f.set_modified(SystemTime::now()).unwrap();
     scene
         .ucmd()
         .arg("-l")
-        .arg("--time-style=+RECENT\nOLD")
+        .arg("--time-style=+OLD\nRECENT")
         .succeeds()
         .stdout_contains("RECENT");
 
@@ -2516,11 +2518,11 @@ fn test_ls_time_recent_future() {
     scene
         .ucmd()
         .arg("-l")
-        .arg("--time-style=+RECENT\nOLD")
+        .arg("--time-style=+OLD\nRECENT")
         .succeeds()
         .stdout_contains("OLD");
 
-    // RECENT format is still used if no "OLD" one provided.
+    // The single format is used for all files when no second one is provided.
     scene
         .ucmd()
         .arg("-l")


### PR DESCRIPTION
FORMAT1 NEWLINE FORMAT2 should use FORMAT1 for non-recent (old) files and FORMAT2 for recent files; the assignment was reversed.

Closes: #12676 
