### PR TITLE
fix(mktemp): remove temporary file or directory when name cannot be printed

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -18,7 +18,6 @@ use std::io::ErrorKind;
 use std::iter;
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 
-#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
@@ -435,7 +434,27 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else {
         res
     };
-    println_verbatim(res?).map_err_context(|| translate!("mktemp-error-failed-print"))
+    let path = res?;
+    match println_verbatim(&path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // We created the temporary file or directory but failed to print
+            // its name to stdout. Since the caller will never learn the name,
+            // the entry is unreachable, so remove it to match GNU mktemp.
+            // The tempfile builder's automatic cleanup was disabled via
+            // `keep()`, so removal must be done manually here. This is
+            // best-effort: if removal fails, still report the original
+            // print error.
+            if !dry_run {
+                let _ = if make_dir {
+                    fs::remove_dir(&path)
+                } else {
+                    fs::remove_file(&path)
+                };
+            }
+            Err(e).map_err_context(|| translate!("mktemp-error-failed-print"))
+        }
+    }
 }
 
 pub fn uu_app() -> Command {

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -11,9 +11,9 @@ use uutests::util_name;
 
 use uucore::display::Quotable;
 
-use std::path::PathBuf;
 #[cfg(not(windows))]
 use std::path::MAIN_SEPARATOR;
+use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[cfg(unix)]
@@ -1213,7 +1213,7 @@ fn test_mktemp_hidden_file_single_dot() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_mktemp_cleanup_on_write_error() {
-    use std::fs::{read_dir, File};
+    use std::fs::{File, read_dir};
 
     // Simulate a write failure by directing stdout to /dev/full (Linux only).
     // Skip if /dev/full is unavailable, mirroring the GNU test's guard.

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -11,9 +11,9 @@ use uutests::util_name;
 
 use uucore::display::Quotable;
 
+use std::path::PathBuf;
 #[cfg(not(windows))]
 use std::path::MAIN_SEPARATOR;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[cfg(unix)]
@@ -1207,5 +1207,44 @@ fn test_mktemp_hidden_file_single_dot() {
         template_name.len(),
         "expected filename of length {}, got {filename}",
         template_name.len()
+    );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_mktemp_cleanup_on_write_error() {
+    use std::fs::{read_dir, File};
+
+    // Simulate a write failure by directing stdout to /dev/full (Linux only).
+    // Skip if /dev/full is unavailable, mirroring the GNU test's guard.
+    let Ok(dev_full) = File::create("/dev/full") else {
+        return;
+    };
+
+    // Case 1: a temporary file is created, but printing its name fails.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("d");
+    ucmd.arg("-p")
+        .arg("d")
+        .set_stdout(dev_full.try_clone().unwrap())
+        .fails()
+        .code_is(1);
+    assert!(
+        read_dir(at.plus("d")).unwrap().next().is_none(),
+        "mktemp left an orphaned temp file after a write error"
+    );
+
+    // Case 2: a temporary directory is created, but printing its name fails.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("d");
+    ucmd.arg("-p")
+        .arg("d")
+        .arg("-d")
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1);
+    assert!(
+        read_dir(at.plus("d")).unwrap().next().is_none(),
+        "mktemp left an orphaned temp directory after a write error"
     );
 }


### PR DESCRIPTION
When `mktemp` creates a temp file/directory but then fails to print its
name to stdout (e.g. stdout is `/dev/full`), it left the created entry
behind as an unreachable orphan. GNU `mktemp` removes it.

Fix: on a print failure, remove the created file or directory before
propagating the error. Best-effort, skipped in dry-run mode. `keep()`
disables tempfile's auto-cleanup, so removal is manual.

Fixes the GNU test `tests/mktemp/write-error.sh`. Added a Linux-only
integration test (file and `-d` cases via `/dev/full`); verified it fails
without the change and passes with it.

Note: distinct from #10494, which targets shared stdout-error *detection*.
This is the mktemp-local *cleanup* the GNU test requires, and is independent.