### PR TITLE
fold: reject a zero width instead of looping forever

### DIFF
--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -64,12 +64,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let width = match poss_width {
-        Some(inp_width) => inp_width.parse::<usize>().map_err(|e| {
-            USimpleError::new(
-                1,
-                translate!("fold-error-illegal-width", "width" => inp_width.quote(), "error" => e),
-            )
-        })?,
+        Some(inp_width) => {
+            let width = inp_width.parse::<usize>().map_err(|e| {
+                USimpleError::new(
+                    1,
+                    translate!("fold-error-illegal-width", "width" => inp_width.quote(), "error" => e),
+                )
+            })?;
+            // A zero width is rejected like any other illegal width; otherwise the
+            // fold loop never makes progress and emits empty lines forever.
+            if width == 0 {
+                return Err(USimpleError::new(1, translate!("fold-error-illegal-width")));
+            }
+            width
+        }
         None => 80,
     };
 

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -16,6 +16,24 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_zero_width_is_rejected() {
+    for arg in ["-w0", "-0"] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("hello\n")
+            .fails_with_code(1)
+            .stderr_only("fold: illegal width value\n");
+    }
+    for mode in ["-c", "-b"] {
+        new_ucmd!()
+            .args(&[mode, "-w0"])
+            .pipe_in("hello\n")
+            .fails_with_code(1)
+            .stderr_only("fold: illegal width value\n");
+    }
+}
+
+#[test]
 fn test_default_80_column_wrap() {
     new_ucmd!()
         .arg("lorem_ipsum.txt")


### PR DESCRIPTION
Fixes #12759

`fold -w0` (and the obsolete `-0`, plus `-c -w0` / `-b -w0`) previously accepted a
column width of 0 and then looped forever emitting empty lines — the fold loop can
never make progress with a zero column budget, so it streamed newlines indefinitely
(a denial-of-service hang).

This rejects a zero width as an illegal width, matching GNU `fold`, which exits 1:

    $ fold -w0
    fold: illegal width value

uutils keeps its existing `illegal width value` wording (already used for other bad
widths such as `-wabc`); GNU's text is `invalid number of columns: '0'`, but both
exit 1.

Added a regression test covering `-w0`, `-0`, and the `-c`/`-b` modes.
