### PR TITLE
sort: use os_string_from_vec for --files0-from names

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -39,8 +39,6 @@ use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write, stdin, stdout};
 use std::num::IntErrorKind;
 use std::ops::Range;
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::Utf8Error;
@@ -2027,7 +2025,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 path: files0_from.clone(),
                 error,
             })?;
-
+            if line.as_slice() == STDIN_FILE.as_bytes() {
+                return Err(SortError::MinusInStdIn.into());
+            }
             if line.is_empty() {
                 return Err(SortError::ZeroLengthFileName {
                     file: files0_from,
@@ -2035,26 +2035,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 }
                 .into());
             }
-
-            let f: OsString = {
-                #[cfg(unix)]
-                {
-                    OsStr::from_bytes(&line).to_os_string()
-                }
-                #[cfg(not(unix))]
-                {
-                    OsString::from(String::from_utf8_lossy(&line).into_owned())
-                }
-            };
-
-            match f.to_str() {
-                Some(s) if s == STDIN_FILE => {
-                    return Err(SortError::MinusInStdIn.into());
-                }
-                _ => {}
-            }
-
-            files.push(f);
+            files.push(uucore::os_string_from_vec(line)?);
         }
 
         if files.is_empty() {

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1801,6 +1801,16 @@ fn test_files0_from_empty() {
 
 #[test]
 #[cfg(unix)]
+fn test_files0_from_non_utf8_name() {
+    new_ucmd!()
+        .args(&["--files0-from", "-"])
+        .pipe_in(vec![0xff_u8])
+        .fails_with_code(2)
+        .stderr_contains("sort: cannot read");
+}
+
+#[test]
+#[cfg(unix)]
 fn test_files0_read_error() {
     new_ucmd!()
         .args(&["--files0-from", "."])


### PR DESCRIPTION
Follow-up to #11593.

#11593 fixed the `--files0-from` non-UTF-8 panic by decoding the raw bytes inline (`#[cfg(unix)] OsStr::from_bytes` / `#[cfg(not(unix))] from_utf8_lossy`). This replaces that inline reimplementation with the shared `uucore::os_string_from_vec` helper, so the byte→`OsString` conversion has a single source of truth rather than duplicated (and already slightly diverging) logic. The `-`/empty-name checks now run on the raw bytes.

Behavior is unchanged on Unix (both are lossless); the Unix-gated regression test (a non-UTF-8 name → `cannot read`, exit 2) still passes.
