### PR TITLE
tail: fix -f/-F not following files on Windows (#4827)

### DIFF
--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -307,7 +307,13 @@ impl Observer {
         let display_name = self.files.get(event_path).display_name.clone();
 
         match event.kind {
-            EventKind::Modify(ModifyKind::Metadata(MetadataKind::Any | MetadataKind::WriteTime) | ModifyKind::Data(DataChange::Any) | ModifyKind::Name(RenameMode::To)) |
+            // NOTE: `ModifyKind::Any` is emitted by the Windows `ReadDirectoryChangesW`
+            // backend (for `FILE_ACTION_MODIFIED`) and by the macOS/BSD `kqueue` backend
+            // (for `NOTE_WRITE`) whenever a watched file's contents change. Without it,
+            // appends are never followed on those platforms (see GH issue #4827).
+            // Linux inotify and the polling fallback report the more specific
+            // `Modify(Data(..))`/`Modify(Metadata(..))` instead, so this is a no-op there.
+            EventKind::Modify(ModifyKind::Any | ModifyKind::Metadata(MetadataKind::Any | MetadataKind::WriteTime) | ModifyKind::Data(DataChange::Any) | ModifyKind::Name(RenameMode::To)) |
             EventKind::Create(CreateKind::File | CreateKind::Folder | CreateKind::Any) => {
                 if let Ok(new_md) = event_path.metadata() {
                     let is_tailable = new_md.is_tailable();

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -227,7 +227,6 @@ fn test_nc_0_wo_follow2() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_n0_with_follow() {
     let (at, mut ucmd) = at_and_ucmd!();
     let test_file = "test.txt";
@@ -501,7 +500,6 @@ fn test_null_default() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: test times out
 fn test_follow_single() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -589,7 +587,6 @@ fn test_permission_denied_is_not_reported_as_not_found() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: test times out
 fn test_follow_multiple() {
     let (at, mut ucmd) = at_and_ucmd!();
     let mut child = ucmd
@@ -625,7 +622,6 @@ fn test_follow_multiple() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: test times out
 fn test_follow_name_multiple() {
     // spell-checker:disable-next-line
     for argument in ["--follow=name", "--follo=nam", "--f=n"] {
@@ -2011,11 +2007,7 @@ fn test_follow_name_remove() {
 }
 
 #[test]
-#[cfg(all(
-    not(target_os = "windows"),
-    not(target_os = "android"),
-    not(target_os = "freebsd")
-))] // FIXME: for currently not working platforms
+#[cfg(all(not(target_os = "android"), not(target_os = "freebsd")))] // FIXME: for currently not working platforms
 fn test_follow_name_truncate1() {
     // This test triggers a truncate event while `tail --follow=name file` is running.
     // $ cp file backup && head file > file && sleep 1 && cp backup file
@@ -2052,11 +2044,7 @@ fn test_follow_name_truncate1() {
 }
 
 #[test]
-#[cfg(all(
-    not(target_os = "windows"),
-    not(target_os = "android"),
-    not(target_os = "freebsd")
-))] // FIXME: for currently not working platforms
+#[cfg(all(not(target_os = "android"), not(target_os = "freebsd")))] // FIXME: for currently not working platforms
 fn test_follow_name_truncate2() {
     // This test triggers a truncate event while `tail --follow=name file` is running.
     // $ ((sleep 1 && echo -n "x\nx\nx\n" >> file && sleep 1 && \
@@ -2099,7 +2087,6 @@ fn test_follow_name_truncate2() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: for currently not working platforms
 fn test_follow_name_truncate3() {
     // Opening an empty file in truncate mode should not trigger a truncate event while
     // `tail --follow=name file` is running.


### PR DESCRIPTION
## Problem

Fixes #4827 — `tail -f` / `tail -F` does not follow a growing file on Windows. `tail` prints the initial tail, then never emits appended content.

## Root cause

The follow event loop in `src/uu/tail/src/follow/watch.rs` (`Observer::handle_event`) matched:

- `Modify(Data(DataChange::Any))`
- `Modify(Metadata(Any | WriteTime))`
- `Modify(Name(RenameMode::To))`
- `Create(..)`

…but **not** the bare `Modify(ModifyKind::Any)`.

notify's Windows `ReadDirectoryChangesW` backend maps every file write (`FILE_ACTION_MODIFIED`) to exactly `EventKind::Modify(ModifyKind::Any)` (`notify/src/windows.rs`). So on Windows every append/truncate event fell through to `_ => {}` and was silently dropped — the file was watched, events arrived, paths matched, but nothing was ever read/printed.

Linux inotify emits the more specific `Modify(Data(..))`, which is why the bug is Windows-only. The macOS/BSD `kqueue` backend also emits `Modify(ModifyKind::Any)` for `NOTE_WRITE`, so this fix hardens follow there too. The polling fallback only emits `Data`/`Metadata`, so this arm is a no-op for it and for inotify.

## Fix

Add `ModifyKind::Any` to the match arm (one line + explanatory comment). It routes through the existing tailable/truncation logic, so appends and in-place truncation are both handled.

## Tests

Re-enabled the seven Windows follow tests that were disabled with `// FIXME: test times out` / `for currently not working platforms` — they timed out **because** of this bug and now pass:

- Append following: `test_follow_single`, `test_follow_multiple`, `test_follow_name_multiple`, `test_n0_with_follow`
- Truncation: `test_follow_name_truncate1`, `test_follow_name_truncate2`, `test_follow_name_truncate3`

These are genuine regression guards (verified on Windows):

- **Without** the fix: `test_follow_single` and `test_follow_name_truncate1` **FAIL**.
- **With** the fix: full Windows follow suite is green.

## Known limitation (out of scope for this PR)

`test_follow_name_truncate4` and the move/rename follow tests remain Windows-disabled for a **different** reason: `MetadataExtTail::file_id_eq()` is stubbed to `false` on Windows in `paths.rs` (it needs `GetFileInformationByHandle` / the `windows_by_handle` API to compare file identity). Truncate-to-same-content and rename detection depend on that, so tail spuriously reports "file has been replaced". That is a separate follow-up.
