### PR TITLE
Fix pr -o/--indent overflow handling

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use std::ffi::OsStr;
 use std::fs::metadata;
 use std::io::{Read, Write, stderr, stdin, stdout};
+use std::num::IntErrorKind;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::time::SystemTime;
@@ -864,7 +865,27 @@ fn build_options(
         across_mode,
     });
 
-    let offset_spaces = " ".repeat(parse_usize(matches, options::INDENT).unwrap_or(Ok(0))?);
+    let offset_spaces = match matches.get_one::<String>(options::INDENT) {
+        None => String::new(),
+        // Parse as i32 to match GNU pr's behavior
+        Some(raw) => match raw.parse::<i32>() {
+            Ok(n) if n >= 0 => " ".repeat(n as usize),
+            Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
+                return Err(PrError::EncounteredErrors {
+                    msg: format!(
+                        "'-o MARGIN' invalid line offset: {}: Value too large for defined data type",
+                        raw.quote()
+                    ),
+                });
+            }
+            _ => {
+                return Err(PrError::EncounteredErrors {
+                    msg: format!("'-o MARGIN' invalid line offset: {}", raw.quote()),
+                });
+            }
+        },
+    };
+
     let join_lines = matches.get_flag(options::JOIN_LINES);
 
     let col_sep_for_printing = column_mode_options.as_ref().map_or_else(

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -429,6 +429,30 @@ fn test_with_offset_space_option() {
 }
 
 #[test]
+fn test_offset_too_large() {
+    let arg = "2147483648";
+    new_ucmd!()
+        .args(&["-o", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-o MARGIN' invalid line offset: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_offset_invalid() {
+    new_ucmd!()
+        .args(&["--indent=-5"])
+        .fails_with_code(1)
+        .stderr_is("pr: '-o MARGIN' invalid line offset: '-5'\n");
+
+    new_ucmd!()
+        .args(&["-o", "abc"])
+        .fails_with_code(1)
+        .stderr_is("pr: '-o MARGIN' invalid line offset: 'abc'\n");
+}
+
+#[test]
 fn test_with_date_format() {
     let whitespace = " ".repeat(50);
     let blank_lines = "\n".repeat(61);


### PR DESCRIPTION
Fixes #12764 

Parse the indent margin as i32 (matching GNU pr's behavior) instead of usize. Offsets larger than i32::MAX now fail with `'-o MARGIN' invalid line offset: <val>: Value too large for defined data type` instead of attempting a huge
allocation. Negative and non-numeric values exit with code 1 and a clear invalid line offset message. Adds tests covering too-large, negative, and non-numeric offsets.