### PR TITLE
mktemp: clean up created file/dir if writing path to stdout fails

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -436,18 +436,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let path = res?;
-    let res = println_verbatim(&path);
+    let print_result = println_verbatim(&path);
 
-    // Delete the file/directory if output flush failed.
-    if res.is_err() {
-        if path.is_dir() {
-            fs::remove_dir(&path)?;
+    // If we failed to print the path, clean up the file/directory we just
+    // created (matching GNU). Nothing is created in dry-run mode, so skip it
+    // there. Removal is best-effort: keep reporting the original print error.
+    if print_result.is_err() && !dry_run {
+        let _ = if make_dir {
+            fs::remove_dir(&path)
         } else {
-            fs::remove_file(&path)?;
-        }
+            fs::remove_file(&path)
+        };
     }
 
-    res.map_err_context(|| translate!("mktemp-error-failed-print"))
+    print_result.map_err_context(|| translate!("mktemp-error-failed-print"))
 }
 
 pub fn uu_app() -> Command {

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -14,12 +14,11 @@ use uucore::translate;
 
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::io::ErrorKind;
 use std::iter;
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 
-#[cfg(unix)]
-use std::fs;
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -435,7 +435,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else {
         res
     };
-    println_verbatim(res?).map_err_context(|| translate!("mktemp-error-failed-print"))
+
+    let path = res?;
+    let res = println_verbatim(&path);
+
+    // Delete the file/directory if output flush failed.
+    if res.is_err() {
+        if path.is_dir() {
+            fs::remove_dir(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+
+    res.map_err_context(|| translate!("mktemp-error-failed-print"))
 }
 
 pub fn uu_app() -> Command {

--- a/src/uucore/src/lib/mods/display.rs
+++ b/src/uucore/src/lib/mods/display.rs
@@ -52,6 +52,7 @@ pub fn println_verbatim<S: AsRef<OsStr>>(text: S) -> io::Result<()> {
     let mut stdout = io::stdout().lock();
     stdout.write_all_os(text.as_ref())?;
     stdout.write_all(b"\n")?;
+    stdout.flush()?;
     Ok(())
 }
 

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -1209,3 +1209,41 @@ fn test_mktemp_hidden_file_single_dot() {
         template_name.len()
     );
 }
+
+/// When the created path cannot be written to stdout, mktemp must delete it
+/// again (matching GNU) instead of leaving it behind. In dry-run mode nothing
+/// is created, so it must fail cleanly without trying to remove a missing path.
+/// `/dev/full` forces the write failure, so this is Linux-only.
+#[cfg(target_os = "linux")]
+#[test]
+fn test_mktemp_cleanup_on_write_error() {
+    use std::fs::{File, read_dir};
+
+    // (extra args, template): a plain file, a directory, and a dry run.
+    let cases: &[(&[&str], &str)] = &[
+        (&[], "wrfailXXXXXX.dat"),
+        (&["-d"], "wrfailXXXXXX"),
+        (&["-u"], "wrfailXXXXXX.dat"),
+    ];
+
+    for (args, template) in cases {
+        let scene = TestScenario::new(util_name!());
+        let dir = scene.fixtures.as_string();
+
+        scene
+            .ucmd()
+            .env(TMPDIR, &dir)
+            .args(args)
+            .arg(template)
+            .set_stdout(File::create("/dev/full").unwrap())
+            .fails()
+            // Cleanup is best-effort and must not surface a spurious removal error.
+            .stderr_does_not_contain("No such file or directory");
+
+        assert_eq!(
+            read_dir(&dir).unwrap().count(),
+            0,
+            "leftover temp path for args {args:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Context

In the GNU version of `mktemp`, if the path of the created file/directory cannot be written to stdout, it will clean up by deleting the created file/directory. In the uutils version of `mktemp`, this does not happen and the file/directory remains. This PR rectifies this difference in behaviour.

## Changes

- Flush immediately in `println_verbatim`, so that any write failures also appear immediately.
- Check for a failure - after trying to print the path - and if one occurred, delete the created file/directory.

## Testing

### Manual

**GNU behaviour:**

```console
toggy-smith@toggysmith:/example$ mktemp XXX.txt > /dev/full
mktemp: write error: No space left on device
toggy-smith@toggysmith:/example$ ls
toggy-smith@toggysmith:/example$ 
```

**Previous behaviour:**

```console
toggy-smith@toggysmith:/example$ mktemp XXX.txt > /dev/full
mktemp: failed to print directory name: No space left on device
Error flushing stdout: No space left on device (os error 28)
toggy-smith@toggysmith:/example$ ls
fuF.txt
```

**New behaviour:**

```console
toggy-smith@toggysmith:/example$ mktemp XXX.txt > /dev/full
mktemp: failed to print directory name: No space left on device
Error flushing stdout: No space left on device (os error 28)
toggy-smith@toggysmith:/example$ ls
toggy-smith@toggysmith:/example$ 
```

### GNU test suite

Before:

```plaintext
================================================
   GNU coreutils 9.11: ./tests/test-suite.log
================================================

# TOTAL: 1
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

[REDACTED SYSTEM INFO]

.. contents:: :depth: 2

FAIL: ../gnu/tests/mktemp/write-error
=====================================

mktemp: failed to print directory name: No space left on device
mktemp: failed to print directory name: No space left on device
FAIL ../gnu/tests/mktemp/write-error.sh (exit status: 1)
```

After:

```plaintext
================================================
   GNU coreutils 9.11: ./tests/test-suite.log
================================================

# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0

[REDACTED SYSTEM INFO]

.. contents:: :depth: 2
```