### PR TITLE
sum: disable test on OpenBSD

### DIFF
--- a/tests/by-util/test_sum.rs
+++ b/tests/by-util/test_sum.rs
@@ -106,7 +106,12 @@ fn test_filename_ends_with_slash() {
         .stderr_is("sum: a/: Not a directory\n");
 }
 
-#[cfg(all(unix, not(windows), not(target_os = "macos")))]
+#[cfg(all(
+    unix,
+    not(windows),
+    not(target_os = "macos"),
+    not(target_os = "openbsd")
+))]
 #[cfg_attr(wasi_runner, ignore)]
 #[test]
 fn test_filename_proc_self_mem() {


### PR DESCRIPTION
This PR disables a test on OpenBSD as there is no `/proc` on OpenBSD.