### PR TITLE
ci: replace devcontainer with dummy

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         push: never
         runCmd: |
-            echo -n "Dummy"
+            cargo check

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -30,5 +30,4 @@ jobs:
       with:
         push: never
         runCmd: |
-            curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-            cargo nextest run --hide-progress-bar --profile ci
+            echo -n "Dummy"


### PR DESCRIPTION
The devcontainer CI workflow no longer needed, so i just replaced it with cargo check to avoid issues