### PR TITLE
GnuTests: remove LD_PRELOAD from nproc-quota.sh & avoid 0 period

### DIFF
--- a/src/uu/nproc/src/nproc.rs
+++ b/src/uu/nproc/src/nproc.rs
@@ -109,8 +109,8 @@ fn cgroups2_quota() -> Option<usize> {
     let mut pair = pair.split_whitespace();
     // map the string "max" to None as we unwrap_or(usize::MAX) later
     let quota = pair.next()?.parse::<usize>().ok()?;
-    let period = pair.next()?.parse::<usize>().ok()?;
-    debug_assert!(period > 0, "kernel should validate it");
+    // kernel does not provide 0 period. But it seems GNU cares about it
+    let period = pair.next()?.parse::<usize>().ok().filter(|&p| p > 0)?;
     // mimic GNU's rounding
     Some(quota.saturating_add(period / 2) / period)
 }

--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -6,6 +6,7 @@ curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --stri
 # TODO stop backporting tests from master at GNU coreutils > $ver
 exit 0
 backport=(
+  nproc/nproc-quota.sh # remove LD_PRELOAD
 )
  for f in "${backport[@]}"
   do curl -L ${repo}/raw/refs/heads/master/tests/$f > tests/$f


### PR DESCRIPTION
backport https://github.com/coreutils/coreutils/issues/309