### PR TITLE
cp: fix --remove-destination deleting source when dest is the same file under a different path

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1993,6 +1993,15 @@ fn backup_dest(dest: &Path, backup_path: &Path, is_dest_symlink: bool) -> CopyRe
     Ok(())
 }
 
+/// Decide whether `source` and `dest` are the same directory entry, as opposed
+/// to merely being two different hard links to the same inode.
+fn paths_are_same_entry(source: &Path, dest: &Path) -> bool {
+    canonicalize(source, MissingHandling::Normal, ResolveMode::Physical)
+        .ok()
+        .zip(canonicalize(dest, MissingHandling::Normal, ResolveMode::Physical).ok())
+        .is_some_and(|(s, d)| s == d)
+}
+
 /// Decide whether source and destination files are the same and
 /// copying is forbidden.
 ///
@@ -2505,12 +2514,14 @@ fn copy_file(
         }
     }
 
+    // Path resolution is the last condition checked, only reached in the rare
+    // hardlink `--remove-destination` case rather than on every file `cp` touches.
     if are_hardlinks_to_same_file(source, dest)
-        && source != dest
         && matches!(
             options.overwrite,
             OverwriteMode::Clobber(ClobberMode::RemoveDestination)
         )
+        && !paths_are_same_entry(source, dest)
     {
         fs::remove_file(dest)?;
     }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3706,6 +3706,21 @@ fn test_remove_destination_with_destination_being_a_hardlink_to_source() {
 }
 
 #[test]
+fn test_remove_destination_with_destination_being_relative_path_of_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = "a";
+    let dest = "./a";
+    at.write(source, "hello");
+
+    ucmd.args(&["--remove-destination", source, dest])
+        .fails()
+        .stderr_contains("are the same file");
+
+    assert!(at.file_exists(source));
+    assert_eq!(at.read(source), "hello");
+}
+
+#[test]
 fn test_remove_destination_with_destination_being_a_symlink_to_source() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "file";


### PR DESCRIPTION
Fixes #13103 (original) and #13144 

### Problem
It compared the source and destination inputs as passed, so for example "a" and "./a" were compared and were -of course- found different.

### Solution
We convert them to absolute paths using `canonicalize(...)` and then perform the equality check.