### PR TITLE
i18n: add whoami zh-CN translation

### DIFF
--- a/src/uu/whoami/locales/zh-CN.ftl
+++ b/src/uu/whoami/locales/zh-CN.ftl
@@ -1,0 +1,6 @@
+whoami-about = 输出当前用户名称。
+whoami-usage = whoami
+
+# Error messages
+whoami-error-failed-to-print = 无法输出用户名
+whoami-error-failed-to-get = 无法获取用户名


### PR DESCRIPTION
## What does this PR do?
Adds Simp Chinese (zh-CN) translation for the `whoami`

## Changes in `src/uu/whoami/locales/zh-CN.ftl`
- `whoami-about`: "Print the current username." → "输出当前用户名称。"
- `whoami-error-failed-to-print`: "failed to print username" → "无法输出用户名"  
- `whoami-error-failed-to-get`: "failed to get username" → "无法获取用户名"

## Testing
- [x] Local: `LANG=zh_CN.UTF-8 ./target/debug/whoami --help` shows Chinese output:
```
输出当前用户名称。

Usage: whoami

Options:
  -h, --help     Print help
  -V, --version  Print version
```
- [x] CI: `cargo test --features=fluent` passed locally