### PR TITLE
tsort: remove unreachable error case

### DIFF
--- a/src/uu/tsort/locales/en-US.ftl
+++ b/src/uu/tsort/locales/en-US.ftl
@@ -7,5 +7,4 @@ tsort-error-is-dir = read error: Is a directory
 tsort-error-odd = input contains an odd number of tokens
 tsort-error-loop = input contains a loop:
 tsort-error-extra-operand = extra operand { $operand }
-  Try '{ $util } --help' for more information.
-tsort-error-at-least-one-input = at least one input
+  Try 'tsort --help' for more information.

--- a/src/uu/tsort/locales/fr-FR.ftl
+++ b/src/uu/tsort/locales/fr-FR.ftl
@@ -7,5 +7,4 @@ tsort-error-is-dir = erreur de lecture : c'est un répertoire
 tsort-error-odd = l'entrée contient un nombre impair de jetons
 tsort-error-loop = l'entrée contient une boucle :
 tsort-error-extra-operand = opérande supplémentaire { $operand }
-  Essayez '{ $util } --help' pour plus d'informations.
-tsort-error-at-least-one-input = au moins une entrée
+  Essayez 'tsort --help' pour plus d'informations.

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -2,8 +2,10 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-//spell-checker:ignore TAOCP indegree FADV
-//spell-checker:ignore (libs) interner uclibc
+
+// spell-checker:ignore TAOCP indegree
+// spell-checker:ignore (libs) interner
+
 use clap::{Arg, ArgAction, Command};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
@@ -35,25 +37,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .into_iter()
         .flatten();
 
-    let input = match (inputs.next(), inputs.next()) {
-        (None, _) => {
-            return Err(USimpleError::new(
-                1,
-                translate!("tsort-error-at-least-one-input"),
-            ));
-        }
-        (Some(input), None) => input,
-        (Some(_), Some(extra)) => {
-            return Err(USimpleError::new(
-                1,
-                translate!(
-                    "tsort-error-extra-operand",
-                    "operand" => extra.quote(),
-                    "util" => "tsort"
-                ),
-            ));
-        }
-    };
+    let input = inputs.next().expect("default value should be set by clap");
+
+    if let Some(extra) = inputs.next() {
+        return Err(USimpleError::new(
+            1,
+            translate!(
+                "tsort-error-extra-operand",
+                "operand" => extra.quote()
+            ),
+        ));
+    }
+
     // Create the directed graph from pairs of tokens in the input data.
     let mut g = Graph::new(input.to_string_lossy().to_string());
     if input == "-" {


### PR DESCRIPTION
This PR removes the code to handle the case of zero `FILE` values. It's not possible to reach that code because we define a default value in `clap` and so there is always at least one value.