### PR TITLE
split: remove dummy std::io::Cursor allocation

### DIFF
--- a/src/uu/split/locales/en-US.ftl
+++ b/src/uu/split/locales/en-US.ftl
@@ -15,6 +15,8 @@ split-after-help = Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...;
   - r/N like 'l' but use round robin distribution
   - r/K/N likewise but only output Kth of N to stdout
 
+# messages
+split-creating-file = creating file { $file }
 # Error messages
 split-error-suffix-not-parsable = invalid suffix length: { $value }
 split-error-suffix-contains-separator = invalid suffix { $value }, contains directory separator

--- a/src/uu/split/src/platform/mod.rs
+++ b/src/uu/split/src/platform/mod.rs
@@ -56,10 +56,9 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
-// todo: add .as_fd for std::io::copy's specialization (blocked by dummy Cursor...)
+// todo: add .as_fd for std::io::copy's specialization for --bytes
 pub enum Writer {
     File(std::fs::File),
-    Cursor(std::io::Cursor<Vec<u8>>),
     #[cfg(unix)]
     Filter(FilterWriter),
 }
@@ -68,7 +67,6 @@ impl std::io::Write for Writer {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
             Self::File(w) => w.write(buf),
-            Self::Cursor(w) => w.write(buf),
             #[cfg(unix)]
             Self::Filter(w) => w.write(buf),
         }
@@ -77,7 +75,6 @@ impl std::io::Write for Writer {
     fn flush(&mut self) -> std::io::Result<()> {
         match self {
             Self::File(w) => w.flush(),
-            Self::Cursor(w) => w.flush(),
             #[cfg(unix)]
             Self::Filter(w) => w.flush(),
         }

--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1272,26 +1272,30 @@ where
     R: BufRead,
 {
     let mut filename_iterator = FilenameIterator::new(&settings.prefix, &settings.suffix)?;
+    let mut next_writer = || -> UResult<_> {
+        let name = filename_iterator.next().ok_or_else(|| {
+            USimpleError::new(1, translate!("split-error-output-file-suffixes-exhausted"))
+        })?;
+        if settings.verbose {
+            writeln!(
+                io::stdout(),
+                "{}",
+                translate!("split-creating-file", "file" => name.quote())
+            )?;
+        }
+        Ok(settings.instantiate_current_writer(&name, true)?)
+    };
 
-    // Initialize the writer just to satisfy the compiler. It is going
-    // to be overwritten for sure at the beginning of the loop below
-    // because we start with `remaining == 0`, indicating that a new
-    // chunk should start.
-    let mut writer = Writer::Cursor(io::Cursor::new(vec![]));
+    let mut writer = next_writer()?;
+    debug_assert!(chunk_size > 0);
+    let mut remaining = chunk_size;
 
-    let mut remaining = 0;
     for line in lines_with_sep(reader, settings.separator) {
         let line = line?;
         let mut line = &line[..];
         loop {
             if remaining == 0 {
-                let filename = filename_iterator.next().ok_or_else(|| {
-                    USimpleError::new(1, translate!("split-error-output-file-suffixes-exhausted"))
-                })?;
-                if settings.verbose {
-                    writeln!(io::stdout(), "creating file {}", filename.quote())?;
-                }
-                writer = settings.instantiate_current_writer(&filename, true)?;
+                writer = next_writer()?;
                 remaining = chunk_size;
             }
 


### PR DESCRIPTION
depends on https://github.com/uutils/coreutils/pull/13078