### PR TITLE
ptx: reject invalid sentence regexps

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -217,10 +217,14 @@ fn get_config(matches: &mut clap::ArgMatches) -> UResult<Config> {
         // In the future, we might want to switch to the onig crate (like expr does) for better compatibility.
 
         // Verify regex is valid and doesn't match empty string
-        if let Ok(re) = Regex::new(&regex) {
-            if re.is_match("") {
-                return Err(USimpleError::new(1, translate!("ptx-error-empty-regexp")));
-            }
+        let re = Regex::new(&regex).map_err(|error| {
+            USimpleError::new(
+                1,
+                translate!("ptx-error-invalid-regexp", "error" => error.to_string()),
+            )
+        })?;
+        if re.is_match("") {
+            return Err(USimpleError::new(1, translate!("ptx-error-empty-regexp")));
         }
 
         config.sentence_regex = Some(regex);

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -295,6 +295,14 @@ fn test_sentence_regexp_newlines_are_spaces() {
 }
 
 #[test]
+fn test_sentence_regexp_invalid_syntax_failure() {
+    new_ucmd!()
+        .args(&["-S", "^["])
+        .fails()
+        .stderr_contains("Invalid regexp");
+}
+
+#[test]
 fn test_gnu_mode_dumb_format() {
     // Test GNU mode (dumb format) - the default mode without -G flag
     new_ucmd!().pipe_in("a b").succeeds().stdout_only(


### PR DESCRIPTION
Fixes #12789.

`ptx` now reports an error when the `-S` value is not a valid regexp. Before, a regexp that failed to compile was silently dropped, leaving `ptx` to run as though no sentence regexp had been given. The supplied pattern is now compiled
while parsing the config, and a compile failure surfaces the existing localized error (`ptx-error-invalid-regexp`) including the underlying parser message.

Added a regression test for invalid `-S` regexp syntax as well. 