### PR TITLE
fix(pr): reject huge --column/-COLUMN counts instead of panicking (fixes #12996)

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -858,6 +858,20 @@ fn build_options(
         None => start_column_option,
     };
 
+    // Reject column counts that would later overflow the Vec allocations in
+    // to_table()/to_table_across()/to_table_short_file() (issue #12996),
+    // matching GNU's "Value too large for defined data type" rejection.
+    if let Some(columns) = column_option_value {
+        if columns > i32::MAX as usize {
+            return Err(PrError::EncounteredErrors {
+                msg: format!(
+                    "invalid number of columns: {}: Value too large for defined data type",
+                    columns.to_string().quote()
+                ),
+            });
+        }
+    }
+
     let column_mode_options = column_option_value.map(|columns| ColumnModeOptions {
         columns,
         width: column_width,

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -943,6 +943,25 @@ fn test_zero_columns_shortcut() {
 }
 
 #[test]
+fn test_huge_columns_does_not_panic() {
+    // Previously panicked with "capacity overflow" (issue #12996).
+    new_ucmd!()
+        .arg("--column=9999999999999999999")
+        .fails_with_code(1)
+        .stderr_contains("invalid number of columns")
+        .stderr_contains("Value too large for defined data type");
+}
+
+#[test]
+fn test_huge_columns_shortcut_does_not_panic() {
+    new_ucmd!()
+        .arg("-9999999999999999999")
+        .fails_with_code(1)
+        .stderr_contains("invalid number of columns")
+        .stderr_contains("Value too large for defined data type");
+}
+
+#[test]
 fn test_zero_expand_tab_width() {
     let expected = "pr: '-e' extra characters or invalid number in the argument: ‘0’\nTry 'pr --help' for more information.\n";
     new_ucmd!()


### PR DESCRIPTION
## Summary

Fixes #12996.

`pr --column N` (or the `-N` shortcut) with an enormous but parseable `N` (e.g. `9999999999999999999`) panics with `capacity overflow` and aborts (exit 134):

```console
$ pr --column 9999999999999999999 /tmp/pr_in
thread 'main' panicked at src/uu/pr/src/pr.rs:1272:20:
capacity overflow
```

`N` parses fine as a `usize` (it's smaller than `usize::MAX` on 64-bit), but it's later used directly as the length of several `Vec` allocations in `to_table()`, `to_table_across()`, and `to_table_short_file()` — `vec![None; columns]` — which overflows once `columns * size_of::<Option<&FileLine>>()` exceeds `isize::MAX`.

GNU `pr` rejects this up front:

```console
$ /usr/bin/pr --column 9999999999999999999 /tmp/pr_in
/usr/bin/pr: invalid number of columns: ‘9999999999999999999’: Value too large for defined data type
```

## Change

In `src/uu/pr/src/pr.rs`, after `column_option_value` is resolved (which already merges both the `--column N` and `-N` forms), reject any value above `i32::MAX` with the same "Value too large for defined data type" message GNU uses, returning exit code 1 instead of panicking.

## Tests

Added `test_huge_columns_does_not_panic` and `test_huge_columns_shortcut_does_not_panic` in `tests/by-util/test_pr.rs` covering both the long and short option forms. All 59 existing `test_pr` tests still pass.