### PR TITLE
mv: use copy_stream for fast cross-device move

### DIFF
--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -28,6 +28,7 @@ rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",
+  "buf-copy",
   "fs",
   "fsxattr",
   "perms",

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -1310,7 +1310,8 @@ fn rename_file_fallback(
             & 0o7777;
         let mut dst_file = create_dest_restrictive(to, /* nofollow */ true)
             .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
-        io::copy(&mut &src_file, &mut dst_file)
+        // copy_stream has fast-path for Linux
+        uucore::buf_copy::copy_stream(&mut &src_file, &mut dst_file)
             .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
 
         #[cfg(not(any(target_os = "macos", target_os = "redox")))]


### PR DESCRIPTION
`copy_stream` has splice path and normal `io::copy` has some unnecessary syscall failures e.g. `copy_file_range` which fails at most cases with cross-device.

```
> hyperfine --ignore-failure "target/release/mv-main /lib/chromium/chromium /tmp/c" "target/release/mv-s /lib/chromium/chromium /tmp/c"
Benchmark 1: target/release/mv-main /lib/chromium/chromium /tmp/c
  Time (mean ± σ):      53.4 ms ±   1.4 ms    [User: 0.4 ms, System: 52.7 ms]
  Range (min … max):    51.4 ms …  60.9 ms    57 runs
Benchmark 2: target/release/mv-s /lib/chromium/chromium /tmp/c
  Time (mean ± σ):      45.7 ms ±   0.7 ms    [User: 0.5 ms, System: 45.0 ms]
  Range (min … max):    44.9 ms …  50.6 ms    58 runs
Summary
  target/release/mv-s /lib/chromium/chromium /tmp/c ran
    1.17 ± 0.04 times faster than target/release/mv-main /lib/chromium/chromium /tmp/c
```