### PR TITLE
fix(head): avoid overflow panic on huge negative -n/-c values

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -329,7 +329,7 @@ where
 
         for separator_offset in memrchr_iter(separator, &buffer[..]) {
             lines += 1;
-            if lines == n + 1 {
+            if lines > n {
                 input.rewind()?;
                 return Ok(read_start_offset
                     + TryInto::<u64>::try_into(separator_offset).unwrap()

--- a/src/uu/head/src/take.rs
+++ b/src/uu/head/src/take.rs
@@ -104,7 +104,10 @@ pub fn copy_all_but_n_bytes(
         loop {
             // Try to buffer at least enough to write the entire first buffer.
             let front_buffer = buffers.front();
-            if front_buffer.is_some_and(|b| buffered_bytes >= n + b.remaining_bytes()) {
+            if front_buffer.is_some_and(|b| {
+                n.checked_add(b.remaining_bytes())
+                    .is_some_and(|needed| buffered_bytes >= needed)
+            }) {
                 break;
             }
             let mut new_buffer = empty_buffer_pool.pop().unwrap_or_else(TakeAllBuffer::new);
@@ -263,7 +266,10 @@ pub fn copy_all_but_n_lines<R: Read, W: Write>(
             // First check if we have enough lines buffered that we can write out the entire
             // front buffer. If so, break.
             let front_buffer = buffers.front();
-            if front_buffer.is_some_and(|b| buffered_terminated_lines > n + b.terminated_lines()) {
+            if front_buffer.is_some_and(|b| {
+                n.checked_add(b.terminated_lines())
+                    .is_some_and(|needed| buffered_terminated_lines > needed)
+            }) {
                 break;
             }
             // Else we need to try to buffer more data...

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -872,6 +872,24 @@ fn test_value_too_large() {
 }
 
 #[test]
+fn test_all_but_last_lines_huge_count_does_not_panic() {
+    // https://github.com/uutils/coreutils/issues/12836
+    new_ucmd!()
+        .args(&["-n=-116265256266241262252526", "lorem_ipsum.txt"])
+        .succeeds()
+        .no_stdout();
+}
+
+#[test]
+fn test_all_but_last_bytes_huge_count_does_not_panic() {
+    // https://github.com/uutils/coreutils/issues/12837
+    new_ucmd!()
+        .args(&["-c=-116265256266241262252526", "lorem_ipsum.txt"])
+        .succeeds()
+        .no_stdout();
+}
+
+#[test]
 fn test_all_but_last_lines() {
     new_ucmd!()
         .args(&["-n", "-15", "lorem_ipsum.txt"])


### PR DESCRIPTION
### What does this PR do?

Fixes two integer overflow panics in `head` when given an extremely large negative value for `-n`/`--lines` or `-c`/`--bytes` (the "all but last N lines/bytes" mode).

- `copy_all_but_n_bytes` and `copy_all_but_n_lines` in `src/uu/head/src/take.rs` computed `n + b.remaining_bytes()` / `n + b.terminated_lines()`, which panics with `attempt to add with overflow` in debug builds when `n` is close to `usize::MAX`.
- `find_nth_line_from_end` in `src/uu/head/src/head.rs` computed `n + 1`, which has the same issue when `n == u64::MAX`.

These values arise because `parse_signed_num_max` intentionally clamps out-of-range numeric input to `u64::MAX`/`usize::MAX` (see existing `test_overflow_max`), so a user passing e.g. `-n=-116265256266241262252526` ends up with `n` at the clamped maximum.

### Fix

- Replaced `n + b.remaining_bytes()` / `n + b.terminated_lines()` with `n.checked_add(...)` and only break the buffering loop if the addition doesn't overflow (i.e. there's genuinely more buffered than needed).
- Replaced `lines == n + 1` with the equivalent overflow-safe `lines > n`.

In both cases, when `n` is at/near `u64::MAX`/`usize::MAX`, the correct behavior is "N exceeds the total lines/bytes in the file", so `head` now exits 0 with no output instead of panicking — consistent with how smaller out-of-range values are already handled.

### Tests

Added regression tests in `tests/by-util/test_head.rs`:
- `test_all_but_last_lines_huge_count_does_not_panic` (#12836)
- `test_all_but_last_bytes_huge_count_does_not_panic` (#12837)

Verified:
- `cargo test --features head --no-default-features --test tests test_head::` — 49/49 pass
- `cargo test -p uu_head --lib` — 23/23 pass
- `cargo fmt -- --check` and `cargo clippy -p uu_head --all-targets` clean

Fixes #12836
Fixes #12837