### PR TITLE
show-utils.sh: help building coreutils without GNU make

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -36,9 +36,9 @@ jobs:
       env:
         CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
       run: |
-        # Get all utilities and exclude ones that don't compile for wasm32-wasip1
-        EXCLUDE="df|du|env|expr|more|tac|test"
-        UTILS=$(./util/show-utils.sh | tr ' ' '\n' | grep -vE "^($EXCLUDE)$" | sed 's/^/-p uu_/' | tr '\n' ' ')
+        # Get all utilities
+        export SKIP_UTILS="df du env expr more tac test" # todo: this should be removed
+        UTILS=$(CARGO_BUILD_TARGET=wasm32-wasip1 PROG_PREFIX="-puu_"./util/show-utils.sh)
         cargo test --target wasm32-wasip1 --no-default-features $UTILS
     - name: Run integration tests via wasmtime
       env:

--- a/util/show-utils.sh
+++ b/util/show-utils.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# spell-checker:ignore (shell) OSTYPE
-# spell-checker:ignore (utils) cksum coreutils dircolors mkdir mktemp printenv printf readlink realpath grealpath rmdir shuf tsort unexpand
-# spell-checker:ignore (jq) deps startswith
+# spell-checker:ignore (utils) grealpath
 
+# A helper script to allow installing coreutils without GNU make
+# todo: reuse this script on GNUmakefile. Does it break some system potentially missing coreutils e.g. Gentoo?
 # Use GNU version for realpath on *BSD
 REALPATH=$(command -v grealpath||command -v realpath)
 
@@ -11,25 +11,29 @@ ME="${0}"
 ME_dir="$(dirname -- "${ME}")"
 ME_parent_dir="$(dirname -- "${ME_dir}")"
 ME_parent_dir_abs="$("${REALPATH}" -mP -- "${ME_parent_dir}" || "${REALPATH}" -- "${ME_parent_dir}")"
+cd "${ME_parent_dir_abs}" || exit 1
 
-# refs: <https://forge.rust-lang.org/release/platform-support.html> , <https://docs.rs/platforms/0.2.1/platforms/platform/tier1/index.html>
+# https://doc.rust-lang.org/beta/rustc/platform-support.html
+: ${CARGO_BUILD_TARGET:=$(rustc --print host-tuple)}
+case "$CARGO_BUILD_TARGET" in
+    *windows*)
+        FEATURES="windows"
+        ;;
+    *wasip*)
+        FEATURES="feat_wasm"
+        ;;
+    *)
+        FEATURES="feat_os_unix"
+        ;;
+esac
 
-# default utility list
-default_utils=$(sed -n '/feat_common_core = \[/,/\]/p' Cargo.toml | sed '1d' |tr -d '],"\n') # $(sed -n '/feat_Tier1 = \[/,/\]/p' Cargo.toml | sed '1d;2d' |tr -d '],"\n') too?
+: ${UTILS:=$(cargo tree --depth 1 --features ${FEATURES} --format "{p}" --prefix none | sed -E -n 's/^uu_([^ ]+).*/\1/p')}
 
-project_main_dir="${ME_parent_dir_abs}"
-# printf 'project_main_dir="%s"\n' "${project_main_dir}"
-cd "${project_main_dir}" &&
-
-    # `jq` available?
-    if ! jq --version 1>/dev/null 2>&1; then
-        echo "WARN: missing \`jq\` (install with \`sudo apt install jq\`); falling back to default (only fully cross-platform) utility list" 1>&2
-        echo "$default_utils"
-    else
-    # Find 'coreutils' id with regex
-    # with cargo v1.76.0, id = "coreutils 0.0.26 (path+file://<coreutils local directory>)"
-    # with cargo >= v1.77.0
-    # - if local path != '<...>/coreutils' id = "path+file://<coreutils local directory>#coreutils@0.0.26"
-    # - if local path == '<...>/coreutils' id = "path+file://<parent directory>/coreutils#0.0.26"
-        cargo metadata "$@" --format-version 1 | jq -r '[.resolve.nodes[] | select(.id|match(".*coreutils[ |@|#]\\d+\\.\\d+\\.\\d+")) | .deps[] | select(.pkg|match("uu_")) | .name | sub("^uu_"; "")] | sort | join(" ")'
-    fi
+# avoid grep dependency for the sake
+for util in $UTILS; do
+    case " $SKIP_UTILS " in
+        *" $util "*) continue ;;
+        *) printf "${PROG_PREFIX}%s " "$util" ;;
+    esac
+done
+echo


### PR DESCRIPTION
- Replace some dependency e.g. `jq` with part of coreutils.
- Honor `(SKIP_)UTILS` and `PROG_PREFIX` e.g. `PROG_PREFIX="-p uu_"` to tell it to `cargo`.

This does not help user of Windows since this still depends on `bash`, but `GNUmakefile` already depends on it.