### PR TITLE
test_install.rs: remove cfg(not(windows))

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -13,7 +13,6 @@ use std::io::{BufRead, BufReader};
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::PathBuf;
-#[cfg(not(windows))]
 use std::process;
 use std::sync::OnceLock;
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -759,11 +758,10 @@ fn test_install_copy_then_compare_file_with_extra_mode() {
 }
 
 const STRIP_TARGET_FILE: &str = "helloworld_installed";
-#[cfg(all(not(windows), not(target_os = "freebsd")))]
+#[cfg(not(target_os = "freebsd"))]
 const SYMBOL_DUMP_PROGRAM: &str = "objdump";
 #[cfg(target_os = "freebsd")]
 const SYMBOL_DUMP_PROGRAM: &str = "llvm-objdump";
-#[cfg(not(windows))]
 const STRIP_SOURCE_FILE_SYMBOL: &str = "main";
 
 fn strip_source_file() -> PathBuf {
@@ -788,7 +786,6 @@ fn strip_source_file() -> PathBuf {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg(not(target_os = "android"))] // missing strip binary
 // FIXME test runs in a timeout with macos-latest on x86_64 in the CI
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
@@ -814,7 +811,6 @@ fn test_install_and_strip() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg(not(target_os = "android"))] // missing strip binary
 // FIXME test runs in a timeout with macos-latest on x86_64 in the CI
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
@@ -832,7 +828,6 @@ fn test_install_no_strip_with_program() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg(not(target_os = "android"))] // missing strip binary
 // FIXME test runs in a timeout with macos-latest on x86_64 in the CI
 #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
@@ -954,7 +949,6 @@ fn test_install_on_invalid_link_at_destination_and_dev_null_at_source() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn test_install_and_strip_with_invalid_program() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -972,7 +966,6 @@ fn test_install_and_strip_with_invalid_program() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn test_install_and_strip_with_signal_terminated_program() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -992,7 +985,6 @@ fn test_install_and_strip_with_signal_terminated_program() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn test_install_and_strip_with_non_existent_program() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -1129,7 +1121,6 @@ fn test_install_creating_leading_dirs_with_multiple_sources_and_target_dir() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn test_install_creating_leading_dir_fails_on_long_name() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
`install` does not support Windows yet. But Windows has [strip](https://packages.msys2.org/packages/mingw-w64-ucrt-x86_64-binutils). Thus we should raise error about missing `strip` binary when we supported it.