### PR TITLE
chroot: dedup .is_empty()

### DIFF
--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -203,8 +203,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         commands
     };
 
-    assert!(!command.is_empty());
-    let chroot_command = command[0];
+    let chroot_command = *command.first().unwrap();
 
     // NOTE: Tests can only trigger code beyond this point if they're invoked with root permissions
     set_context(&options)?;


### PR DESCRIPTION
`assert!` has same risk with `.unwrap()`.