### PR TITLE
chroot: remove bad .is_dir() usage

### DIFF
--- a/src/uu/chroot/locales/en-US.ftl
+++ b/src/uu/chroot/locales/en-US.ftl
@@ -19,7 +19,6 @@ chroot-error-missing-newroot = Missing operand: NEWROOT
 chroot-error-no-group-specified = no group specified for unknown uid: { $uid }
 chroot-error-no-such-user = invalid user
 chroot-error-no-such-group = invalid group
-chroot-error-no-such-directory = cannot change root directory to { $dir }: no such directory
 chroot-error-set-gid-failed = cannot set gid to { $gid }: { $err }
 chroot-error-set-groups-failed = cannot set groups: { $err }
 chroot-error-set-user-failed = cannot set user to { $user }: { $err }

--- a/src/uu/chroot/locales/fr-FR.ftl
+++ b/src/uu/chroot/locales/fr-FR.ftl
@@ -19,7 +19,6 @@ chroot-error-missing-newroot = Opérande manquant : NOUVRACINE
 chroot-error-no-group-specified = aucun groupe spécifié pour l'uid inconnu : { $uid }
 chroot-error-no-such-user = utilisateur invalide
 chroot-error-no-such-group = groupe invalide
-chroot-error-no-such-directory = impossible de changer le répertoire racine vers { $dir } : aucun répertoire de ce type
 chroot-error-set-gid-failed = impossible de définir le gid à { $gid } : { $err }
 chroot-error-set-groups-failed = impossible de définir les groupes : { $err }
 chroot-error-set-user-failed = impossible de définir l'utilisateur à { $user } : { $err }

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -184,10 +184,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
-    if !options.newroot.is_dir() {
-        return Err(ChrootError::NoSuchDirectory(options.newroot).into());
-    }
-
     let commands: Vec<&OsStr> = matches
         .get_many::<String>(options::COMMAND)
         .map_or_else(Vec::new, |v| v.map(OsStr::new).collect());

--- a/src/uu/chroot/src/error.rs
+++ b/src/uu/chroot/src/error.rs
@@ -52,10 +52,6 @@ pub enum ChrootError {
     #[error("{}", translate!("chroot-error-no-such-group"))]
     NoSuchGroup,
 
-    /// The given directory does not exist.
-    #[error("{}", translate!("chroot-error-no-such-directory", "dir" => _0.quote()))]
-    NoSuchDirectory(PathBuf),
-
     /// The call to `setgid()` failed.
     #[error("{}", translate!("chroot-error-set-gid-failed", "gid" => _0, "err" => _1))]
     SetGidFailed(String, #[source] Error),

--- a/tests/by-util/test_chroot.rs
+++ b/tests/by-util/test_chroot.rs
@@ -46,14 +46,15 @@ fn test_enter_chroot_fails() {
 }
 
 #[test]
-fn test_no_such_directory() {
+#[cfg(target_os = "linux")]
+fn test_not_a_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
     at.touch(at.plus_as_string("a"));
 
     ucmd.arg("a")
         .fails_with_code(125)
-        .stderr_is("chroot: cannot change root directory to 'a': no such directory\n");
+        .stderr_contains("cannot chroot to 'a': Not a directory"); //todo: strip (os error N)
 }
 
 #[test]


### PR DESCRIPTION
I'm not sure if `.is_dir()` causes TOCTOU race, but we should believe OS API to extract proper error message.
Closes https://github.com/uutils/coreutils/issues/13178