### PR TITLE
head: fix panic on write error when printing a long -v filename header

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -460,7 +460,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                         writeln!(stdout)?;
                     }
                     write!(stdout, "==> ")?;
-                    print_verbatim(file).unwrap();
+                    print_verbatim(file)?;
                     writeln!(stdout, " <==")?;
                     first = false;
                 }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1002,6 +1002,35 @@ fn test_directory_header_with_multiple_files_zero_output() {
 /// GNU `head` prints the `==> name <==` header only after the file is
 /// successfully opened. A file that exists but cannot be opened (e.g. no read
 /// permission) must therefore produce only an error and no header.
+/// Regression test for #13264: writing a long `-v` filename header to a
+/// full device must not panic.  The `print_verbatim` call used `.unwrap()`
+/// which panicked when stdout's internal buffer was flushed mid-write and
+/// returned an error.  A short filename stays buffered and its error surfaces
+/// at a later `?`-checked write, so we need a path longer than the buffer
+/// (~1024 bytes) to trigger the flush inside `print_verbatim`.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+fn test_verbose_long_filename_write_error_does_not_panic() {
+    use std::fs::OpenOptions;
+
+    // Build a path > 1024 bytes that still resolves to an existing file.
+    // Repeated "./" segments are verbatim in the header but collapsed by the OS.
+    let long_path = format!("/dev/{}null", "./".repeat(512));
+    assert!(long_path.len() > 1024);
+
+    let dev_full = OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .unwrap();
+
+    // Must not panic (which would exit 134). Any non-zero exit code is fine.
+    new_ucmd!()
+        .arg("-v")
+        .arg(&long_path)
+        .set_stdout(dev_full)
+        .fails();
+}
+
 #[cfg(unix)]
 #[test]
 fn test_unreadable_file_prints_no_header() {


### PR DESCRIPTION
## Summary

`head -v` prints a `==> <filename> <==` header for each file.  The
filename was written with `print_verbatim(file).unwrap()`.  If stdout
is a full device (`ENOSPC`) **and** the filename is longer than the
`LineWriter` internal buffer (~1024 bytes), `write_all` inside
`print_verbatim` flushes mid-write, the write error is returned to
`.unwrap()`, and the process **panics** (exit 134) instead of exiting
cleanly.

A short filename stays entirely within the buffer, so its error only
surfaces at the next `?`-checked `writeln!` — those fail gracefully.
This asymmetry means only long filenames trigger the panic.

```console
$ LONG="/dev/$(python3 -c "print('./'*512)")null"   # >1024-byte path
$ head -v "$LONG" > /dev/full
thread 'main' panicked at src/uu/head/src/head.rs:463:42:
called `Result::unwrap()` on an `Err` value: Os { code: 28, kind: StorageFull, ... }
Aborted (core dumped)
```

GNU `head` reports the error and exits with code 1.

## Fix

Replace `.unwrap()` with `?` so the error propagates through the
enclosing `UResult<()>` closure, exactly like the surrounding
`write!`/`writeln!` calls.

## Changes

- `src/uu/head/src/head.rs` line 463: `.unwrap()` → `?`
- `tests/by-util/test_head.rs`: regression test using `/dev/full` and a
  >1024-byte path built from repeated `./` segments.

Fixes #13264