### PR TITLE
wc: don't 0-fill buffer with -c

### DIFF
--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 bytecount = { workspace = true, features = ["runtime-dispatch-simd"] }
 clap = { workspace = true }
 fluent = { workspace = true }
+rustix = { workspace = true, features = ["fs"] }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = [
   "hardware",
@@ -34,7 +35,6 @@ unicode-width = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
-rustix = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/wc/src/count_fast.rs
+++ b/src/uu/wc/src/count_fast.rs
@@ -155,9 +155,19 @@ pub(crate) fn count_bytes_fast<T: WordCountable>(handle: &mut T) -> (usize, Opti
 
     // Fall back on `read`, but without the overhead of counting words and lines.
 
-    let mut buf = [0_u8; BUF_SIZE];
+    #[cfg(any(unix, target_os = "wasi"))]
+    let mut buf = [std::mem::MaybeUninit::<u8>::uninit(); BUF_SIZE];
+    // todo: avoid cost by 0-fill
+    #[cfg(not(any(unix, target_os = "wasi")))]
+    let mut buf = [0u8; BUF_SIZE];
     loop {
-        match handle.read(&mut buf) {
+        #[cfg(any(unix, target_os = "wasi"))]
+        let res = rustix::io::read(&handle, &mut buf)
+            .map(|f| f.0.len())
+            .map_err(io::Error::from);
+        #[cfg(not(any(unix, target_os = "wasi")))]
+        let res = handle.read(&mut buf);
+        match res {
             Ok(0) => return (byte_count, None),
             Ok(n) => byte_count += n,
             Err(e) if e.kind() == ErrorKind::Interrupted => (),

--- a/src/uu/wc/src/countable.rs
+++ b/src/uu/wc/src/countable.rs
@@ -10,30 +10,24 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, StdinLock};
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 use std::os::fd::{AsFd, AsRawFd};
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 pub trait WordCountable: AsFd + AsRawFd + Read {
     type Buffered: BufRead;
     fn buffered(self) -> Self::Buffered;
+    #[cfg(not(target_os = "wasi"))]
     fn inner_file(&mut self) -> Option<&mut File>;
 }
 
-#[cfg(all(not(unix), not(target_os = "wasi")))]
+#[cfg(not(any(unix, target_os = "wasi")))]
 pub trait WordCountable: Read {
     type Buffered: BufRead;
     fn buffered(self) -> Self::Buffered;
     fn inner_file(&mut self) -> Option<&mut File>;
 }
 
-#[cfg(target_os = "wasi")]
-pub trait WordCountable: Read {
-    type Buffered: BufRead;
-    fn buffered(self) -> Self::Buffered;
-}
-
-#[cfg(not(target_os = "wasi"))]
 impl WordCountable for StdinLock<'_> {
     type Buffered = Self;
 
@@ -45,16 +39,6 @@ impl WordCountable for StdinLock<'_> {
     }
 }
 
-#[cfg(target_os = "wasi")]
-impl WordCountable for StdinLock<'_> {
-    type Buffered = Self;
-
-    fn buffered(self) -> Self::Buffered {
-        self
-    }
-}
-
-#[cfg(not(target_os = "wasi"))]
 impl WordCountable for File {
     type Buffered = BufReader<Self>;
 
@@ -64,14 +48,5 @@ impl WordCountable for File {
 
     fn inner_file(&mut self) -> Option<&mut File> {
         Some(self)
-    }
-}
-
-#[cfg(target_os = "wasi")]
-impl WordCountable for File {
-    type Buffered = BufReader<Self>;
-
-    fn buffered(self) -> Self::Buffered {
-        BufReader::new(self)
     }
 }


### PR DESCRIPTION
`wc -c` is mostly done by metadata. But buf exists on the same call stack and 0-filled...