### PR TITLE
cp: improve perf for non-reflink copy

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -360,6 +360,7 @@ uutests
 uutils
 
 # * function names
+sendfile
 execfn
 fadvise
 fstatfs

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -31,7 +31,11 @@ where
 {
     let mut src = open_source(source, source_nofollow)?;
     let mut dst = create_dest_restrictive(dest, false)?;
-    std::io::copy(&mut src, &mut dst).map(|_| ())
+    if ioctl_ficlone(&dst, &src).is_err() {
+        // faster than io::copy's copy_file_range and sendfile
+        buf_copy::copy_stream(&mut src, &mut dst)?;
+    }
+    Ok(())
 }
 
 /// The fallback behavior for [`clone`] on failed system call.


### PR DESCRIPTION
Replace `std::io::copy` by manual reflink copy + copy_stream
```
> hyperfine "target/release/cp /lib/chromium/chromium /tmp/c" "target/release/cp-s /lib/chromium/chromium /tmp/c"
Benchmark 1: target/release/cp /lib/chromium/chromium /tmp/c
  Time (mean ± σ):      53.9 ms ±   0.6 ms    [User: 0.5 ms, System: 53.1 ms]
  Range (min … max):    51.5 ms …  54.7 ms    57 runs
 
Benchmark 2: target/release/cp-s /lib/chromium/chromium /tmp/c
  Time (mean ± σ):      45.3 ms ±   0.8 ms    [User: 0.7 ms, System: 44.5 ms]
  Range (min … max):    43.1 ms …  46.4 ms    64 runs
 
Summary
  target/release/cp-s /lib/chromium/chromium /tmp/c ran
    1.19 ± 0.02 times faster than target/release/cp /lib/chromium/chromium /tmp/c
```