### PR TITLE
realpath: fix 'nonexistent/./' to be treated as invalid

### DIFF
--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -295,6 +295,12 @@ fn resolve_path(
     relative_base: Option<&Path>,
 ) -> std::io::Result<()> {
     let abs = canonicalize(p, can_mode, resolve)?;
+    if can_mode == MissingHandling::Normal {
+        let path_str = p.to_string_lossy();
+        if path_str.ends_with("/.") || path_str.ends_with("/./") {
+            abs.metadata()?; // raise no such file or directory error
+        }
+    }
 
     let abs = process_relative(abs, relative_base, relative_to);
 

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -458,6 +458,18 @@ fn test_realpath_trailing_slash() {
         .args(&["-m", "link_no_dir/"])
         .succeeds()
         .stdout_contains(format!("{MAIN_SEPARATOR}no_dir\n"));
+
+    scene
+        .ucmd()
+        .arg("nonexistent/.")
+        .fails()
+        .stderr_contains("No such file or directory\n");
+
+    scene
+        .ucmd()
+        .arg("nonexistent/./")
+        .fails()
+        .stderr_contains("No such file or directory\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13152 

When `MissingHandling` is in **Normal Mode** and path ends with "/." or "/./" we purposefully call `abs.metadata()?` to raise the `No such file or directory` error.