### PR TITLE
pr: pr panics (Option::unwrap() on None) in merge mode -m on empty input #12995

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1103,29 +1103,27 @@ fn group_lines(num_files: usize, lines: Vec<FileLine>) -> Vec<(usize, Vec<FileLi
     let mut current_key: Option<usize> = None;
     let mut current_group: Vec<FileLine> = vec![];
 
-    if lines.is_empty() {
-        result
-    } else {
-        for file_line in lines {
-            match current_key {
-                None => {
-                    current_key = Some(group_key(num_files, &file_line));
-                    current_group.push(file_line);
-                }
-                Some(key) if group_key(num_files, &file_line) == key => {
-                    current_group.push(file_line);
-                }
-                Some(key) => {
-                    result.push((key, current_group.clone()));
-                    current_group.clear();
-                    current_key = Some(group_key(num_files, &file_line));
-                    current_group.push(file_line);
-                }
+    for file_line in lines {
+        match current_key {
+            None => {
+                current_key = Some(group_key(num_files, &file_line));
+                current_group.push(file_line);
+            }
+            Some(key) if group_key(num_files, &file_line) == key => {
+                current_group.push(file_line);
+            }
+            Some(key) => {
+                result.push((key, current_group.clone()));
+                current_group.clear();
+                current_key = Some(group_key(num_files, &file_line));
+                current_group.push(file_line);
             }
         }
-        result.push((current_key.unwrap(), current_group));
-        result
     }
+    if let Some(k) = current_key {
+        result.push((k, current_group));
+    }
+    result
 }
 
 /// Group each line by its file and page number.

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1102,26 +1102,30 @@ fn group_lines(num_files: usize, lines: Vec<FileLine>) -> Vec<(usize, Vec<FileLi
     let mut result: Vec<(usize, Vec<FileLine>)> = vec![];
     let mut current_key: Option<usize> = None;
     let mut current_group: Vec<FileLine> = vec![];
-    for file_line in lines {
-        match current_key {
-            None => {
-                current_key = Some(group_key(num_files, &file_line));
-                current_group.push(file_line);
-            }
-            Some(key) if group_key(num_files, &file_line) == key => {
-                current_group.push(file_line);
-            }
-            Some(key) => {
-                result.push((key, current_group.clone()));
-                current_group.clear();
-                current_key = Some(group_key(num_files, &file_line));
-                current_group.push(file_line);
+
+    if lines.is_empty() {
+        result
+    } else {
+        for file_line in lines {
+            match current_key {
+                None => {
+                    current_key = Some(group_key(num_files, &file_line));
+                    current_group.push(file_line);
+                }
+                Some(key) if group_key(num_files, &file_line) == key => {
+                    current_group.push(file_line);
+                }
+                Some(key) => {
+                    result.push((key, current_group.clone()));
+                    current_group.clear();
+                    current_key = Some(group_key(num_files, &file_line));
+                    current_group.push(file_line);
+                }
             }
         }
+        result.push((current_key.unwrap(), current_group));
+        result
     }
-    // TODO Handle empty file.
-    result.push((current_key.unwrap(), current_group));
-    result
 }
 
 /// Group each line by its file and page number.
@@ -1153,6 +1157,10 @@ fn get_file_line_groups(
 
 fn mpr(paths: &[&str], options: &OutputOptions) -> Result<i32, PrError> {
     let file_line_groups = get_file_line_groups(options, paths)?;
+
+    if file_line_groups.is_empty() {
+        return Ok(0);
+    }
 
     let start_page = options.start_page;
     let mut lines = Vec::new();

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1010,3 +1010,12 @@ fn test_negative_expand_tabs() {
         .fails_with_code(1)
         .stderr_is("pr: '-e' extra characters or invalid number in the argument: ‘-1’\nTry 'pr --help' for more information.\n");
 }
+
+#[cfg(unix)]
+#[test]
+fn test_empty_input_in_merge_mode() {
+    new_ucmd!()
+        .args(&["-m", "/dev/null", "/dev/null"])
+        .succeeds()
+        .stdout_is("");
+}

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1013,9 +1013,9 @@ fn test_negative_expand_tabs() {
 
 #[cfg(unix)]
 #[test]
-fn test_empty_input_in_merge_mode() {
+fn test_merge_empty_input() {
     new_ucmd!()
         .args(&["-m", "/dev/null", "/dev/null"])
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }


### PR DESCRIPTION
This PR resolves #12995
GNU pr exits with silently with code 0, whenever the input in merge mode is an empty file.