### PR TITLE
od: don't abort on a huge --width

### DIFF
--- a/src/uu/od/src/input_decoder.rs
+++ b/src/uu/od/src/input_decoder.rs
@@ -44,17 +44,26 @@ impl<I> InputDecoder<'_, I> {
         normal_length: usize,
         peek_length: usize,
         byte_order: ByteOrder,
-    ) -> InputDecoder<'_, I> {
-        let bytes = vec![0; normal_length + peek_length];
+    ) -> io::Result<InputDecoder<'_, I>> {
+        // A huge `--width` would otherwise abort the process while allocating
+        // the line buffer. Compute the size with a checked add and reserve it
+        // fallibly so an out-of-range width yields a clean error instead.
+        let size = normal_length
+            .checked_add(peek_length)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::OutOfMemory, "memory exhausted"))?;
+        let mut data: Vec<u8> = Vec::new();
+        data.try_reserve_exact(size)
+            .map_err(|_| io::Error::new(io::ErrorKind::OutOfMemory, "memory exhausted"))?;
+        data.resize(size, 0);
 
-        InputDecoder {
+        Ok(InputDecoder {
             input,
-            data: bytes,
+            data,
             reserved_peek_length: peek_length,
             used_normal_length: 0,
             used_peek_length: 0,
             byte_order,
-        }
+        })
     }
 }
 
@@ -235,7 +244,7 @@ mod tests {
     fn smoke_test() {
         let data = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xff, 0xff];
         let mut input = PeekReader::new(Cursor::new(&data));
-        let mut sut = InputDecoder::new(&mut input, 8, 2, ByteOrder::Little);
+        let mut sut = InputDecoder::new(&mut input, 8, 2, ByteOrder::Little).unwrap();
 
         // Peek normal length
         let mut mem = sut.peek_read().unwrap();

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -269,7 +269,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             od_options.line_bytes,
             PEEK_BUFFER_SIZE,
             od_options.byte_order,
-        );
+        )
+        .map_err(|e| USimpleError::new(1, e.to_string()))?;
 
         let output_info = OutputInfo::new(
             od_options.line_bytes,

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -489,6 +489,26 @@ fn test_non_numeric_width_argument() {
 }
 
 #[test]
+fn test_huge_width_argument() {
+    // A huge width must produce a clean error instead of aborting the process
+    // while allocating the line buffer. Regression test for issue #12839.
+    new_ucmd!()
+        .arg("-w1162652562662412622")
+        .arg("-An")
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_contains("memory exhausted");
+
+    // A width that does not even fit in `usize` is rejected as too large.
+    new_ucmd!()
+        .arg("-w99999999999999999999999")
+        .arg("-An")
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_contains("too large");
+}
+
+#[test]
 fn test_width_without_value() {
     let input: [u8; 40] = [0; 40];
     let expected_output = unindent("


### PR DESCRIPTION
## Summary

Fixes #12839.

`od -w=<huge>` aborted the process while allocating the line buffer:

```console
$ od -w=1162652562662412622 a
memory allocation of 1162652562662412626 bytes failed
Aborted (core dumped)
```

## Change

`InputDecoder::new` now computes the buffer size with a checked add and reserves
it with `try_reserve_exact`, returning an `io::Error` instead of aborting. The
caller maps it to a clean error, matching the graceful out-of-memory behavior of
GNU `od`:

```console
$ od -w=1162652562662412622 a
od: memory exhausted
```

A width that does not fit in `usize` is still rejected by the existing
"argument too large" check.

## Checks

- New regression test `test_huge_width_argument`; existing `od` width tests and the `input_decoder` unit test still pass.
- `cargo fmt` clean, `cargo clippy -p uu_od --all-targets` clean.