### PR TITLE
df: Syncing when paths are provided

### DIFF
--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -295,15 +295,8 @@ fn is_best(previous: &[MountInfo], mi: &MountInfo) -> bool {
 
 /// Get all currently mounted filesystems.
 ///
-/// `opt` excludes certain filesystems from consideration and allows for the synchronization of filesystems before running; see
-/// [`Options`] for more information.
+/// `opt` excludes certain filesystems from consideration; see [`Options`] for more information.
 fn get_all_filesystems(opt: &Options) -> UResult<Vec<Filesystem>> {
-    // Run a sync call before any operation if so instructed.
-    if opt.sync {
-        #[cfg(not(any(windows, target_os = "redox")))]
-        rustix::fs::sync();
-    }
-
     let mut mounts = vec![];
     for mut mi in read_fs_list()? {
         // TODO The running time of the `is_best()` function is linear
@@ -450,6 +443,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let opt = Options::from(&matches).map_err(DfError::OptionsError)?;
+
+    // Run a sync call before any operation if so instructed.
+    if opt.sync {
+        #[cfg(not(any(windows, target_os = "redox")))]
+        rustix::fs::sync();
+    }
+
     // Get the list of filesystems to display in the output table.
     let filesystems: Vec<Filesystem> = match matches.get_many::<OsString>(OPT_PATHS) {
         None => {


### PR DESCRIPTION
Part of #12584, fixing `df/sync.sh`.

Decided not to use `syncfs` for when filesystems are provided (which would only sync the required filesystems), though I am very open to this being the desired implementation. It isn't clear to me why the sync call was initially left out of the case where paths are provided, but might have missed something...
