### PR TITLE
test: compare integers with arbitrary precision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,6 +4253,7 @@ dependencies = [
  "clap",
  "fluent",
  "libc",
+ "num-bigint",
  "tempfile",
  "thiserror 2.0.18",
  "uucore",

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 clap = { workspace = true }
 fluent = { workspace = true }
 libc = { workspace = true }
+num-bigint = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["process"] }
 

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -10,6 +10,7 @@ mod parser;
 
 use clap::Command;
 use error::{ParseError, ParseResult};
+use num_bigint::BigInt;
 use parser::{Operator, Symbol, UnaryOperator, parse};
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -175,14 +176,16 @@ fn eval(stack: &mut Vec<Symbol>) -> ParseResult<bool> {
 /// `b` is the left hand side
 /// `op` the operation (ex: -eq, -lt, etc)
 fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
-    // Parse the two inputs
-    let a: i128 = a
+    // Parse the two inputs. GNU `test` compares integers with arbitrary
+    // precision, so use `BigInt` instead of a fixed-width type to avoid
+    // rejecting values that do not fit in 128 bits.
+    let a: BigInt = a
         .to_str()
         .map(str::trim)
         .and_then(|s| s.parse().ok())
         .ok_or_else(|| ParseError::InvalidInteger(a.quote().to_string()))?;
 
-    let b: i128 = b
+    let b: BigInt = b
         .to_str()
         .map(str::trim)
         .and_then(|s| s.parse().ok())
@@ -443,5 +446,21 @@ mod tests {
         let a = OsStr::new("42");
         let b = OsStr::new("42");
         assert!(!integers(a, b, OsStr::new("-ne")).unwrap());
+    }
+
+    #[test]
+    fn test_integer_op_arbitrary_precision() {
+        // GNU `test` accepts integers that do not fit in 128 bits.
+        let huge =
+            OsStr::new("16267277278126277227728782172782882627278282882172762677623672762783782");
+        assert!(integers(huge, huge, OsStr::new("-eq")).unwrap());
+        assert!(!integers(OsStr::new("1"), huge, OsStr::new("-eq")).unwrap());
+        assert!(integers(OsStr::new("1"), huge, OsStr::new("-lt")).unwrap());
+        assert!(integers(huge, OsStr::new("1"), OsStr::new("-gt")).unwrap());
+
+        let huge_neg =
+            OsStr::new("-16267277278126277227728782172782882627278282882172762677623672762783782");
+        assert!(integers(huge_neg, huge, OsStr::new("-lt")).unwrap());
+        assert!(integers(huge_neg, huge_neg, OsStr::new("-eq")).unwrap());
     }
 }

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -255,11 +255,21 @@ fn test_some_int_compares() {
 }
 
 #[test]
-#[ignore = "fixme: evaluation error (code 1); GNU returns 0"]
 fn test_values_greater_than_i64_allowed() {
     new_ucmd!()
         .args(&["9223372036854775808", "-gt", "0"])
         .succeeds();
+}
+
+#[test]
+fn test_arbitrary_precision_integers() {
+    // GNU `test` compares integers with arbitrary precision, accepting values
+    // that do not fit in 128 bits.
+    let huge = "16267277278126277227728782172782882627278282882172762677623672762783782";
+    new_ucmd!().args(&[huge, "-eq", huge]).succeeds();
+    new_ucmd!().args(&["1", "-eq", huge]).fails_with_code(1);
+    new_ucmd!().args(&["1", "-lt", huge]).succeeds();
+    new_ucmd!().args(&[huge, "-gt", "1"]).succeeds();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #12874.

GNU `test` compares integers of any magnitude, but uutils parsed the operands of
the integer relational operators into `i128` and rejected anything larger:

```console
$ test 1 -eq 16267277278126277227728782172782882627278282882172762677623672762783782
test: invalid integer '16267277278126277227728782172782882627278282882172762677623672762783782'
$ # GNU prints nothing and exits 1
```

## Change

- Parse the operands of `-eq`/`-ne`/`-lt`/`-le`/`-gt`/`-ge` as
  `num_bigint::BigInt` instead of `i128`. `num-bigint` is already a workspace
  dependency (used by `expr`), and the existing trimming / sign handling is
  preserved — only the artificial 128-bit range limit is removed.
- The previously `#[ignore]`d `test_values_greater_than_i64_allowed` now passes,
  so the attribute is dropped.
- Add `test_arbitrary_precision_integers` (CLI) and
  `test_integer_op_arbitrary_precision` (unit) covering values beyond 128 bits,
  including negatives.

```console
$ test 16267277278126277227728782172782882627278282882172762677623672762783782 \
       -eq 16267277278126277227728782172782882627278282882172762677623672762783782
$ echo $?
0
```

## Checks

- `cargo test -p uu_test --lib` and the `test_test` integration tests pass
- `cargo fmt` clean, `cargo clippy -p uu_test --all-targets` clean