### PR TITLE
od: fix overflow panic in --traditional label accumulator

### DIFF
--- a/src/uu/od/src/input_offset.rs
+++ b/src/uu/od/src/input_offset.rs
@@ -35,9 +35,9 @@ impl InputOffset {
 
     /// Increase `byte_pos` and `label` if a label is used.
     pub fn increase_position(&mut self, n: u64) {
-        self.byte_pos += n;
+        self.byte_pos = self.byte_pos.wrapping_add(n);
         if let Some(l) = self.label {
-            self.label = Some(l + n);
+            self.label = Some(l.wrapping_add(n));
         }
     }
 
@@ -93,6 +93,14 @@ fn test_input_offset() {
     sut.increase_position(10);
     sut.set_radix(Radix::Octal);
     assert_eq!("0000036", &sut.format_byte_offset());
+}
+
+#[test]
+fn test_increase_position_wraps_on_overflow() {
+    // A label of u64::MAX must not panic — it wraps, matching C unsigned semantics.
+    let mut sut = InputOffset::new(Radix::Hexadecimal, 0, Some(u64::MAX));
+    sut.increase_position(1); // would panic in debug builds before the fix
+    assert_eq!(sut.label, Some(0));
 }
 
 #[test]

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -1360,3 +1360,16 @@ fn test_hex_lowercase() {
             ",
         ));
 }
+
+/// Regression test for #13225: `od --traditional` with a pseudo-address label
+/// near `u64::MAX` must not panic with "attempt to add with overflow".
+///
+/// GNU `od` uses C unsigned arithmetic which wraps on overflow; the Rust port
+/// previously used plain `+=` / `+` which panics in debug builds.
+#[test]
+fn test_traditional_label_near_u64_max_does_not_panic() {
+    new_ucmd!()
+        .args(&["--traditional", "-", "0", "0xffffffffffffffff"])
+        .pipe_in("0123456789ABCDEF")
+        .succeeds(); // must not panic (exit 101 in debug before the fix)
+}


### PR DESCRIPTION
## Summary

`InputOffset::increase_position` used plain `+=` / `+` for the running
byte position and user-supplied `--traditional` label. In debug builds
(or any build compiled with `-C overflow-checks=on`) a label near
`u64::MAX` causes an "attempt to add with overflow" panic on the very
first read:

```console
$ printf '0123456789ABCDEF' | ./target/debug/od --traditional - 0 0xffffffffffffffff
thread 'main' panicked at src/uu/od/src/input_offset.rs:40:31:
attempt to add with overflow
```

GNU `od` uses C `unsigned long` arithmetic, which silently wraps on
overflow. The fix switches both fields to `wrapping_add` to match that
behaviour and eliminate the panic.

## Changes

- `src/uu/od/src/input_offset.rs`: `increase_position` now uses
  `wrapping_add` for `byte_pos` and `label`.
- Adds `test_increase_position_wraps_on_overflow` unit test that would
  have panicked before this fix.

Fixes #13225