### PR TITLE
deps: update memmap2 to 0.9.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,9 +1914,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
fixes #13037 
see [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186)