### PR TITLE
dircolors: don't panic on an invalid TERM/COLORTERM glob

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -310,7 +310,8 @@ impl StrUtils for str {
     }
 
     fn fnmatch(&self, pat: &str) -> bool {
-        parse_glob::from_str(pat).unwrap().matches(self)
+        // An invalid glob never matches (GNU ignores it); don't unwrap the Err.
+        parse_glob::from_str(pat).is_ok_and(|glob| glob.matches(self))
     }
 }
 

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -254,3 +254,12 @@ fn test_colorterm_empty_with_wildcard() {
         .succeeds()
         .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
 }
+
+#[test]
+fn test_invalid_term_glob() {
+    new_ucmd!()
+        .pipe_in("TERM [\nDIR 01;34\n")
+        .args(&["-b", "-"])
+        .succeeds()
+        .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
+}


### PR DESCRIPTION
Fixes #12727

A database file with a TERM/COLORTERM line whose value is an invalid glob (e.g. an unclosed `[`) aborted dircolors with a `Result::unwrap()` panic: `fnmatch` did `parse_glob::from_str(pat).unwrap().matches(self)`, and `from_str` returns `Err` for an unparseable pattern.

Use `is_ok_and`, so an invalid glob is treated as a non-match (the unmatched TERM section is skipped) instead of crashing — matching GNU, which emits an empty `LS_COLORS` and exits 0. Adds a regression test.
