### PR TITLE
chroot: don't panic on --skip-chdir with a non-resolving NEWROOT

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -171,8 +171,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             MissingHandling::Normal,
             ResolveMode::Logical,
         )
-        .unwrap()
-        .to_str()
+        // A NEWROOT that does not resolve is by definition not old `/`, so treat
+        // an Err as a non-match instead of unwrapping it.
+        .ok()
+        .as_deref()
+        .and_then(|p| p.to_str())
             != Some("/")
     {
         return Err(UUsageError::new(

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -290,6 +290,15 @@ fn test_chroot_skip_chdir_not_root() {
 }
 
 #[test]
+fn test_chroot_skip_chdir_nonexistent() {
+    new_ucmd!()
+        .arg("--skip-chdir")
+        .arg("/nonexistent/sub")
+        .fails_with_code(125)
+        .stderr_contains("chroot: option --skip-chdir only permitted if NEWROOT is old '/'");
+}
+
+#[test]
 fn test_chroot_skip_chdir() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;


### PR DESCRIPTION
Fixes #12731

`chroot --skip-chdir NEWROOT` aborted with a `Result::unwrap()` panic when NEWROOT did not resolve: the permitted-only-if check canonicalized NEWROOT and unwrapped the result, but `canonicalize` returns `Err` when the path (or a component) doesn't exist or isn't readable.

Map the `Err` to a non-match (`.ok().as_deref().and_then(|p| p.to_str())`) so a non-resolving NEWROOT takes the existing "only permitted if NEWROOT is old '/'" usage error (exit 125) like GNU, instead of crashing. The check runs during argument validation before any chroot syscall. Adds a regression test.
