### PR TITLE
date: fix UTC keyword with relative seconds across DST (#12555)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "97bf4965940c2382204c0ded6dd3dd48c0c4e872f1e76fb1bf94f45991a2cb6a"
 dependencies = [
  "clap",
 ]
@@ -465,7 +465,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1016,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2251,13 +2251,11 @@ dependencies = [
 
 [[package]]
 name = "parse_datetime"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413775a7eac2261d2211a79d10ef275e5b6f7b527eec42ad09adce2ffa92b6e5"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "num-traits",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -2684,7 +2682,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2917,7 +2915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3002,7 +3000,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3012,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3137,7 +3135,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -3146,7 +3144,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -4768,7 +4766,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4991,15 +4989,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,7 +450,7 @@ num-bigint = "0.4.4"
 num-prime = "0.5.0"
 num-traits = "0.2.19"
 onig = { version = "~6.5.1", default-features = false }
-parse_datetime = "0.14.0"
+parse_datetime = "0.15.0"
 phf = "0.14.0"
 phf_codegen = "0.14.0"
 platform-info = "2.0.3"
@@ -783,3 +783,6 @@ debug = true
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+parse_datetime = { path = "../parse_datetime" }

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -879,7 +879,9 @@ fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S, now: &Zoned) -> Optio
     }
 
     // Parse in the target timezone so "10:30 EDT" means 10:30 in EDT.
-    let parsed = parse_datetime::parse_datetime_at_date(now.clone(), date_part).ok()?;
+    let parsed = parse_datetime::parse_datetime_at_date(now.clone(), date_part)
+        .ok()
+        .and_then(|p| p.into_zoned())?;
     let zoned = parsed.datetime().to_zoned(tz).ok()?;
 
     // The trailing abbreviation only describes the *input* timezone. For display,
@@ -947,9 +949,17 @@ fn parse_date<S: AsRef<str> + Clone>(
     }
 
     match parse_datetime::parse_datetime_at_date(now.clone(), input_str) {
-        // Convert to system timezone for display
-        // (parse_datetime 0.13 returns Zoned in the input's timezone)
-        Ok(date) => {
+        // Convert to system timezone for display.
+        // parse_datetime returns the value in the input's timezone; the
+        // `Extended` variant covers years outside jiff's range, which `date`
+        // cannot represent, so treat it as an invalid input.
+        Ok(parsed) => {
+            let Some(date) = parsed.into_zoned() else {
+                return Err((
+                    input_str.into(),
+                    parse_datetime::ParseDateTimeError::InvalidInput,
+                ));
+            };
             let result = date.timestamp().to_zoned(now.time_zone().clone());
             if dbg_opts.debug {
                 // Show final parsed date and time

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -797,7 +797,10 @@ fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
         }
     }
 
-    if let Ok(zoned) = parse_datetime::parse_datetime_at_date(ref_zoned, s) {
+    if let Some(zoned) = parse_datetime::parse_datetime_at_date(ref_zoned, s)
+        .ok()
+        .and_then(|parsed| parsed.into_zoned())
+    {
         return Ok(timestamp_to_filetime(zoned.timestamp()));
     }
 

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -317,6 +317,21 @@ fn test_date_utc_vs_local() {
 }
 
 #[test]
+fn test_date_utc_keyword_plus_relative_seconds_across_dst() {
+    // Regression test for #12555. The "UTC" keyword fixes the offset and must
+    // anchor the instant before the relative "N seconds" is applied. In a
+    // DST-observing zone, the epoch base is in winter (CET, +1) while the result
+    // lands in summer (CEST, +2); a naive implementation drifts by one hour.
+    // "1970-01-01 UTC + N seconds" must always be exactly N seconds past the epoch.
+    let seconds = 1_780_318_971; // lands in summer 2026
+    new_ucmd!()
+        .env("TZ", "Europe/Berlin")
+        .args(&["-d", &format!("1970/01/01 UTC {seconds} seconds"), "+%s"])
+        .succeeds()
+        .stdout_only(format!("{seconds}\n"));
+}
+
+#[test]
 fn test_date_utc_output_formats() {
     let cases = [
         ("-I", "2024-06-15"),


### PR DESCRIPTION
Bump parse_datetime to 0.15 (which anchors a fixed offset before relative items) and migrate date/touch to its ParsedDateTime API. Add a regression test asserting that "1970/01/01 UTC N seconds" is exactly N seconds past the epoch in a DST-observing zone.

just WIP
needs a new release of parse_datetime