### PR TITLE
nice: add newline to warning message

### DIFF
--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -137,7 +137,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if let Err(e) = rustix::process::setpriority_process(None, new_niceness) {
         let warning_msg = translate!("nice-warning-setpriority", "util_name" => "nice", "error" => strip_errno(&e.into()) );
 
-        if write!(std::io::stderr(), "{warning_msg}").is_err() {
+        if write!(std::io::stderr(), "{warning_msg}\n").is_err() {
             set_exit_code(125);
             return Ok(());
         }

--- a/src/uu/nice/src/nice.rs
+++ b/src/uu/nice/src/nice.rs
@@ -137,7 +137,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if let Err(e) = rustix::process::setpriority_process(None, new_niceness) {
         let warning_msg = translate!("nice-warning-setpriority", "util_name" => "nice", "error" => strip_errno(&e.into()) );
 
-        if write!(std::io::stderr(), "{warning_msg}\n").is_err() {
+        if writeln!(std::io::stderr(), "{warning_msg}").is_err() {
             set_exit_code(125);
             return Ok(());
         }

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -124,5 +124,5 @@ fn test_nice_adj_negative() {
     new_ucmd!()
         .args(&["--adj", "-20", "true"])
         .succeeds()
-        .stdout_is("nice: warning: setpriority: Permission denied\n");
+        .stderr_is("nice: warning: setpriority: Permission denied\n");
 }

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -122,6 +122,11 @@ fn test_sign_middle() {
 #[test]
 #[cfg(not(target_os = "android"))]
 fn test_nice_adj_negative() {
+    // This assumes the test suite is run as a normal (non-root) user, and as
+    // such attempting to set a negative niceness value will be rejected by
+    // the OS.  If it gets denied, then we know a negative value was parsed
+    // correctly.
+
     new_ucmd!()
         .args(&["--adj", "-20", "true"])
         .succeeds()

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -123,6 +123,6 @@ fn test_sign_middle() {
 fn test_nice_adj_negative() {
     new_ucmd!()
         .args(&["--adj", "-20", "true"])
-        .fails()
-        .std_err_is("nice: warning: setpriority: Permission denied\n");
+        .succeeds()
+        .stdout_is("nice: warning: setpriority: Permission denied\n");
 }

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -120,6 +120,7 @@ fn test_sign_middle() {
 //Both message is fine
 
 #[test]
+#[cfg(not(target_os = "android"))]
 fn test_nice_adj_negative() {
     new_ucmd!()
         .args(&["--adj", "-20", "true"])

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -118,3 +118,11 @@ fn test_sign_middle() {
 //uu: "-2+4" is not a valid number: invalid digit found in string
 //gnu: invalid adjustment `-2+4'
 //Both message is fine
+
+#[test]
+fn test_nice_adj_negative() {
+    new_ucmd!()
+        .args(&["--adj", "-20", "true"])
+        .fails()
+        .std_err_is("nice: warning: setpriority: Permission denied\n");
+}

--- a/tests/by-util/test_nice.rs
+++ b/tests/by-util/test_nice.rs
@@ -15,17 +15,16 @@ fn test_get_current_niceness() {
 
 #[test]
 #[cfg(not(target_os = "android"))]
-fn test_negative_adj_is_adjustment() {
+fn test_nice_adj_negative() {
     // This assumes the test suite is run as a normal (non-root) user, and as
     // such attempting to set a negative niceness value will be rejected by
     // the OS.  If it gets denied, then we know a negative value was parsed
     // correctly.
 
-    let res = new_ucmd!().args(&["--adj", "-1", "true"]).succeeds();
-    assert!(
-        res.stderr_str()
-            .starts_with("nice: warning: setpriority: Permission denied")
-    ); // spell-checker:disable-line
+    new_ucmd!()
+        .args(&["--adj", "-20", "true"])
+        .succeeds()
+        .stderr_is("nice: warning: setpriority: Permission denied\n");
 }
 
 #[test]
@@ -118,17 +117,3 @@ fn test_sign_middle() {
 //uu: "-2+4" is not a valid number: invalid digit found in string
 //gnu: invalid adjustment `-2+4'
 //Both message is fine
-
-#[test]
-#[cfg(not(target_os = "android"))]
-fn test_nice_adj_negative() {
-    // This assumes the test suite is run as a normal (non-root) user, and as
-    // such attempting to set a negative niceness value will be rejected by
-    // the OS.  If it gets denied, then we know a negative value was parsed
-    // correctly.
-
-    new_ucmd!()
-        .args(&["--adj", "-20", "true"])
-        .succeeds()
-        .stderr_is("nice: warning: setpriority: Permission denied\n");
-}


### PR DESCRIPTION
This pr closes #12927. Is test required? I don't think that can regress in future