### PR TITLE
cut: support `-O` as short for `--output-delimiter`

### DIFF
--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -759,6 +759,7 @@ pub fn uu_app() -> Command {
         )
         .arg(
             Arg::new(options::OUTPUT_DELIMITER)
+                .short('O')
                 .long(options::OUTPUT_DELIMITER)
                 .value_parser(ValueParser::os_string())
                 .help(translate!("cut-help-output-delimiter"))

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -165,29 +165,32 @@ fn test_delimiter_with_more_than_one_char() {
 
 #[test]
 fn test_output_delimiter() {
-    // we use -d here to ensure output delimiter
-    // is applied to the current, and not just the default, input delimiter
-    new_ucmd!()
-        .args(&[
-            "-d:",
-            "--output-delimiter=@",
-            "-f",
-            COMPLEX_SEQUENCE.sequence,
-            INPUT,
-        ])
-        .succeeds()
-        .stdout_only_fixture("output_delimiter.expected");
+    for param in ["--output-delimiter=@", "--output-del=@", "-O@"] {
+        // with default field delimiter (tab)
+        new_ucmd!()
+            .arg(param)
+            .arg("-f1,2")
+            .pipe_in("a:\tb:\tc:\n")
+            .succeeds()
+            .stdout_only("a:@b:\n");
 
-    new_ucmd!()
-        .args(&[
-            "-d:",
-            "--output-del=@",
-            "-f",
-            COMPLEX_SEQUENCE.sequence,
-            INPUT,
-        ])
-        .succeeds()
-        .stdout_only_fixture("output_delimiter.expected");
+        // with custom field delimiter
+        new_ucmd!()
+            .arg(param)
+            .arg("-f1,2")
+            .arg("-d:")
+            .pipe_in("a:\tb:\tc\n")
+            .succeeds()
+            .stdout_only("a@\tb\n");
+
+        // with no field delimiter
+        new_ucmd!()
+            .arg(param)
+            .arg("-f1,2")
+            .pipe_in("a:b:c\n")
+            .succeeds()
+            .stdout_only("a:b:c\n");
+    }
 }
 
 #[test]

--- a/tests/fixtures/cut/output_delimiter.expected
+++ b/tests/fixtures/cut/output_delimiter.expected
@@ -1,5 +1,0 @@
-foo@bar@qux
-one@two@four@six@seven
-alpha@beta@delta@zeta@eta@iota@kappa@lambda@mu
-the quick brown fox jumps over the lazy dog
-sally	sells	seashells	down	by	the	seashore	where	are	the	seashells	sally	sells


### PR DESCRIPTION
This PR adds support for `-O` as a short for `--output-delimiter` and simplifies the corresponding test by removing the fixture.