### PR TITLE
shred: fix error message when path has trailing slash

### DIFF
--- a/src/uu/shred/locales/en-US.ftl
+++ b/src/uu/shred/locales/en-US.ftl
@@ -42,7 +42,8 @@ shred-invalid-number-of-passes = invalid number of passes: {$passes}
 shred-cannot-open-random-source = cannot open random source: {$source}
 shred-invalid-file-size = invalid file size: {$size}
 shred-no-such-file-or-directory = {$file}: No such file or directory
-shred-failed-to-open-writing-not-dir = failed to open for writing: Not a directory
+shred-failed-to-open-for-writing-not-a-directory = {$file}: failed to open for writing: Not a directory
+shred-failed-to-open-for-writing-is-a-directory = {$file}: failed to open for writing: Is a directory
 shred-not-a-file = {$file}: Not a file
 
 # Option help text

--- a/src/uu/shred/locales/en-US.ftl
+++ b/src/uu/shred/locales/en-US.ftl
@@ -42,6 +42,7 @@ shred-invalid-number-of-passes = invalid number of passes: {$passes}
 shred-cannot-open-random-source = cannot open random source: {$source}
 shred-invalid-file-size = invalid file size: {$size}
 shred-no-such-file-or-directory = {$file}: No such file or directory
+shred-failed-to-open-writing-not-dir = failed to open for writing: Not a directory
 shred-not-a-file = {$file}: Not a file
 
 # Option help text

--- a/src/uu/shred/locales/fr-FR.ftl
+++ b/src/uu/shred/locales/fr-FR.ftl
@@ -41,7 +41,8 @@ shred-invalid-number-of-passes = nombre de passes invalide : {$passes}
 shred-cannot-open-random-source = impossible d'ouvrir la source aléatoire : {$source}
 shred-invalid-file-size = taille de fichier invalide : {$size}
 shred-no-such-file-or-directory = {$file} : Aucun fichier ou répertoire de ce type
-shred-failed-to-open-writing-not-dir = Impossible d'ouvrir le répertoire en écriture : Ce n'est pas un répertoire
+shred-failed-to-open-for-writing-not-a-directory = {$file} : impossible d'ouvrir en écriture : N'est pas un répertoire
+shred-failed-to-open-for-writing-is-a-directory = {$file} : impossible d'ouvrir en écriture : Est un répertoire
 shred-not-a-file = {$file} : N'est pas un fichier
 
 # Texte d'aide des options

--- a/src/uu/shred/locales/fr-FR.ftl
+++ b/src/uu/shred/locales/fr-FR.ftl
@@ -41,6 +41,7 @@ shred-invalid-number-of-passes = nombre de passes invalide : {$passes}
 shred-cannot-open-random-source = impossible d'ouvrir la source aléatoire : {$source}
 shred-invalid-file-size = taille de fichier invalide : {$size}
 shred-no-such-file-or-directory = {$file} : Aucun fichier ou répertoire de ce type
+shred-failed-to-open-writing-not-dir = Impossible d'ouvrir le répertoire en écriture : Ce n'est pas un répertoire
 shred-not-a-file = {$file} : N'est pas un fichier
 
 # Texte d'aide des options

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -625,12 +625,22 @@ fn wipe_file(
 ) -> UResult<()> {
     // Get these potential errors out of the way first
     let path = Path::new(path_str);
-    if !path.is_file() {
-        return Err(USimpleError::new(
-            1,
-            translate!("shred-failed-to-open-writing-not-dir"),
-        ));
+
+    if path_str.as_encoded_bytes().ends_with(b"/") {
+        if path.is_dir() {
+            return Err(USimpleError::new(
+                1,
+                translate!("shred-failed-to-open-for-writing-is-a-directory", "file" => path.maybe_quote()),
+            ));
+        }
+        if fs::metadata(path).is_err_and(|e| e.kind() == io::ErrorKind::NotADirectory) {
+            return Err(USimpleError::new(
+                1,
+                translate!("shred-failed-to-open-for-writing-not-a-directory", "file" => path.maybe_quote()),
+            ));
+        }
     }
+
     if !path.exists() {
         return Err(USimpleError::new(
             1,

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -625,6 +625,12 @@ fn wipe_file(
 ) -> UResult<()> {
     // Get these potential errors out of the way first
     let path = Path::new(path_str);
+    if !path.is_file() {
+        return Err(USimpleError::new(
+            1,
+            translate!("shred-failed-to-open-writing-not-dir"),
+        ));
+    }
     if !path.exists() {
         return Err(USimpleError::new(
             1,

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -434,3 +434,15 @@ fn test_gnu_shred_passes_different_counts() {
     result.stderr_contains("pass 1/19 (random)");
     result.stderr_contains("pass 19/19 (random)");
 }
+
+#[test]
+fn test_shred_trailing_slash_on_file() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    scene
+        .ucmd()
+        .arg("a/")
+        .fails()
+        .stderr_contains("Not a directory");
+}

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -446,3 +446,15 @@ fn test_shred_trailing_slash_on_file() {
         .fails()
         .stderr_contains("Not a directory");
 }
+
+#[test]
+fn test_shred_trailing_slash_on_dir() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("d");
+    scene
+        .ucmd()
+        .arg("d/")
+        .fails()
+        .stderr_contains("Is a directory");
+}


### PR DESCRIPTION
fix #12701 