### PR TITLE
shred: two refactorings

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -596,20 +596,6 @@ fn create_standard_pass_sequence(num_passes: usize) -> Vec<PassType> {
     sequence
 }
 
-/// Create compatible pass sequence using the standard algorithm
-fn create_compatible_sequence(
-    num_passes: usize,
-    random_source: Option<&RefCell<File>>,
-) -> UResult<Vec<PassType>> {
-    if random_source.is_some() {
-        // For deterministic behavior with random source file, use hardcoded sequence
-        create_test_compatible_sequence(num_passes, random_source)
-    } else {
-        // For system random, use standard algorithm
-        Ok(create_standard_pass_sequence(num_passes))
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::cognitive_complexity)]
 fn wipe_file(
@@ -690,7 +676,7 @@ fn wipe_file(
         } else {
             // Use compatible sequence when using deterministic random source
             if random_source.is_some() {
-                pass_sequence = create_compatible_sequence(n_passes, random_source)?;
+                pass_sequence = create_test_compatible_sequence(n_passes, random_source)?;
             } else {
                 pass_sequence = create_standard_pass_sequence(n_passes);
             }

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -498,7 +498,7 @@ fn generate_patterns_with_middle_randoms(
 /// Create test-compatible pass sequence using deterministic seeding
 fn create_test_compatible_sequence(
     num_passes: usize,
-    random_source: Option<&RefCell<File>>,
+    random_source: &RefCell<File>,
 ) -> UResult<Vec<PassType>> {
     if num_passes == 0 {
         return Ok(Vec::new());
@@ -506,42 +506,40 @@ fn create_test_compatible_sequence(
 
     // For the specific test case with 'U'-filled random source,
     // return the exact expected sequence based on standard seeding algorithm
-    if let Some(file_cell) = random_source {
-        // Check if this is the 'U'-filled random source used by test compatibility
-        file_cell
-            .borrow_mut()
-            .seek(SeekFrom::Start(0))
-            .map_err_context(|| translate!("shred-failed-to-seek-file"))?;
-        let mut buffer = [0u8; 1024];
-        if let Ok(bytes_read) = file_cell.borrow_mut().read(&mut buffer) {
-            if bytes_read > 0 && buffer[..bytes_read].iter().all(|&b| b == 0x55) {
-                // This is the test scenario - replicate exact algorithm
-                let test_patterns = vec![
-                    0xFFF, 0x924, 0x888, 0xDB6, 0x777, 0x492, 0xBBB, 0x555, 0xAAA, 0x6DB, 0x249,
-                    0x999, 0x111, 0x000, 0xB6D, 0xEEE, 0x333,
-                ];
+    // Check if this is the 'U'-filled random source used by test compatibility
+    random_source
+        .borrow_mut()
+        .seek(SeekFrom::Start(0))
+        .map_err_context(|| translate!("shred-failed-to-seek-file"))?;
+    let mut buffer = [0u8; 1024];
+    if let Ok(bytes_read) = random_source.borrow_mut().read(&mut buffer) {
+        if bytes_read > 0 && buffer[..bytes_read].iter().all(|&b| b == 0x55) {
+            // This is the test scenario - replicate exact algorithm
+            let test_patterns = vec![
+                0xFFF, 0x924, 0x888, 0xDB6, 0x777, 0x492, 0xBBB, 0x555, 0xAAA, 0x6DB, 0x249, 0x999,
+                0x111, 0x000, 0xB6D, 0xEEE, 0x333,
+            ];
 
-                if num_passes >= 3 {
-                    let mut sequence = Vec::new();
-                    let n_random = (num_passes / 10).max(3);
-                    let n_pattern = num_passes - n_random;
+            if num_passes >= 3 {
+                let mut sequence = Vec::new();
+                let n_random = (num_passes / 10).max(3);
+                let n_pattern = num_passes - n_random;
 
-                    // Standard algorithm: first random, patterns with middle random(s), final random
-                    sequence.push(PassType::Random);
+                // Standard algorithm: first random, patterns with middle random(s), final random
+                sequence.push(PassType::Random);
 
-                    let middle_randoms = n_random - 2;
-                    let mut pattern_sequence = generate_patterns_with_middle_randoms(
-                        &test_patterns,
-                        n_pattern,
-                        middle_randoms,
-                        num_passes,
-                    );
-                    sequence.append(&mut pattern_sequence);
+                let middle_randoms = n_random - 2;
+                let mut pattern_sequence = generate_patterns_with_middle_randoms(
+                    &test_patterns,
+                    n_pattern,
+                    middle_randoms,
+                    num_passes,
+                );
+                sequence.append(&mut pattern_sequence);
 
-                    sequence.push(PassType::Random);
+                sequence.push(PassType::Random);
 
-                    return Ok(sequence);
-                }
+                return Ok(sequence);
             }
         }
     }
@@ -675,8 +673,8 @@ fn wipe_file(
             }
         } else {
             // Use compatible sequence when using deterministic random source
-            if random_source.is_some() {
-                pass_sequence = create_test_compatible_sequence(n_passes, random_source)?;
+            if let Some(src) = random_source {
+                pass_sequence = create_test_compatible_sequence(n_passes, src)?;
             } else {
                 pass_sequence = create_standard_pass_sequence(n_passes);
             }


### PR DESCRIPTION
This PR applies two refactorings:
* it removes `create_compatible_sequence` which simply delegates to `create_test_compatible_sequence` and calls this function instead
* it changes the type of the `random_source` param of `create_test_compatible_sequence` from `Option<&RefCell<File>>` to `&RefCell<File>` as the function is never called with `None`