### PR TITLE
fix(hashsum): always report malformed input with --status (fixes #12867)

### DIFF
--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -951,9 +951,7 @@ fn process_checksum_file(
     // not a single line correctly formatted found
     // return an error
     if res.total_properly_formatted() == 0 {
-        if opts.verbose.over_status() {
-            log_no_properly_formatted(filename_display());
-        }
+        log_no_properly_formatted(filename_display());
         return Err(FileCheckError::Failed);
     }
 

--- a/tests/by-util/test_md5sum.rs
+++ b/tests/by-util/test_md5sum.rs
@@ -462,6 +462,18 @@ fn test_check_status_code() {
 }
 
 #[test]
+fn test_check_status_reports_malformed_input() {
+    // --status should still print "no properly formatted checksum lines found"
+    // when all input lines are invalid (issue #12867)
+    new_ucmd!()
+        .args(&["-c", "--status"])
+        .pipe_in("I'mNotAHash\n")
+        .fails()
+        .no_stdout()
+        .stderr_contains("no properly formatted checksum lines found");
+}
+
+#[test]
 fn test_sha1_with_md5sum_should_fail() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
## Summary

Fixes #12867.

When `md5sum -c --status` (or any hashsum variant) receives input where **all** checksum lines are improperly formatted, it previously exited with an error code but printed **no diagnostic at all**. GNU coreutils emits `"md5sum: 'stdin': no properly formatted checksum lines found"` in this case regardless of `--status`.

The `--status` flag is documented to suppress per-file `OK`/`FAILED` lines, **not** structural error messages about the input format itself.

## Change

In `src/uucore/src/lib/features/checksum/validate.rs`, removed the `opts.verbose.over_status()` guard around `log_no_properly_formatted()`:

```rust
// Before
if res.total_properly_formatted() == 0 {
    if opts.verbose.over_status() {
        log_no_properly_formatted(filename_display());
    }
    return Err(FileCheckError::Failed);
}

// After
if res.total_properly_formatted() == 0 {
    log_no_properly_formatted(filename_display());
    return Err(FileCheckError::Failed);
}
```

This fix applies to all hashsum utilities (md5sum, sha256sum, sha512sum, b2sum, etc.) since they share this code path.

## Tests

Added `test_check_status_reports_malformed_input` in `tests/by-util/test_md5sum.rs` that asserts the error message appears on stderr even with `--status`.

Note: PR #12622 made the same fix but only added a b2sum test; this PR adds coverage for md5sum and fixes the root cause in the shared validation code.