### PR TITLE
Fix base32/base64 error for file paths ending in slash

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -62,16 +62,7 @@ impl Config {
                 if name == "-" {
                     None
                 } else {
-                    let path = Path::new(name);
-
-                    if !path.exists() {
-                        return Err(USimpleError::new(
-                            BASE_CMD_PARSE_ERROR,
-                            translate!("base-common-no-such-file", "file" => path.maybe_quote()),
-                        ));
-                    }
-
-                    Some(path.to_owned())
+                    Some(Path::new(name).to_owned())
                 }
             }
             None => None,

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -3,7 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-
+#[cfg(target_os = "linux")]
+use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
 #[test]
@@ -167,4 +168,15 @@ fn test_encode_large_input_is_buffered() {
         .pipe_in(input)
         .succeeds()
         .stdout_contains("BIFAUCQK"); // spell-checker:disable-line
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_base32_file_with_trailing_slash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("a", "b");
+
+    ucmd.arg("a/")
+        .fails()
+        .stderr_only("base32: a/: Not a directory\n");
 }

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -285,3 +285,14 @@ fn test_read_error() {
         .fails()
         .stderr_is("base64: read error: Input/output error\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_base64_file_with_trailing_slash() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("a", "b");
+
+    ucmd.arg("a/")
+        .fails()
+        .stderr_only("base64: a/: Not a directory\n");
+}


### PR DESCRIPTION
Fixes #12670

Before, `base32` and `base64` checked `Path::exists()` before opening the file. That turned the real OS error into `No such file or directory`. Now the file is opened directly, so paths like `file/` correctly report `Not a directory`.

Added regression tests for `base32` and `base64`.

No GNU coreutils source code was read or copied.