### PR TITLE
test_install.rs: remove unnecessary cfg

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -814,15 +814,11 @@ fn test_install_and_strip() {
 }
 
 #[test]
-#[cfg(not(windows))]
-#[cfg(not(target_os = "android"))] // missing strip binary
-// FIXME test runs in a timeout with macos-latest on x86_64 in the CI
-#[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
 fn test_install_no_strip_with_program() {
     TestScenario::new(util_name!())
         .ucmd()
         .arg("--strip-program")
-        .arg("true")
+        .arg("false")
         .arg(strip_source_file())
         .arg(STRIP_TARGET_FILE)
         .succeeds()


### PR DESCRIPTION
`--strip-program=false` ignores `strip` which should success on all platforms.