### PR TITLE
split: replace OPT_ by options::

### DIFF
--- a/src/uu/split/src/cli.rs
+++ b/src/uu/split/src/cli.rs
@@ -1,0 +1,191 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use clap::{Arg, ArgAction, Command, ValueHint};
+use std::env;
+use std::ffi::OsString;
+pub use uucore::{format_usage, translate};
+
+pub const ARG_INPUT: &str = "input";
+pub const ARG_PREFIX: &str = "prefix";
+
+pub mod options {
+    pub const BYTES: &str = "bytes";
+    pub const LINE_BYTES: &str = "line-bytes";
+    pub const LINES: &str = "lines";
+    pub const ADDITIONAL_SUFFIX: &str = "additional-suffix";
+    pub const FILTER: &str = "filter";
+    pub const NUMBER: &str = "number";
+    pub const NUMERIC_SUFFIXES: &str = "numeric-suffixes";
+    pub const NUMERIC_SUFFIXES_SHORT: &str = "-d";
+    pub const HEX_SUFFIXES: &str = "hex-suffixes";
+    pub const HEX_SUFFIXES_SHORT: &str = "-x";
+    pub const SUFFIX_LENGTH: &str = "suffix-length";
+    pub const VERBOSE: &str = "verbose";
+    pub const SEPARATOR: &str = "separator";
+    pub const ELIDE_EMPTY_FILES: &str = "elide-empty-files";
+    pub const IO_BLKSIZE: &str = "-io-blksize";
+}
+
+pub fn uu_app() -> Command {
+    Command::new("split")
+        .version(uucore::crate_version!())
+        .help_template(uucore::localized_help_template(uucore::util_name()))
+        .about(translate!("split-about"))
+        .after_help(translate!("split-after-help"))
+        .override_usage(format_usage(&translate!("split-usage")))
+        .infer_long_args(true)
+        // strategy (mutually exclusive)
+        .arg(
+            Arg::new(options::BYTES)
+                .short('b')
+                .long(options::BYTES)
+                .allow_hyphen_values(true)
+                .value_name("SIZE")
+                .help(translate!("split-help-bytes")),
+        )
+        .arg(
+            Arg::new(options::LINE_BYTES)
+                .short('C')
+                .long(options::LINE_BYTES)
+                .allow_hyphen_values(true)
+                .value_name("SIZE")
+                .help(translate!("split-help-line-bytes")),
+        )
+        .arg(
+            Arg::new(options::LINES)
+                .short('l')
+                .long(options::LINES)
+                .allow_hyphen_values(true)
+                .value_name("NUMBER")
+                .default_value("1000")
+                .help(translate!("split-help-lines")),
+        )
+        .arg(
+            Arg::new(options::NUMBER)
+                .short('n')
+                .long(options::NUMBER)
+                .allow_hyphen_values(true)
+                .value_name("CHUNKS")
+                .help(translate!("split-help-number")),
+        )
+        // rest of the arguments
+        .arg(
+            Arg::new(options::ADDITIONAL_SUFFIX)
+                .long(options::ADDITIONAL_SUFFIX)
+                .allow_hyphen_values(true)
+                .value_name("SUFFIX")
+                .default_value("")
+                .value_parser(clap::value_parser!(OsString))
+                .help(translate!("split-help-additional-suffix")),
+        )
+        .arg(
+            Arg::new(options::FILTER)
+                .long(options::FILTER)
+                .allow_hyphen_values(true)
+                .value_name("COMMAND")
+                .value_hint(ValueHint::CommandName)
+                .help(translate!("split-help-filter")),
+        )
+        .arg(
+            Arg::new(options::ELIDE_EMPTY_FILES)
+                .long(options::ELIDE_EMPTY_FILES)
+                .short('e')
+                .help(translate!("split-help-elide-empty-files"))
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::NUMERIC_SUFFIXES_SHORT)
+                .short('d')
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([
+                    options::NUMERIC_SUFFIXES,
+                    options::NUMERIC_SUFFIXES_SHORT,
+                    options::HEX_SUFFIXES,
+                    options::HEX_SUFFIXES_SHORT,
+                ])
+                .help(translate!("split-help-numeric-suffixes-short")),
+        )
+        .arg(
+            Arg::new(options::NUMERIC_SUFFIXES)
+                .long(options::NUMERIC_SUFFIXES)
+                .require_equals(true)
+                .num_args(0..=1)
+                .overrides_with_all([
+                    options::NUMERIC_SUFFIXES,
+                    options::NUMERIC_SUFFIXES_SHORT,
+                    options::HEX_SUFFIXES,
+                    options::HEX_SUFFIXES_SHORT,
+                ])
+                .value_name("FROM")
+                .help(translate!("split-help-numeric-suffixes")),
+        )
+        .arg(
+            Arg::new(options::HEX_SUFFIXES_SHORT)
+                .short('x')
+                .action(ArgAction::SetTrue)
+                .overrides_with_all([
+                    options::NUMERIC_SUFFIXES,
+                    options::NUMERIC_SUFFIXES_SHORT,
+                    options::HEX_SUFFIXES,
+                    options::HEX_SUFFIXES_SHORT,
+                ])
+                .help(translate!("split-help-hex-suffixes-short")),
+        )
+        .arg(
+            Arg::new(options::HEX_SUFFIXES)
+                .long(options::HEX_SUFFIXES)
+                .require_equals(true)
+                .num_args(0..=1)
+                .overrides_with_all([
+                    options::NUMERIC_SUFFIXES,
+                    options::NUMERIC_SUFFIXES_SHORT,
+                    options::HEX_SUFFIXES,
+                    options::HEX_SUFFIXES_SHORT,
+                ])
+                .value_name("FROM")
+                .help(translate!("split-help-hex-suffixes")),
+        )
+        .arg(
+            Arg::new(options::SUFFIX_LENGTH)
+                .short('a')
+                .long(options::SUFFIX_LENGTH)
+                .allow_hyphen_values(true)
+                .value_name("N")
+                .help(translate!("split-help-suffix-length")),
+        )
+        .arg(
+            Arg::new(options::VERBOSE)
+                .long(options::VERBOSE)
+                .help(translate!("split-help-verbose"))
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::SEPARATOR)
+                .short('t')
+                .long(options::SEPARATOR)
+                .allow_hyphen_values(true)
+                .value_name("SEP")
+                .action(ArgAction::Append)
+                .help(translate!("split-help-separator")),
+        )
+        .arg(
+            Arg::new(options::IO_BLKSIZE)
+                .long("io-blksize")
+                .alias(options::IO_BLKSIZE)
+                .hide(true),
+        )
+        .arg(
+            Arg::new(ARG_INPUT)
+                .default_value("-")
+                .value_hint(ValueHint::FilePath)
+                .value_parser(clap::value_parser!(OsString)),
+        )
+        .arg(
+            Arg::new(ARG_PREFIX)
+                .default_value("x")
+                .value_parser(clap::value_parser!(OsString)),
+        )
+}

--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -30,14 +30,11 @@
 //! assert_eq!(it.next().unwrap(), "chunk_ac.txt");
 //! ```
 
+use crate::cli::options;
 use crate::number::DynamicWidthNumber;
 use crate::number::FixedWidthNumber;
 use crate::number::Number;
 use crate::strategy::Strategy;
-use crate::{
-    OPT_ADDITIONAL_SUFFIX, OPT_HEX_SUFFIXES, OPT_HEX_SUFFIXES_SHORT, OPT_NUMERIC_SUFFIXES,
-    OPT_NUMERIC_SUFFIXES_SHORT, OPT_SUFFIX_LENGTH,
-};
 use clap::ArgMatches;
 use std::ffi::{OsStr, OsString};
 use std::path::is_separator;
@@ -148,15 +145,15 @@ impl Suffix {
         // Since all suffixes are setup with 'overrides_with_all()' against themselves and each other,
         // last one wins, all others are ignored
         match (
-            matches.contains_id(OPT_NUMERIC_SUFFIXES),
-            matches.contains_id(OPT_HEX_SUFFIXES),
-            matches.get_flag(OPT_NUMERIC_SUFFIXES_SHORT),
-            matches.get_flag(OPT_HEX_SUFFIXES_SHORT),
+            matches.contains_id(options::NUMERIC_SUFFIXES),
+            matches.contains_id(options::HEX_SUFFIXES),
+            matches.get_flag(options::NUMERIC_SUFFIXES_SHORT),
+            matches.get_flag(options::HEX_SUFFIXES_SHORT),
         ) {
             (true, _, _, _) => {
                 stype = SuffixType::Decimal;
                 // if option was specified, but without value - this will return None as there is no default value
-                if let Some(opt) = matches.get_one::<String>(OPT_NUMERIC_SUFFIXES) {
+                if let Some(opt) = matches.get_one::<String>(options::NUMERIC_SUFFIXES) {
                     start = opt
                         .parse::<usize>()
                         .map_err(|_| SuffixError::NotParsable(opt.to_owned()))?;
@@ -166,7 +163,7 @@ impl Suffix {
             (_, true, _, _) => {
                 stype = SuffixType::Hexadecimal;
                 // if option was specified, but without value - this will return None as there is no default value
-                if let Some(opt) = matches.get_one::<String>(OPT_HEX_SUFFIXES) {
+                if let Some(opt) = matches.get_one::<String>(options::HEX_SUFFIXES) {
                     start = usize::from_str_radix(opt, 16)
                         .map_err(|_| SuffixError::NotParsable(opt.to_owned()))?;
                     auto_widening = false;
@@ -179,7 +176,7 @@ impl Suffix {
 
         // Get suffix length and a flag to indicate if it was specified with command line option
         let (mut length, is_length_cmd_opt) =
-            if let Some(v) = matches.get_one::<String>(OPT_SUFFIX_LENGTH) {
+            if let Some(v) = matches.get_one::<String>(options::SUFFIX_LENGTH) {
                 // suffix length was specified in command line
                 let parsed_length = v
                     .parse::<usize>()
@@ -228,7 +225,7 @@ impl Suffix {
         }
 
         let additional = matches
-            .get_one::<OsString>(OPT_ADDITIONAL_SUFFIX)
+            .get_one::<OsString>(options::ADDITIONAL_SUFFIX)
             .unwrap()
             .clone();
         if additional.to_string_lossy().chars().any(is_separator) {

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -5,15 +5,19 @@
 
 // spell-checker:ignore nbbbb ncccc hexdigit getmaxstdio
 
+mod cli;
 mod filenames;
 mod number;
 mod platform;
 mod strategy;
 
+use crate::cli::ARG_INPUT;
+use crate::cli::ARG_PREFIX;
+use crate::cli::options;
+pub use crate::cli::uu_app;
 use crate::filenames::{FilenameIterator, Suffix, SuffixError};
 use crate::strategy::{NumberType, Strategy, StrategyError};
-use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint, parser::ValueSource};
-use std::env;
+use clap::{ArgMatches, parser::ValueSource};
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, metadata};
 use std::io;
@@ -26,27 +30,7 @@ use uucore::translate;
 
 use uucore::parser::parse_size::parse_size_u64;
 
-use uucore::format_usage;
 use uucore::uio_error;
-
-const OPT_BYTES: &str = "bytes";
-const OPT_LINE_BYTES: &str = "line-bytes";
-const OPT_LINES: &str = "lines";
-const OPT_ADDITIONAL_SUFFIX: &str = "additional-suffix";
-const OPT_FILTER: &str = "filter";
-const OPT_NUMBER: &str = "number";
-const OPT_NUMERIC_SUFFIXES: &str = "numeric-suffixes";
-const OPT_NUMERIC_SUFFIXES_SHORT: &str = "-d";
-const OPT_HEX_SUFFIXES: &str = "hex-suffixes";
-const OPT_HEX_SUFFIXES_SHORT: &str = "-x";
-const OPT_SUFFIX_LENGTH: &str = "suffix-length";
-const OPT_VERBOSE: &str = "verbose";
-const OPT_SEPARATOR: &str = "separator";
-const OPT_ELIDE_EMPTY_FILES: &str = "elide-empty-files";
-const OPT_IO_BLKSIZE: &str = "-io-blksize";
-
-const ARG_INPUT: &str = "input";
-const ARG_PREFIX: &str = "prefix";
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
@@ -212,14 +196,14 @@ fn handle_preceding_options(
     if let Some(opt) = slice.strip_prefix("--") {
         *preceding_long_opt_req_value = matches!(
             opt,
-            OPT_BYTES
-                | OPT_LINE_BYTES
-                | OPT_LINES
-                | OPT_ADDITIONAL_SUFFIX
-                | OPT_FILTER
-                | OPT_NUMBER
-                | OPT_SUFFIX_LENGTH
-                | OPT_SEPARATOR
+            options::BYTES
+                | options::LINE_BYTES
+                | options::LINES
+                | options::ADDITIONAL_SUFFIX
+                | options::FILTER
+                | options::NUMBER
+                | options::SUFFIX_LENGTH
+                | options::SEPARATOR
         );
     }
     // capture if current slice is a preceding short option that requires value and does not have value in the same slice (value separated by whitespace)
@@ -232,167 +216,6 @@ fn handle_preceding_options(
         *preceding_short_opt_req_value = false;
         *preceding_long_opt_req_value = false;
     }
-}
-
-pub fn uu_app() -> Command {
-    Command::new("split")
-        .version(uucore::crate_version!())
-        .help_template(uucore::localized_help_template(uucore::util_name()))
-        .about(translate!("split-about"))
-        .after_help(translate!("split-after-help"))
-        .override_usage(format_usage(&translate!("split-usage")))
-        .infer_long_args(true)
-        // strategy (mutually exclusive)
-        .arg(
-            Arg::new(OPT_BYTES)
-                .short('b')
-                .long(OPT_BYTES)
-                .allow_hyphen_values(true)
-                .value_name("SIZE")
-                .help(translate!("split-help-bytes")),
-        )
-        .arg(
-            Arg::new(OPT_LINE_BYTES)
-                .short('C')
-                .long(OPT_LINE_BYTES)
-                .allow_hyphen_values(true)
-                .value_name("SIZE")
-                .help(translate!("split-help-line-bytes")),
-        )
-        .arg(
-            Arg::new(OPT_LINES)
-                .short('l')
-                .long(OPT_LINES)
-                .allow_hyphen_values(true)
-                .value_name("NUMBER")
-                .default_value("1000")
-                .help(translate!("split-help-lines")),
-        )
-        .arg(
-            Arg::new(OPT_NUMBER)
-                .short('n')
-                .long(OPT_NUMBER)
-                .allow_hyphen_values(true)
-                .value_name("CHUNKS")
-                .help(translate!("split-help-number")),
-        )
-        // rest of the arguments
-        .arg(
-            Arg::new(OPT_ADDITIONAL_SUFFIX)
-                .long(OPT_ADDITIONAL_SUFFIX)
-                .allow_hyphen_values(true)
-                .value_name("SUFFIX")
-                .default_value("")
-                .value_parser(clap::value_parser!(OsString))
-                .help(translate!("split-help-additional-suffix")),
-        )
-        .arg(
-            Arg::new(OPT_FILTER)
-                .long(OPT_FILTER)
-                .allow_hyphen_values(true)
-                .value_name("COMMAND")
-                .value_hint(ValueHint::CommandName)
-                .help(translate!("split-help-filter")),
-        )
-        .arg(
-            Arg::new(OPT_ELIDE_EMPTY_FILES)
-                .long(OPT_ELIDE_EMPTY_FILES)
-                .short('e')
-                .help(translate!("split-help-elide-empty-files"))
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new(OPT_NUMERIC_SUFFIXES_SHORT)
-                .short('d')
-                .action(ArgAction::SetTrue)
-                .overrides_with_all([
-                    OPT_NUMERIC_SUFFIXES,
-                    OPT_NUMERIC_SUFFIXES_SHORT,
-                    OPT_HEX_SUFFIXES,
-                    OPT_HEX_SUFFIXES_SHORT,
-                ])
-                .help(translate!("split-help-numeric-suffixes-short")),
-        )
-        .arg(
-            Arg::new(OPT_NUMERIC_SUFFIXES)
-                .long(OPT_NUMERIC_SUFFIXES)
-                .require_equals(true)
-                .num_args(0..=1)
-                .overrides_with_all([
-                    OPT_NUMERIC_SUFFIXES,
-                    OPT_NUMERIC_SUFFIXES_SHORT,
-                    OPT_HEX_SUFFIXES,
-                    OPT_HEX_SUFFIXES_SHORT,
-                ])
-                .value_name("FROM")
-                .help(translate!("split-help-numeric-suffixes")),
-        )
-        .arg(
-            Arg::new(OPT_HEX_SUFFIXES_SHORT)
-                .short('x')
-                .action(ArgAction::SetTrue)
-                .overrides_with_all([
-                    OPT_NUMERIC_SUFFIXES,
-                    OPT_NUMERIC_SUFFIXES_SHORT,
-                    OPT_HEX_SUFFIXES,
-                    OPT_HEX_SUFFIXES_SHORT,
-                ])
-                .help(translate!("split-help-hex-suffixes-short")),
-        )
-        .arg(
-            Arg::new(OPT_HEX_SUFFIXES)
-                .long(OPT_HEX_SUFFIXES)
-                .require_equals(true)
-                .num_args(0..=1)
-                .overrides_with_all([
-                    OPT_NUMERIC_SUFFIXES,
-                    OPT_NUMERIC_SUFFIXES_SHORT,
-                    OPT_HEX_SUFFIXES,
-                    OPT_HEX_SUFFIXES_SHORT,
-                ])
-                .value_name("FROM")
-                .help(translate!("split-help-hex-suffixes")),
-        )
-        .arg(
-            Arg::new(OPT_SUFFIX_LENGTH)
-                .short('a')
-                .long(OPT_SUFFIX_LENGTH)
-                .allow_hyphen_values(true)
-                .value_name("N")
-                .help(translate!("split-help-suffix-length")),
-        )
-        .arg(
-            Arg::new(OPT_VERBOSE)
-                .long(OPT_VERBOSE)
-                .help(translate!("split-help-verbose"))
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new(OPT_SEPARATOR)
-                .short('t')
-                .long(OPT_SEPARATOR)
-                .allow_hyphen_values(true)
-                .value_name("SEP")
-                .action(ArgAction::Append)
-                .help(translate!("split-help-separator")),
-        )
-        .arg(
-            Arg::new(OPT_IO_BLKSIZE)
-                .long("io-blksize")
-                .alias(OPT_IO_BLKSIZE)
-                .hide(true),
-        )
-        .arg(
-            Arg::new(ARG_INPUT)
-                .default_value("-")
-                .value_hint(ValueHint::FilePath)
-                .value_parser(clap::value_parser!(OsString)),
-        )
-        .arg(
-            Arg::new(ARG_PREFIX)
-                .default_value("x")
-                .value_parser(clap::value_parser!(OsString)),
-        )
 }
 
 /// Parameters that control how a file gets split.
@@ -478,7 +301,7 @@ impl Settings {
         // defaults to '\n' - newline character
         // If the same separator (the same value) was used multiple times - `split` should NOT fail
         // If the separator was used multiple times but with different values (not all values are the same) - `split` should fail
-        let separator = match matches.get_many::<String>(OPT_SEPARATOR) {
+        let separator = match matches.get_many::<String>(options::SEPARATOR) {
             Some(mut sep_values) => {
                 let first = sep_values.next().unwrap(); // it is safe to just unwrap here since Clap should not return empty ValuesRef<'_,String> in the option from get_many() call
                 if !sep_values.all(|s| s == first) {
@@ -493,25 +316,26 @@ impl Settings {
             None => b'\n',
         };
 
-        let io_blksize: Option<u64> = if let Some(s) = matches.get_one::<String>(OPT_IO_BLKSIZE) {
-            match parse_size_u64(s) {
-                Ok(0) => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
-                Ok(n) if n <= uucore::fs::sane_blksize::MAX => Some(n),
-                _ => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
-            }
-        } else {
-            None
-        };
+        let io_blksize: Option<u64> =
+            if let Some(s) = matches.get_one::<String>(options::IO_BLKSIZE) {
+                match parse_size_u64(s) {
+                    Ok(0) => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
+                    Ok(n) if n <= uucore::fs::sane_blksize::MAX => Some(n),
+                    _ => return Err(SettingsError::InvalidIOBlockSize(s.to_owned())),
+                }
+            } else {
+                None
+            };
 
         let result = Self {
             prefix: matches.get_one::<OsString>(ARG_PREFIX).unwrap().clone(),
             suffix,
             input: matches.get_one::<OsString>(ARG_INPUT).unwrap().clone(),
-            filter: matches.get_one::<String>(OPT_FILTER).cloned(),
+            filter: matches.get_one::<String>(options::FILTER).cloned(),
             strategy,
-            verbose: matches.value_source(OPT_VERBOSE) == Some(ValueSource::CommandLine),
+            verbose: matches.value_source(options::VERBOSE) == Some(ValueSource::CommandLine),
             separator,
-            elide_empty_files: matches.get_flag(OPT_ELIDE_EMPTY_FILES),
+            elide_empty_files: matches.get_flag(options::ELIDE_EMPTY_FILES),
             io_blksize,
         };
 

--- a/src/uu/split/src/strategy.rs
+++ b/src/uu/split/src/strategy.rs
@@ -5,7 +5,7 @@
 //! Determine the strategy for breaking up the input (file or stdin) into chunks
 //! based on the command line options
 
-use crate::{OPT_BYTES, OPT_LINE_BYTES, OPT_LINES, OPT_NUMBER};
+use crate::cli::options;
 use clap::{ArgMatches, parser::ValueSource};
 use thiserror::Error;
 use uucore::{
@@ -244,10 +244,10 @@ impl Strategy {
         // overrides_with_all() due to obsolete lines value option
         match (
             obs_lines,
-            matches.value_source(OPT_LINES) == Some(ValueSource::CommandLine),
-            matches.value_source(OPT_BYTES) == Some(ValueSource::CommandLine),
-            matches.value_source(OPT_LINE_BYTES) == Some(ValueSource::CommandLine),
-            matches.value_source(OPT_NUMBER) == Some(ValueSource::CommandLine),
+            matches.value_source(options::LINES) == Some(ValueSource::CommandLine),
+            matches.value_source(options::BYTES) == Some(ValueSource::CommandLine),
+            matches.value_source(options::LINE_BYTES) == Some(ValueSource::CommandLine),
+            matches.value_source(options::NUMBER) == Some(ValueSource::CommandLine),
         ) {
             (Some(v), false, false, false, false) => {
                 let v = parse_size_u64_max(v).map_err(|_| {
@@ -263,19 +263,19 @@ impl Strategy {
             }
             (None, false, false, false, false) => Ok(Self::Lines(1000)),
             (None, true, false, false, false) => {
-                get_and_parse(matches, OPT_LINES, Self::Lines, StrategyError::Lines)
+                get_and_parse(matches, options::LINES, Self::Lines, StrategyError::Lines)
             }
             (None, false, true, false, false) => {
-                get_and_parse(matches, OPT_BYTES, Self::Bytes, StrategyError::Bytes)
+                get_and_parse(matches, options::BYTES, Self::Bytes, StrategyError::Bytes)
             }
             (None, false, false, true, false) => get_and_parse(
                 matches,
-                OPT_LINE_BYTES,
+                options::LINE_BYTES,
                 Self::LineBytes,
                 StrategyError::Bytes,
             ),
             (None, false, false, false, true) => {
-                let s = matches.get_one::<String>(OPT_NUMBER).unwrap();
+                let s = matches.get_one::<String>(options::NUMBER).unwrap();
                 let number_type = NumberType::from(s).map_err(StrategyError::NumberType)?;
                 Ok(Self::Number(number_type))
             }


### PR DESCRIPTION
- replace `OPT_` by `options::` as other utils does.
- Please split huge .rs file. This is difficult to parse by eye.