### PR TITLE
nproc: clamp an out-of-range --ignore instead of erroring

### DIFF
--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -84,7 +84,17 @@ pub fn uu_app() -> Command {
                 .value_name("N")
                 .default_value("0")
                 .value_parser(|s: &str| -> Result<usize, String> {
-                    s.trim().parse::<usize>().map_err(|e| e.to_string())
+                    match s.trim().parse::<usize>() {
+                        Ok(n) => Ok(n),
+                        // GNU clamps an out-of-range `--ignore` to "ignore
+                        // everything" rather than erroring, which yields the
+                        // minimum count of 1. Mirror the OMP_NUM_THREADS
+                        // overflow handling above.
+                        Err(e) if *e.kind() == std::num::IntErrorKind::PosOverflow => {
+                            Ok(usize::MAX)
+                        }
+                        Err(e) => Err(e.to_string()),
+                    }
                 })
                 .help(translate!("nproc-help-ignore")),
         )

--- a/tests/by-util/test_nproc.rs
+++ b/tests/by-util/test_nproc.rs
@@ -82,6 +82,17 @@ fn test_nproc_ignore() {
 }
 
 #[test]
+fn test_nproc_ignore_overflow_is_clamped() {
+    // GNU clamps an out-of-range --ignore to "ignore everything", printing the
+    // minimum count of 1 rather than erroring. Regression test for #12862.
+    new_ucmd!()
+        .arg("--ignore")
+        .arg("99999999999999999999")
+        .succeeds()
+        .stdout_only("1\n");
+}
+
+#[test]
 fn test_nproc_ignore_all_omp() {
     let result = TestScenario::new(util_name!())
         .ucmd()


### PR DESCRIPTION
## Summary

Fixes #12862.

`nproc --ignore <huge>` rejected the argument, while GNU clamps it to "ignore
everything" and prints the minimum count of 1:

```console
$ nproc --ignore 99999999999999999999
nproc: '99999999999999999999' is not a valid number: number too large to fit in target type
$ gnu nproc --ignore 99999999999999999999
1
```

## Change

Clamp a positive-overflow `--ignore` value to `usize::MAX`, mirroring the
existing `OMP_NUM_THREADS` overflow handling in the same file. The ignored count
then exceeds the number of cores, so the result saturates to 1.

## Checks

- New regression test `test_nproc_ignore_overflow_is_clamped`; existing nproc tests still pass.
- `cargo fmt` clean, `cargo clippy -p uu_nproc --all-targets` clean.