### PR TITLE
split: avoid abort on excessively large suffix lengths

### DIFF
--- a/src/uu/split/src/number.rs
+++ b/src/uu/split/src/number.rs
@@ -194,7 +194,9 @@ pub struct FixedWidthNumber {
 impl FixedWidthNumber {
     /// Instantiate a number of the given radix and width.
     pub fn new(radix: u8, width: usize, mut suffix_start: usize) -> Result<Self, Overflow> {
-        let mut digits = vec![0_u8; width];
+        let mut digits = Vec::new();
+        digits.try_reserve_exact(width).map_err(|_| Overflow)?;
+        digits.resize(width, 0);
 
         for i in (0..digits.len()).rev() {
             let remainder = (suffix_start % (radix as usize)) as u8;


### PR DESCRIPTION
Fixes #12599

Previously, `split -a <very-large-number>` could abort due to an attempted
allocation of an enormous `Vec<u8>` in `FixedWidthNumber::new`.

Replace the infallible allocation:

```rust
vec![0_u8; width]
````

with a fallible allocation using `try_reserve_exact`, returning `Overflow`
instead of aborting when the allocation cannot be satisfied.

After this change, `split` reports a normal error instead of crashing.

Example:

```console
$ split -a 66542562175252
split: numerical suffix start value is too large for the suffix length
```