### PR TITLE
du: do not panic on a non-UTF-8 name in the --exclude check

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -653,7 +653,7 @@ fn du_regular(
                                 // if we have 'du foo' but search to exclude 'foo/bar'
                                 // we need the full path
                                 if pattern.matches(&this_stat.path.to_string_lossy())
-                                    || pattern.matches(&entry.file_name().into_string().unwrap())
+                                    || pattern.matches(&entry.file_name().to_string_lossy())
                                 {
                                     // if the directory is ignored, leave early
                                     if options.verbose {

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1365,6 +1365,23 @@ fn test_du_exclude() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_du_exclude_non_utf8_name() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.mkdir("d");
+    let mut name = std::ffi::OsString::from("d/");
+    name.push(OsStr::from_bytes(&[0xff, 0xfe]));
+    at.mkdir(name);
+
+    ts.ucmd().args(&["-L", "--exclude=zzz", "d"]).succeeds();
+}
+
+#[test]
 // Disable on Windows because we are looking for /
 // And the tests would be more complex if we have to support \ too
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Fixes #12769

`du`'s regular (non-safe) traversal — used whenever `-L`/`--dereference` is given, and always on non-Linux — matched `--exclude` patterns against `entry.file_name().into_string().unwrap()`. `OsString::into_string()` returns `Err` for any non-UTF-8 entry name, so the `.unwrap()` aborted the process:

```console
$ mkdir -p duex/sub
$ python3 -c "import os; os.mkdir(b'duex/sub/\xff\xfedir')"
$ du -L --exclude='zzz' duex
thread 'main' panicked at src/uu/du/src/du.rs:656:89:
called `Result::unwrap()` on an `Err` value: "\xFF\xFEdir"
$ echo $?
134
```

GNU lists the directory and exits 0. This uses `to_string_lossy()` instead — matching the sibling `this_stat.path.to_string_lossy()` already on the line above (and the identical exclude check in the safe traversal) — so a non-UTF-8 name is handled gracefully:

```console
$ du -L --exclude='zzz' duex ; echo $?
...
0
```

Added a Unix-gated regression test (`test_du_exclude_non_utf8_name`).
