### PR TITLE
numfmt: bound --format precision for a zero value

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -542,8 +542,12 @@ fn consider_suffix(
 fn is_too_large_to_format(scaled: i128, precision: usize) -> bool {
     const MAX_FORMATTED: u128 = 10_000_000_000_000_000_000;
     let precision_factor = 10_u128.pow(precision.min(19) as u32);
+    // `.max(1)`: a zero value must still be bounded by precision, else any
+    // `--format` precision is accepted (0 * factor == 0), printing/allocating
+    // unboundedly. Treating 0 as magnitude 1 matches GNU's threshold.
     scaled
         .unsigned_abs()
+        .max(1)
         .checked_mul(precision_factor)
         .is_none_or(|v| v >= MAX_FORMATTED)
 }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1635,3 +1635,18 @@ fn test_float_precision_greater_than_16bits() {
         .succeeds()
         .stdout_is("1\n");
 }
+
+#[test]
+fn test_format_precision_too_large_on_zero() {
+    new_ucmd!()
+        .args(&["--format=%.40f", "0"])
+        .fails()
+        .code_is(2)
+        .stderr_only(
+            "numfmt: value/precision too large to be printed: '0e+0/40' (consider using --to)\n",
+        );
+    new_ucmd!()
+        .args(&["--format=%.18f", "0"])
+        .succeeds()
+        .stdout_only("0.000000000000000000\n");
+}


### PR DESCRIPTION
Fixes #12937

`is_too_large_to_format` multiplied the scaled magnitude by the precision factor, which is `0` for any precision when the value is `0`, so an oversized `--format` precision was accepted for `0` — formatting `0.` followed by that many zeros (gigabytes for large precisions, an allocation abort for huge ones) instead of erroring like every other value and like GNU.

Treat a zero value as magnitude `1` so it hits the same precision threshold (`>= 19`) as any other value, matching GNU (`%.18f` formats, `%.19f`+ errors with exit 2, for both `0` and non-zero). Adds a regression test.
