### PR TITLE
fix install same file with backup flag

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -771,6 +771,14 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
             return copy_files_into_dir(sources, &target, b);
         }
 
+        if b.backup_mode.ne(&BackupMode::None)
+            && let Ok(to_abs) = target.canonicalize()
+        {
+            if source.canonicalize()? == to_abs {
+                return Err(InstallError::SameFile(source.clone(), target.clone()).into());
+            }
+        }
+
         if target.is_file() || is_new_file_path(&target) {
             #[cfg(unix)]
             if let (Some(ref parent_fd), Some(ref filename)) = (target_parent_fd, target_filename) {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2818,3 +2818,30 @@ fn test_install_proc_self_mem_as_dst() {
         .fails()
         .stderr_contains("cannot remove");
 }
+
+#[test]
+fn test_install_backup_nil_same_file() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file = "test_install_backup_numbering_file";
+
+    at.write(file, "content");
+
+    let methods = [
+        "none", "off", "numbered", "t", "existing", "nil", "simple", "never",
+    ];
+
+    for method in &methods {
+        scene
+            .ucmd()
+            .args(&[
+                format!("--backup={method}"),
+                file.to_string(),
+                file.to_string(),
+            ])
+            .fails()
+            .stderr_contains("are the same file");
+        assert_eq!(at.read(file), "content");
+    }
+}


### PR DESCRIPTION
Fixes #12696.
In fact, whenever we use the backup flag with the same file, it need to report that the src and dst are the same file.