### PR TITLE
Simplify if-guard-then-bool returns

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2029,14 +2029,10 @@ fn is_forbidden_to_copy_to_same_file(
     }
     // If source and dest are both the same symlink but with different names, then allow the copy.
     // This can occur, for example, if source and dest are both hardlinks to the same symlink.
-    if dest_is_symlink
+    !(dest_is_symlink
         && source_is_symlink
         && source.file_name() != dest.file_name()
-        && !options.dereference
-    {
-        return false;
-    }
-    true
+        && !options.dereference)
 }
 
 /// Back up, remove, or leave intact the destination file, depending on the options.

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -273,11 +273,7 @@ fn mount_info_lt(m1: &MountInfo, m2: &MountInfo) -> bool {
     // matching an existing mnt point, to avoid problematic
     // replacement when given inaccurate mount lists, seen with some
     // chroot environments for example.
-    if m1.dev_name != m2.dev_name && m1.mount_dir == m2.mount_dir {
-        return false;
-    }
-
-    true
+    !(m1.dev_name != m2.dev_name && m1.mount_dir == m2.mount_dir)
 }
 
 /// Whether to prioritize given mount info over all others on the same device.

--- a/src/uu/sort/src/custom_str_cmp.rs
+++ b/src/uu/sort/src/custom_str_cmp.rs
@@ -13,10 +13,7 @@ fn filter_char(c: u8, ignore_non_printing: bool, ignore_non_dictionary: bool) ->
     if ignore_non_dictionary && !(c.is_ascii_alphanumeric() || c.is_ascii_whitespace()) {
         return false;
     }
-    if ignore_non_printing && (c.is_ascii_control() || !c.is_ascii()) {
-        return false;
-    }
-    true
+    !(ignore_non_printing && (c.is_ascii_control() || !c.is_ascii()))
 }
 
 fn cmp_chars(a: u8, b: u8, ignore_case: bool) -> Ordering {


### PR DESCRIPTION
Reduce the `if cond { return false } true` pattern to `!(cond)` in df, cp and sort. No behavior change.