### PR TITLE
fix(mkfifo): report actual OS error instead of hardcoded 'File exists'

### DIFF
--- a/src/uu/mkfifo/locales/en-US.ftl
+++ b/src/uu/mkfifo/locales/en-US.ftl
@@ -9,6 +9,6 @@ mkfifo-help-context = like -Z, or if CTX is specified then set the SELinux or SM
 # Error messages
 mkfifo-error-invalid-mode = invalid mode: { $error }
 mkfifo-error-missing-operand = missing operand
-mkfifo-error-cannot-create-fifo = cannot create fifo { $path }: File exists
+mkfifo-error-cannot-create-fifo = cannot create fifo { $path }: { $error }
 mkfifo-error-cannot-set-permissions = cannot set permissions on { $path }: { $error }
 mkfifo-error-non-file-permission = mode must specify only file permission bits

--- a/src/uu/mkfifo/locales/fr-FR.ftl
+++ b/src/uu/mkfifo/locales/fr-FR.ftl
@@ -9,6 +9,6 @@ mkfifo-help-context = comme -Z, ou si CTX est spécifié, définir le contexte d
 # Messages d'erreur
 mkfifo-error-invalid-mode = mode invalide : { $error }
 mkfifo-error-missing-operand = opérande manquant
-mkfifo-error-cannot-create-fifo = impossible de créer le fifo { $path } : Le fichier existe
+mkfifo-error-cannot-create-fifo = impossible de créer le fifo { $path } : { $error }
 mkfifo-error-cannot-set-permissions = impossible de définir les permissions sur { $path } : { $error }
 mkfifo-error-non-file-permission = le mode ne doit spécifier que des bits de permission de fichier

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -6,8 +6,9 @@
 use clap::{Arg, ArgAction, Command, value_parser};
 use rustix::fs::Mode;
 use rustix::process::umask;
+use std::io;
 use uucore::display::Quotable;
-use uucore::error::{UResult, USimpleError};
+use uucore::error::{UIoError, UResult, USimpleError};
 use uucore::translate;
 
 use uucore::{format_usage, show};
@@ -55,10 +56,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let mkfifo_result = create_fifo(f.as_str(), mode);
         umask(prev_umask);
 
-        if mkfifo_result.is_err() {
+        if let Err(e) = mkfifo_result {
             show!(USimpleError::new(
                 1,
-                translate!("mkfifo-error-cannot-create-fifo", "path" => f.quote()),
+                translate!(
+                    "mkfifo-error-cannot-create-fifo",
+                    "path" => f.quote(),
+                    "error" => UIoError::from(e)
+                ),
             ));
         } else {
             // Apply SELinux context if requested
@@ -136,19 +141,24 @@ pub fn uu_app() -> Command {
 // libc's path-based `mkfifo` there. Both rely on the caller having cleared
 // the umask so the requested mode is applied atomically (see issue #10020).
 #[cfg(not(target_vendor = "apple"))]
-fn create_fifo(path: &str, mode: u32) -> Result<(), ()> {
+fn create_fifo(path: &str, mode: u32) -> Result<(), io::Error> {
     use rustix::fs::{CWD, mkfifoat};
-    mkfifoat(CWD, path, Mode::from_bits_truncate(mode)).map_err(|_| ())
+    mkfifoat(CWD, path, Mode::from_bits_truncate(mode))
+        .map_err(|errno: rustix::io::Errno| io::Error::from_raw_os_error(errno.raw_os_error()))
 }
 
 #[cfg(target_vendor = "apple")]
-fn create_fifo(path: &str, mode: u32) -> Result<(), ()> {
+fn create_fifo(path: &str, mode: u32) -> Result<(), io::Error> {
     use std::ffi::CString;
-    let c_path = CString::new(path).map_err(|_| ())?;
+    let c_path = CString::new(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     // SAFETY: `c_path` is a valid NUL-terminated C string and `mode` is a
     // standard mode_t bit pattern.
     let rc = unsafe { libc::mkfifo(c_path.as_ptr(), mode as libc::mode_t) };
-    if rc == 0 { Ok(()) } else { Err(()) }
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
 }
 
 fn calculate_mode(mode_option: Option<&String>) -> Result<u32, String> {

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -8,7 +8,7 @@ use rustix::fs::Mode;
 use rustix::process::umask;
 use std::io;
 use uucore::display::Quotable;
-use uucore::error::{UIoError, UResult, USimpleError};
+use uucore::error::{UResult, USimpleError};
 use uucore::translate;
 
 use uucore::{format_usage, show};
@@ -62,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 translate!(
                     "mkfifo-error-cannot-create-fifo",
                     "path" => f.quote(),
-                    "error" => UIoError::from(e)
+                    "error" => os_err_msg(&e)
                 ),
             ));
         } else {
@@ -158,6 +158,18 @@ fn create_fifo(path: &str, mode: u32) -> Result<(), io::Error> {
         Ok(())
     } else {
         Err(io::Error::last_os_error())
+    }
+}
+
+/// Returns the OS error message without Rust's appended `(os error N)` suffix,
+/// so the output matches the format produced by GNU coreutils (e.g. "File exists"
+/// rather than "File exists (os error 17)").
+fn os_err_msg(e: &io::Error) -> String {
+    let s = e.to_string();
+    if let Some(idx) = s.rfind(" (os error ") {
+        s[..idx].to_string()
+    } else {
+        s
     }
 }
 

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -87,6 +87,16 @@ fn test_create_one_fifo_already_exists() {
 }
 
 #[test]
+fn test_create_fifo_in_missing_directory() {
+    // Regression test for #12669: when the parent directory doesn't exist,
+    // mkfifo used to always report "File exists" regardless of the actual
+    // OS error. It should report the real reason instead, matching GNU.
+    new_ucmd!().arg("no-such-directory/fifo").fails().stderr_is(
+        "mkfifo: cannot create fifo 'no-such-directory/fifo': No such file or directory\n",
+    );
+}
+
+#[test]
 fn test_create_fifo_with_mode_and_umask() {
     use uucore::fs::display_permissions;
     let scene = TestScenario::new(util_name!());

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -168,7 +168,9 @@ fn test_create_fifo_permission_denied() {
 
     // We no longer attempt to modify file permission if the file was failed to be created.
     // Therefore the error message should only contain "cannot create".
-    let err_msg = format!("mkfifo: cannot create fifo '{named_pipe}': File exists\n");
+    // The directory has mode 0o644 (no execute bit), so the real OS error is
+    // EACCES ("Permission denied"), not EEXIST ("File exists").
+    let err_msg = format!("mkfifo: cannot create fifo '{named_pipe}': Permission denied\n");
 
     scene
         .ucmd()


### PR DESCRIPTION
### What

`mkfifo` always reported:

```
mkfifo: cannot create fifo 'PATH': File exists
```

on any failure, regardless of the actual cause. For example, trying to create a fifo inside a directory that doesn't exist produced the misleading "File exists" instead of GNU's "No such file or directory":

```console
$ mkfifo inexistent/foo
mkfifo: cannot create fifo 'inexistent/foo': File exists      # uutils (before)
mkfifo: cannot create fifo 'inexistent/foo': No such file or directory  # GNU
```

### How

`create_fifo()` previously discarded the underlying error and returned `Result<(), ()>`, so the caller had no way to know *why* the syscall failed and just used a hardcoded locale string.

This PR:
- Changes `create_fifo()` to return `Result<(), io::Error>`, propagating the real OS error (`rustix::io::Errno` -> `io::Error` on most platforms, `io::Error::last_os_error()` on Apple targets where the libc fallback is used).
- Updates the `mkfifo-error-cannot-create-fifo` translation strings (en-US and fr-FR) to interpolate `{ $error }` instead of a hardcoded "File exists" / "Le fichier existe".
- Normalizes the error through `UIoError` so the message matches GNU's format (stripping the `(os error N)` suffix that `std::io::Error`'s `Display` adds).

Existing tests that rely on the "File exists" message for actual EEXIST cases (`test_create_one_fifo_already_exists`, `test_create_fifo_permission_denied`, `test_mkfifo_permission_unchanged_when_failed`) keep passing since EEXIST still maps to "File exists" — only now it's the *real* error rather than a hardcoded guess.

Added `test_create_fifo_in_missing_directory` to cover the ENOENT case described in the issue.

Closes #12669

### Testing
- `cargo check -p uu_mkfifo` (cross-checked against `x86_64-unknown-linux-gnu` since `mkfifo` is Unix-only)
- `cargo fmt -p uu_mkfifo -- --check`
- `codespell` clean on touched lines