### PR TITLE
fix(cp): don't delete dest before same-file check with --remove-destination

### DIFF
--- a/.vscode/cspell.dictionaries/acronyms+names.wordlist.txt
+++ b/.vscode/cspell.dictionaries/acronyms+names.wordlist.txt
@@ -4,6 +4,7 @@ AIX
 ASLR # address space layout randomization
 AST # abstract syntax tree
 CATN # busybox cat -n feature flag
+GHSA # GitHub Security Advisory identifier
 CATV # busybox cat -v feature flag
 CICD # continuous integration/deployment
 CPU

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2506,13 +2506,21 @@ fn copy_file(
     }
 
     if are_hardlinks_to_same_file(source, dest)
-        && source != dest
         && matches!(
             options.overwrite,
             OverwriteMode::Clobber(ClobberMode::RemoveDestination)
         )
     {
-        fs::remove_file(dest)?;
+        // `source != dest` is not enough here: "a" and "./a" are different
+        // `Path`s but the very same directory entry, and removing it would
+        // destroy the only copy of the data (GHSA-9p9p-xh9v-6fvx). Only
+        // remove when `source` and `dest` are genuinely distinct directory
+        // entries that happen to be hard-linked to the same file.
+        let same_entry = canonicalize(source, MissingHandling::Normal, ResolveMode::Physical).ok()
+            == canonicalize(dest, MissingHandling::Normal, ResolveMode::Physical).ok();
+        if !same_entry {
+            fs::remove_file(dest)?;
+        }
     }
 
     if initial_dest_metadata.is_some()

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -3687,6 +3687,25 @@ fn test_cp_mode_hardlink_no_dereference() {
     assert_eq!(at.read_symlink("z"), "slink");
 }
 
+#[test]
+fn test_remove_destination_same_path_does_not_destroy_file() {
+    // Regression test for GHSA-9p9p-xh9v-6fvx: source and dest are the same
+    // directory entry, just spelled differently ("a" vs "./a"). cp must
+    // refuse with a "same file" error instead of deleting the file before
+    // detecting the source and destination are identical.
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "a";
+
+    at.write(file, "hello\n");
+
+    ucmd.args(&["--remove-destination", file, &format!("./{file}")])
+        .fails()
+        .stderr_contains("are the same file");
+
+    assert!(at.file_exists(file));
+    assert_eq!(at.read(file), "hello\n");
+}
+
 #[cfg(not(any(windows, target_os = "android")))]
 #[test]
 fn test_remove_destination_with_destination_being_a_hardlink_to_source() {


### PR DESCRIPTION
Fixes #13144 (GHSA-9p9p-xh9v-6fvx).

## Bug

```
$ echo hello > a
$ cp --remove-destination a ./a
cp: cannot stat 'a': No such file or directory
$ cat a
cat: a: No such file or directory      # file is gone
```

`cp --remove-destination a ./a` deletes the file before discovering that
source and destination refer to the same data, destroying it. GNU cp
refuses with `cp: 'a' and './a' are the same file` and leaves the file
intact.

## Root cause

In `copy_file`, the block that removes `dest` ahead of time to let
`--remove-destination` recreate hard-linked destinations used `source !=
dest` (a raw `Path` comparison) as the guard against deleting the source
itself:

```rust
if are_hardlinks_to_same_file(source, dest)
    && source != dest
    && matches!(options.overwrite, OverwriteMode::Clobber(ClobberMode::RemoveDestination))
{
    fs::remove_file(dest)?;
}
```

`"a"` and `"./a"` are different `Path` values but the exact same
directory entry, so the guard doesn't catch this case and the file gets
unlinked before the later same-file check (in `handle_existing_dest`)
ever runs.

## Fix

Compare canonicalized paths instead of the raw `Path`s. This still allows
deletion for the legitimate case this block exists for — two distinct
directory entries that are hard-linked to each other (e.g. `cp
--remove-destination file hardlink`, covered by
`test_remove_destination_with_destination_being_a_hardlink_to_source`) —
but skips it when source and dest are actually the same entry, letting
the existing "same file" error fire instead.

## Testing

Added `test_remove_destination_same_path_does_not_destroy_file`
(cross-platform) reproducing the exact GHSA repro. Ran the full `cp` test
suite (159 tests) with no regressions, plus `cargo clippy -D warnings`
and `cargo fmt --check`.