### PR TITLE
sync: drop unuseful comment

### DIFF
--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -3,8 +3,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-/* Last synced with: sync (GNU coreutils) 8.13 */
-
 use clap::{Arg, ArgAction, Command};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::errno::Errno;


### PR DESCRIPTION
I don't think version of GNU is useful.