### PR TITLE
sort: add merge benchmarks for the UTF-8 locale

### DIFF
--- a/src/uu/sort/BENCHMARKING.md
+++ b/src/uu/sort/BENCHMARKING.md
@@ -93,6 +93,27 @@ Example: Run `hyperfine './target/release/coreutils sort shuffled_wordlist.txt -
 - Sort each part by running `for f in shuffled_wordlist_slice_*; do sort $f -o $f; done`
 - Benchmark merging by running `hyperfine "target/release/coreutils sort -m shuffled_wordlist_slice_*"`
 
+The merge comparator compares lines lazily, so the locale matters a lot here: in a
+UTF-8 locale (locale-aware collation) merging must avoid computing a full collation sort
+key for every line, since a k-way merge only performs O(n log k) comparisons (and none at
+all when merging a single already-sorted file). Make sure to benchmark both the C locale
+and a UTF-8 locale, and the single-file case in particular:
+
+```
+# Single already-sorted file (worst case for eager sort-key computation)
+LC_ALL=en_US.UTF-8 hyperfine --warmup 3 \
+  'target/release/coreutils sort -m /usr/share/dict/words' \
+  'sort -m /usr/share/dict/words'
+
+# Several pre-sorted slices
+LC_ALL=en_US.UTF-8 hyperfine --warmup 3 \
+  'target/release/coreutils sort -m shuffled_wordlist_slice_*' \
+  'sort -m shuffled_wordlist_slice_*'
+```
+
+The same scenarios are covered by the `merge_single_file_utf8_locale` and
+`merge_pre_sorted_files_utf8_locale` cases in `benches/sort_locale_utf8_bench.rs`.
+
 ## Check
 
 When invoked with -c, we simply check if the input is already ordered. The input for benchmarking should be an already sorted file.

--- a/src/uu/sort/benches/sort_locale_utf8_bench.rs
+++ b/src/uu/sort/benches/sort_locale_utf8_bench.rs
@@ -154,6 +154,84 @@ fn sort_long_common_prefix_utf8_locale(bencher: Bencher) {
     });
 }
 
+/// Benchmark merging a single pre-sorted file (`sort -m FILE`) with a UTF-8 locale.
+///
+/// This is the worst case for the old implementation: a full ICU collation sort key was
+/// computed for every line even though merging a single file performs no comparisons at
+/// all. The merge path now compares lazily with the collator, so this should be close to
+/// a plain copy regardless of locale.
+#[divan::bench]
+fn merge_single_file_utf8_locale(bencher: Bencher) {
+    // `-m` expects already-sorted input, so sort the generated lines first.
+    let raw = text_data::generate_ascii_data_simple(500_000);
+    let mut lines: Vec<&[u8]> = raw
+        .split(|&b| b == b'\n')
+        .filter(|l| !l.is_empty())
+        .collect();
+    lines.sort();
+    let mut data = Vec::with_capacity(raw.len());
+    for line in lines {
+        data.extend_from_slice(line);
+        data.push(b'\n');
+    }
+    let file_path = setup_test_file(&data);
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
+
+    let args = ["-m", "-o", &output_path, file_path.to_str().unwrap()];
+    black_box(run_util_function(uumain, &args));
+    bencher.bench(|| {
+        black_box(run_util_function(uumain, &args));
+    });
+}
+
+/// Benchmark merging several pre-sorted files (`sort -m`) with a UTF-8 locale.
+///
+/// Mirrors `merge_pre_sorted_files` from `sort_bench_merge.rs`, but runs under a UTF-8
+/// locale to exercise the locale-aware merge comparison.
+#[divan::bench]
+fn merge_pre_sorted_files_utf8_locale(bencher: Bencher) {
+    const TOTAL_LINES: usize = 500_000;
+    const NUM_FILES: usize = 8;
+
+    let data = text_data::generate_ascii_data(TOTAL_LINES);
+    let lines: Vec<&[u8]> = data
+        .split(|&b| b == b'\n')
+        .filter(|l| !l.is_empty())
+        .collect();
+    let lines_per_file = lines.len() / NUM_FILES;
+
+    let mut file_paths = Vec::with_capacity(NUM_FILES);
+    for i in 0..NUM_FILES {
+        let start = i * lines_per_file;
+        let end = if i == NUM_FILES - 1 {
+            lines.len()
+        } else {
+            (i + 1) * lines_per_file
+        };
+
+        let mut chunk_lines = lines[start..end].to_vec();
+        chunk_lines.sort();
+
+        let mut chunk_data = Vec::new();
+        for line in chunk_lines {
+            chunk_data.extend_from_slice(line);
+            chunk_data.push(b'\n');
+        }
+        file_paths.push(setup_test_file(&chunk_data));
+    }
+
+    let output_file = NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
+    let file_args: Vec<&str> = file_paths.iter().map(|p| p.to_str().unwrap()).collect();
+
+    bencher.bench(|| {
+        let mut args = vec!["-m", "-o", output_path.as_str()];
+        args.extend(&file_args);
+        black_box(run_util_function(uumain, &args));
+    });
+}
+
 fn main() {
     // Set UTF-8 locale BEFORE any benchmarks run.
     // This must happen before divan::main() because the locale is cached


### PR DESCRIPTION
Add merge_single_file_utf8_locale and merge_pre_sorted_files_utf8_locale to benches/sort_locale_utf8_bench.rs, covering `sort -m` of a single already-sorted file and of several pre-sorted slices under a UTF-8 locale. 