### PR TITLE
Bump `time` & adapt `pinky` and `who` to API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,9 +857,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "diff"
@@ -2031,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2984,12 +2981,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -3001,15 +2997,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/uu/pinky/src/platform/unix.rs
+++ b/src/uu/pinky/src/platform/unix.rs
@@ -136,6 +136,8 @@ fn idle_string(when: i64) -> String {
 }
 
 fn time_string(ut: &UtmpxRecord) -> String {
+    const FORMAT_DESCRIPTION_VERSION: usize = 2;
+
     let time_format: Vec<time::format_description::FormatItem> = if ["LC_ALL", "LC_TIME", "LANG"]
         .into_iter()
         .find_map(std::env::var_os)
@@ -143,11 +145,16 @@ fn time_string(ut: &UtmpxRecord) -> String {
         == Some(std::ffi::OsStr::new("C"))
     {
         // "%b %e %H:%M"
-        time::format_description::parse("[month repr:short] [day padding:space] [hour]:[minute]")
-            .unwrap()
+        time::format_description::parse_borrowed::<FORMAT_DESCRIPTION_VERSION>(
+            "[month repr:short] [day padding:space] [hour]:[minute]",
+        )
+        .unwrap()
     } else {
         // "%Y-%m-%d %H:%M"
-        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]").unwrap()
+        time::format_description::parse_borrowed::<FORMAT_DESCRIPTION_VERSION>(
+            "[year]-[month]-[day] [hour]:[minute]",
+        )
+        .unwrap()
     };
     ut.login_time().format(&time_format).unwrap()
 }

--- a/src/uu/who/src/platform/unix.rs
+++ b/src/uu/who/src/platform/unix.rs
@@ -162,6 +162,8 @@ fn idle_string<'a>(when: i64, boottime: i64) -> Cow<'a, str> {
 }
 
 fn time_string(ut: &UtmpxRecord) -> String {
+    const FORMAT_DESCRIPTION_VERSION: usize = 2;
+
     let time_format: Vec<time::format_description::FormatItem> = if ["LC_ALL", "LC_TIME", "LANG"]
         .into_iter()
         .find_map(std::env::var_os)
@@ -169,11 +171,16 @@ fn time_string(ut: &UtmpxRecord) -> String {
         == Some(std::ffi::OsStr::new("C"))
     {
         // "%b %e %H:%M"
-        time::format_description::parse("[month repr:short] [day padding:space] [hour]:[minute]")
-            .unwrap()
+        time::format_description::parse_borrowed::<FORMAT_DESCRIPTION_VERSION>(
+            "[month repr:short] [day padding:space] [hour]:[minute]",
+        )
+        .unwrap()
     } else {
         // "%Y-%m-%d %H:%M"
-        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]").unwrap()
+        time::format_description::parse_borrowed::<FORMAT_DESCRIPTION_VERSION>(
+            "[year]-[month]-[day] [hour]:[minute]",
+        )
+        .unwrap()
     };
     ut.login_time().format(&time_format).unwrap()
 }


### PR DESCRIPTION
This PR bumps `time` from `0.3.47` to `0.3.49` and it adapts `pinky` and `who` to use `parse_borrowed()` instead of the deprecated `parse()`.

Closes https://github.com/uutils/coreutils/pull/12803