### PR TITLE
install: fix -D data-loss when destination parent is the root directory

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -657,9 +657,17 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
                     while trimmed_bytes.ends_with(b"/") {
                         trimmed_bytes = &trimmed_bytes[..trimmed_bytes.len() - 1];
                     }
-                    let trimmed_os_str = std::ffi::OsStr::from_bytes(trimmed_bytes);
-                    to_create_owned = PathBuf::from(trimmed_os_str);
-                    to_create_owned.as_path()
+                    if trimmed_bytes.is_empty() {
+                        // Path was entirely slashes (i.e. "/").  Stripping them
+                        // yields "" which resolves to the current directory and
+                        // causes a later unlink_at to delete the source file
+                        // instead of the intended destination (#13232).
+                        to_create
+                    } else {
+                        let trimmed_os_str = std::ffi::OsStr::from_bytes(trimmed_bytes);
+                        to_create_owned = PathBuf::from(trimmed_os_str);
+                        to_create_owned.as_path()
+                    }
                 }
                 _ => to_create,
             };

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2863,3 +2863,37 @@ fn test_install_backup_nil_same_file() {
         assert_eq!(at.read(file), "content");
     }
 }
+
+/// Regression test for #13232: `install -D src /single-component-dest` must
+/// not delete the source file when the destination's parent directory is `/`.
+///
+/// The slash-stripping loop turned `"/"` into `""`, which `create_dir_all_safe`
+/// resolved to the current directory.  A subsequent `unlink_at` then removed
+/// the source file instead of the (non-existent) destination.
+///
+/// We cannot write to `/` as a regular user, so we verify that install fails
+/// AND that the source is left intact.
+#[test]
+#[cfg(unix)]
+fn test_install_D_root_parent_does_not_destroy_source() {
+    // Skip if running as root — root can actually create /file, which would
+    // make the operation succeed and change the assertion below.
+    if unsafe { libc::getuid() } == 0 {
+        return;
+    }
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("src", "hello\n");
+
+    // /install_test_13232 lives directly under "/" — parent is "/"
+    scene
+        .ucmd()
+        .args(&["-D", "src", "/install_test_13232"])
+        .fails();
+
+    // Source must survive regardless of the failure reason.
+    assert!(at.file_exists("src"), "source file was deleted by install -D");
+    assert_eq!(at.read("src"), "hello\n");
+}


### PR DESCRIPTION
## Summary

`install -D src /file` silently **deletes the source file** and then
fails, leaving the user with neither the source nor the destination.

### Root cause

When the target is a single-component absolute path like `/file`,
`target.parent()` returns `"/"`.  Before calling `create_dir_all_safe`,
the code strips trailing slashes from that parent:

```rust
while trimmed_bytes.ends_with(b"/") {
    trimmed_bytes = &trimmed_bytes[..trimmed_bytes.len() - 1];
}
```

For `"/"` this strips ALL bytes and produces `""`.
`find_existing_ancestor("")` maps an empty path to `"."` (current
directory), so `create_dir_all_safe` returns a `DirFd` pointing at CWD
instead of `/`.

The subsequent `unlink_at(cwd_fd, "file")` then removes `./file` — the
source — rather than any existing destination.  The copy step fails
because the source is gone, and the user ends up with nothing.

### Fix

Skip the trailing-slash strip when the result would be empty (i.e. the
path was entirely slashes).  The root directory `"/"` is left as-is, so
`create_dir_all_safe` opens `/` as the parent fd and later
`unlink_at(root_fd, "file")` targets the intended destination.

## Changes

- `src/uu/install/src/install.rs`: guard the slash-strip so an
  all-slash path (`"/"`) is kept intact.
- `tests/by-util/test_install.rs`: regression test verifying the source
  file survives when `install -D src /dest` fails (non-root execution).

Fixes #13232