### PR TITLE
stat: bad error message when directory doesn't exist

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -374,6 +374,8 @@ weblate
 algs
 wasm
 wasip
+statx
+Statx
 
 # * stty terminal flags
 brkint

--- a/src/uu/stat/locales/en-US.ftl
+++ b/src/uu/stat/locales/en-US.ftl
@@ -63,7 +63,7 @@ stat-error-invalid-directive = {$directive}: invalid directive
 stat-error-cannot-read-filesystem = cannot read table of mounted file systems: {$error}
 stat-error-stdin-filesystem-mode = using '-' to denote standard input does not work in file system mode
 stat-error-cannot-read-filesystem-info = cannot read file system information for {$file}: {$error}
-stat-error-cannot-stat = cannot stat {$file}: {$error}
+stat-error-cannot-statx = cannot statx {$file}: {$error}
 
 ## Warning messages
 

--- a/src/uu/stat/locales/fr-FR.ftl
+++ b/src/uu/stat/locales/fr-FR.ftl
@@ -99,7 +99,7 @@ stat-error-invalid-directive = {$directive} : directive invalide
 stat-error-cannot-read-filesystem = impossible de lire la table des systèmes de fichiers montés : {$error}
 stat-error-stdin-filesystem-mode = utiliser '-' pour désigner l'entrée standard ne fonctionne pas en mode système de fichiers
 stat-error-cannot-read-filesystem-info = impossible de lire les informations du système de fichiers pour {$file} : {$error}
-stat-error-cannot-stat = impossible d'obtenir le statut de {$file} : {$error}
+stat-error-cannot-statx = impossible d'obtenir le statut de {$file} : {$error}
 
 ## Messages d'avertissement
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -11,6 +11,7 @@ use uucore::translate;
 
 use clap::builder::ValueParser;
 use uucore::display::Quotable;
+use uucore::error::strip_errno;
 use uucore::fs::{display_permissions, major, minor};
 use uucore::fsext::{
     FsMeta, MetadataTimeField, StatFs, metadata_get_time, pretty_filetype, pretty_fstype,
@@ -46,8 +47,8 @@ enum StatError {
     StdinFilesystemMode,
     #[error("{}", translate!("stat-error-cannot-read-filesystem-info", "file" => file.clone(), "error" => error.clone()))]
     CannotReadFilesystemInfo { file: String, error: String },
-    #[error("{}", translate!("stat-error-cannot-stat", "file" => file.clone(), "error" => error.clone()))]
-    CannotStat { file: String, error: String },
+    #[error("{}", translate!("stat-error-cannot-statx", "file" => file.clone(), "error" => error.clone()))]
+    CannotStatx { file: String, error: String },
 }
 
 impl UError for StatError {
@@ -1287,9 +1288,9 @@ impl Stater {
                 Err(e) => {
                     show_error!(
                         "{}",
-                        StatError::CannotStat {
+                        StatError::CannotStatx {
                             file: display_name.quote().to_string(),
-                            error: e.to_string()
+                            error: strip_errno(&e)
                         }
                     );
                     return 1;

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -733,6 +733,6 @@ fn test_no_such_directory_message() {
     let ts = TestScenario::new(util_name!());
     ts.ucmd()
         .arg("a")
-        .fails_with(1)
+        .fails_with_code(1)
         .stderr_is("stat: cannot statx 'a': No such file or directory\n");
 }

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -727,3 +727,12 @@ fn test_correct_metadata() {
         assert_eq!(output, &expected);
     }
 }
+
+#[test]
+fn test_no_such_directory_message() {
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd()
+        .arg("a")
+        .fails_with(1)
+        .stderr_is("stat: cannot statx 'a': No such file or directory\n");
+}


### PR DESCRIPTION
in GNU stat, the error message means cannot statx, as in the syscall statx(2), not the util name itself.
Closes #13012 