### PR TITLE
head: don't panic on a write error while printing a verbose header

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -460,7 +460,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                         writeln!(stdout)?;
                     }
                     write!(stdout, "==> ")?;
-                    print_verbatim(file).unwrap();
+                    print_verbatim(file)?;
                     writeln!(stdout, " <==")?;
                     first = false;
                 }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -919,6 +919,22 @@ fn test_write_to_dev_full() {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+#[test]
+fn test_verbose_header_long_name_write_error_no_panic() {
+    use std::fs::OpenOptions;
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+
+    let long_name = format!("/dev/{}null", "./".repeat(512));
+
+    new_ucmd!()
+        .args(&["-v", &long_name])
+        .set_stdout(dev_full)
+        .fails_with_code(1)
+        .stderr_contains("head: No space left on device");
+}
+
 #[test]
 #[cfg(target_os = "linux")]
 #[cfg_attr(wasi_runner, ignore = "WASI: argv/filenames must be valid UTF-8")]


### PR DESCRIPTION
Fixes #13264

The verbose `==> name <==` header wrote the filename with `print_verbatim(file).unwrap()`, while the surrounding header writes use `?`. When the filename is longer than the stdout buffer (~1024 bytes), `write_all` flushes mid-write, so a write error (e.g. stdout on a full device) is raised inside the `unwrap` and aborts the process instead of being reported.

This propagates the error with `?` like the neighbouring writes, so a write failure exits non-zero with a message instead of panicking, regardless of filename length.

Before:

```console
$ LONG="/dev/$(python3 -c "print('./'*512)")null"
$ head -v "$LONG" > /dev/full
thread 'main' panicked at src/uu/head/src/head.rs:463:42:
called `Result::unwrap()` on an `Err` value: Os { code: 28, kind: StorageFull, message: "No space left on device" }
Aborted (core dumped)          # exit 134
```

After (consistent with the short-filename path, and non-zero like GNU):

```console
$ head -v "$LONG" > /dev/full ; echo $?
head: No space left on device
1
```

A regression test (`test_verbose_header_long_name_write_error_no_panic`) covers it with `.fails_with_code(1)`, which the pre-fix abort would not satisfy.
