### PR TITLE
Use Option::ok_or with ? instead of let...else returning Err

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -176,12 +176,12 @@ fn parse_signal_opt(target: &mut SignalRequest, opt: &OsStr) -> UResult<()> {
         .filter(|chunk| !chunk.is_empty())
         .map(OsStr::from_bytes)
     {
-        let Some(sig_str) = sig.to_str() else {
-            return Err(USimpleError::new(
+        let sig_str = sig.to_str().ok_or_else(|| {
+            USimpleError::new(
                 1,
                 translate!("env-error-invalid-signal", "signal" => sig.quote()),
-            ));
-        };
+            )
+        })?;
         let sig_val = parse_signal_value(sig_str)?;
         target.signals.insert(sig_val);
     }

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -444,12 +444,9 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
             };
 
             if is_line_numbered {
-                let Some(line_number) = stats.line_number else {
-                    return Err(USimpleError::new(
-                        1,
-                        translate!("nl-error-line-number-overflow"),
-                    ));
-                };
+                let line_number = stats.line_number.ok_or_else(|| {
+                    USimpleError::new(1, translate!("nl-error-line-number-overflow"))
+                })?;
                 settings
                     .number_format
                     .format_to(&mut writer, line_number, settings.number_width)

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2185,13 +2185,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         translate!(
                             "sort-maximum-batch-size-rlimit",
                             "rlimit" => {
-                                let Some(rlimit) = fd_soft_limit() else {
-                                    return Err(UUsageError::new(
-                                        2,
-                                        translate!("sort-failed-fetch-rlimit"),
-                                    ));
-                                };
-                                rlimit
+                                fd_soft_limit().ok_or_else(|| {
+                                    UUsageError::new(2, translate!("sort-failed-fetch-rlimit"))
+                                })?
                             }
                         )
                     }

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -229,12 +229,9 @@ fn file_truncate(
     // 2. The size of the file to be truncated if no reference has been provided.
     let actual_reference_size = reference_size.unwrap_or(file_size);
 
-    let Some(truncate_size) = mode.to_size(actual_reference_size) else {
-        return Err(USimpleError::new(
-            1,
-            translate!("truncate-error-division-by-zero"),
-        ));
-    };
+    let truncate_size = mode
+        .to_size(actual_reference_size)
+        .ok_or_else(|| USimpleError::new(1, translate!("truncate-error-division-by-zero")))?;
 
     do_file_truncate(path, !no_create, truncate_size)
 }

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -833,9 +833,8 @@ fn process_checksum_line(
 
     // Use `LineInfo` to extract the data of a line.
     // Then, depending on its format, apply a different pre-treatment.
-    let Some(line_info) = LineInfo::parse(line, cached_line_format) else {
-        return Err(LineCheckError::ImproperlyFormatted);
-    };
+    let line_info =
+        LineInfo::parse(line, cached_line_format).ok_or(LineCheckError::ImproperlyFormatted)?;
 
     if line_info.format == LineFormat::AlgoBased {
         process_algo_based_line(&line_info, cli_algo_name, opts, last_algo)

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -377,11 +377,8 @@ impl<F: Formatter<T>, T> Format<F, T> {
             }
         }
 
-        let Some(spec) = spec else {
-            return Err(FormatError::NeedAtLeastOneSpec(
-                format_string.as_ref().to_vec(),
-            ));
-        };
+        let spec =
+            spec.ok_or_else(|| FormatError::NeedAtLeastOneSpec(format_string.as_ref().to_vec()))?;
 
         let formatter = F::try_from_spec(spec)?;
 

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -158,9 +158,7 @@ impl Spec {
         let start = *rest;
 
         // Check for a positional specifier (%m$)
-        let Some(position) = eat_argument_position(rest, &mut index) else {
-            return Err(&start[..index]);
-        };
+        let position = eat_argument_position(rest, &mut index).ok_or(&start[..index])?;
 
         let flags = Flags::parse(rest, &mut index);
 
@@ -193,9 +191,7 @@ impl Spec {
         // We ignore the length. It's not really relevant to printf
         let _ = Self::parse_length(rest, &mut index);
 
-        let Some(type_spec) = rest.get(index) else {
-            return Err(&start[..index]);
-        };
+        let type_spec = rest.get(index).ok_or(&start[..index])?;
         index += 1;
         *rest = &start[index..];
 

--- a/src/uucore/src/lib/features/parser/num_parser.rs
+++ b/src/uucore/src/lib/features/parser/num_parser.rs
@@ -445,9 +445,9 @@ fn construct_extended_big_decimal(
 
         // powi "only" supports i64 values. Just overflow/underflow if the value provided
         // is > 2**64 or < 2**-64.
-        let Some(exponent) = exponent.to_i64() else {
-            return Err(make_error(exponent.is_positive(), negative));
-        };
+        let exponent = exponent
+            .to_i64()
+            .ok_or_else(|| make_error(exponent.is_positive(), negative))?;
 
         // Confusingly, exponent is in base 2 for hex floating point numbers.
         let base: BigDecimal = 2.into();


### PR DESCRIPTION
Rewrite `let Some(x) = opt else { return Err(e); }` patterns as `let x = opt.ok_or(e)?` (or `ok_or_else` when the error value is non-trivial, to preserve the lazy evaluation of the else branch).

Applied across uucore (checksum, format, num_parser) and the nl, truncate, sort and env utilities.