### PR TITLE
Bump `itertools` from `0.14.0` to `0.15.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "fluent-syntax",
  "glob",
  "hex-literal",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "libc",
  "nix",
@@ -979,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1659,6 +1659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,7 +1984,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2559,7 +2568,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2877,7 +2886,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2887,7 +2896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3861,7 +3870,7 @@ version = "0.9.0"
 dependencies = [
  "clap",
  "fluent",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "memchr",
  "regex",
  "thiserror 2.0.18",
@@ -4072,7 +4081,7 @@ dependencies = [
  "ctrlc",
  "fluent",
  "foldhash",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "memchr",
  "rand 0.10.1",
@@ -4412,7 +4421,7 @@ version = "0.9.0"
 dependencies = [
  "clap",
  "fluent",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "rustix",
  "uucore",
 ]
@@ -4444,7 +4453,7 @@ dependencies = [
  "icu_decimal",
  "icu_locale",
  "icu_provider",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "jiff-icu",
  "libc",
@@ -4634,7 +4643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,7 +420,7 @@ icu_decimal = { version = "2.0.0", default-features = false }
 icu_locale = { version = "2.0.0", default-features = false }
 icu_provider = { version = "2.0.0", default-features = false }
 indicatif = "0.18.0"
-itertools = "0.14.0"
+itertools = "0.15.0"
 itoa = "1.0.15"
 jiff = "0.2.18"
 jiff-icu = "0.2.2"

--- a/deny.toml
+++ b/deny.toml
@@ -84,6 +84,8 @@ skip = [
   { name = "thiserror-impl", version = "1.0.69" },
   # bindgen
   { name = "itertools", version = "0.13.0" },
+  # codspeed-divan-compat-macros
+  { name = "itertools", version = "0.14.0" },
   # ordered-multimap
   { name = "hashbrown", version = "0.14.5" },
   # cexpr (via bindgen)

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1116,9 +1116,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]


### PR DESCRIPTION
This PR bumps `itertools` from `0.14.0` to `0.15.0` and adds it to the skip list in `deny.toml`.

Closes https://github.com/uutils/coreutils/pull/12928