### PR TITLE
pr: reject a multibyte -e/-n argument instead of panicking

### DIFF
--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -102,3 +102,4 @@ pr-error-column-merge-conflict = cannot specify number of columns when printing 
 pr-error-across-merge-conflict = cannot specify both printing across and printing in parallel
 pr-error-invalid-pages-range = invalid --pages argument '{$start}:{$end}'
 pr-error-invalid-expand-tab-argument ='-e' extra characters or invalid number in the argument: ‘{$arg}’
+pr-error-invalid-number-argument ='-n' extra characters or invalid number in the argument: ‘{$arg}’

--- a/src/uu/pr/locales/fr-FR.ftl
+++ b/src/uu/pr/locales/fr-FR.ftl
@@ -101,3 +101,4 @@ pr-error-column-merge-conflict = impossible de spécifier le nombre de colonnes 
 pr-error-across-merge-conflict = impossible de spécifier à la fois l'impression transversale et l'impression en parallèle
 pr-error-invalid-pages-range = argument --pages invalide '{$start}:{$end}'
 pr-error-invalid-expand-tab-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-e': '{$arg}'
+pr-error-invalid-number-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-n': '{$arg}'

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -550,27 +550,41 @@ fn build_options(
     let number = matches
         .get_one::<String>(options::NUMBER_LINES)
         .map(|i| {
+            let invalid = |arg: &str| PrError::EncounteredErrors {
+                msg: format!(
+                    "{}\n{}",
+                    translate!("pr-error-invalid-number-argument", "arg" => arg),
+                    translate!("pr-try-help-message")
+                ),
+            };
+
             let parse_result = i.parse::<usize>();
 
             let separator = if parse_result.is_err() {
-                i[0..1].to_string()
+                match i.chars().next() {
+                    Some(c) if c.is_ascii() => c.to_string(),
+                    Some(_) | None => return Err(invalid(i)),
+                }
             } else {
                 NumberingMode::default().separator
             };
 
             let width = match parse_result {
                 Ok(res) => res,
-                Err(_) => i[1..]
+                Err(_) => i
+                    .get(1..)
+                    .unwrap_or_default()
                     .parse::<usize>()
                     .unwrap_or(NumberingMode::default().width),
             };
 
-            NumberingMode {
+            Ok(NumberingMode {
                 width,
                 separator,
                 first_number,
-            }
+            })
         })
+        .transpose()?
         .or_else(|| {
             if matches.contains_id(options::NUMBER_LINES) {
                 Some(NumberingMode::default())
@@ -601,6 +615,8 @@ fn build_options(
                             input_char: TAB,
                             width,
                         })
+                    } else if !c.is_ascii() {
+                        Err(invalid(s))
                     } else if s.len() > 1 {
                         let width: i32 = s[1..].parse().map_err(|_e| invalid(&s[1..]))?;
                         if width <= 0 {

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -54,6 +54,34 @@ fn test_invalid_flag() {
 }
 
 #[test]
+fn test_expand_tabs_multibyte_char_is_rejected() {
+    for arg in ["-e€", "-e€3"] {
+        new_ucmd!()
+            .args(&[arg, "test_one_page.log"])
+            .fails_with_code(1)
+            .stderr_contains("pr: '-e' extra characters or invalid number in the argument");
+    }
+}
+
+#[test]
+fn test_number_lines_multibyte_separator_is_rejected() {
+    for arg in ["-n€", "-n€5"] {
+        new_ucmd!()
+            .args(&[arg, "test_one_page.log"])
+            .fails_with_code(1)
+            .stderr_contains("pr: '-n' extra characters or invalid number in the argument");
+    }
+}
+
+#[test]
+fn test_number_lines_empty_value_is_rejected() {
+    new_ucmd!()
+        .args(&["--number-lines=", "test_one_page.log"])
+        .fails_with_code(1)
+        .stderr_contains("pr: '-n' extra characters or invalid number in the argument");
+}
+
+#[test]
 fn test_without_any_options() {
     let test_file_path = "test_one_page.log";
     let expected_test_file_path = "test_one_page.log.expected";


### PR DESCRIPTION
Fixes #12761

`pr -e<CHAR>` and `pr -n<CHAR>` (and an empty `--number-lines=`) byte-sliced the option argument at index 1 to split the leading character from the trailing width. A multibyte leading character (e.g. `€`) made that index land inside the code point, and an empty value sliced out of bounds — both aborted:

```console
$ printf 'a\tb\n' | pr -e€
thread 'main' panicked at src/uu/pr/src/pr.rs:605:43:
byte index 1 is not a char boundary; it is inside '€' (bytes 0..3) of `€`

$ printf 'a\n' | pr -n€
thread 'main' panicked at src/uu/pr/src/pr.rs:556:18:
byte index 1 is not a char boundary; it is inside '€' (bytes 0..3) of `€`

$ printf 'a\n' | pr --number-lines=
thread 'main' panicked at src/uu/pr/src/pr.rs:556:18:
byte index 1 is out of bounds of ``
```

This splits on the first *character* instead, and rejects a non-ASCII or empty expand/separator argument with an error (exit 1), matching GNU:

```console
$ printf 'a\n' | pr -n€ ; echo $?
pr: '-n' extra characters or invalid number in the argument: ‘€’
Try 'pr --help' for more information.
1
```

ASCII forms (`-e@3`, `-ex`, `-n@3`, `-nx5`, …) and the bare `-n` flag are unchanged. Added a `pr-error-invalid-number-argument` locale string (en-US + fr-FR) and regression tests for the `-e`/`-n` multibyte and empty-value cases.
