### PR TITLE
uucore: fall back to '~' when the backup suffix is empty

### DIFF
--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -245,7 +245,8 @@ pub mod arguments {
 ///
 /// 1. From the '-S' or '--suffix' CLI argument, if present
 /// 2. From the "SIMPLE_BACKUP_SUFFIX" environment variable, if present
-/// 3. By using the default '~' if none of the others apply, or if they contained slashes
+/// 3. By using the default '~' if none of the others apply, or if the
+///    resolved suffix is empty or contains slashes
 ///
 /// This function directly takes [`ArgMatches`] as argument and looks for
 /// the '-S' and '--suffix' arguments itself.
@@ -256,7 +257,7 @@ pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
     } else {
         env::var("SIMPLE_BACKUP_SUFFIX").unwrap_or_else(|_| DEFAULT_BACKUP_SUFFIX.to_owned())
     };
-    if suffix.contains('/') {
+    if suffix.is_empty() || suffix.contains('/') {
         DEFAULT_BACKUP_SUFFIX.to_owned()
     } else {
         suffix
@@ -705,6 +706,15 @@ mod tests {
         let _dummy = TEST_MUTEX.lock().unwrap();
         let matches =
             make_app().get_matches_from(vec!["command", "-b", "--suffix", "_/../../dest"]);
+
+        let result = determine_backup_suffix(&matches);
+        assert_eq!(result, DEFAULT_BACKUP_SUFFIX);
+    }
+
+    #[test]
+    fn test_suffix_empty_defaults_to_tilde() {
+        let _dummy = TEST_MUTEX.lock().unwrap();
+        let matches = make_app().get_matches_from(vec!["command", "-b", "--suffix", ""]);
 
         let result = determine_backup_suffix(&matches);
         assert_eq!(result, DEFAULT_BACKUP_SUFFIX);

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1157,6 +1157,23 @@ fn test_cp_arg_suffix_hyphen_value() {
 }
 
 #[test]
+fn test_cp_arg_suffix_empty_defaults_to_tilde() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    ucmd.arg(TEST_HELLO_WORLD_SOURCE)
+        .arg("-b")
+        .arg("--suffix=")
+        .arg(TEST_HOW_ARE_YOU_SOURCE)
+        .succeeds();
+
+    assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
+    assert_eq!(
+        at.read(&format!("{TEST_HOW_ARE_YOU_SOURCE}~")),
+        "How are you?\n"
+    );
+}
+
+#[test]
 fn test_cp_custom_backup_suffix_via_env() {
     let (at, mut ucmd) = at_and_ucmd!();
     let suffix = "super-suffix-of-the-century";

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -1310,6 +1310,30 @@ fn test_install_backup_short_custom_suffix() {
 }
 
 #[test]
+fn test_install_backup_empty_suffix_defaults_to_tilde() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    let file_a = "test_install_backup_empty_suffix_file_a";
+    let file_b = "test_install_backup_empty_suffix_file_b";
+
+    at.touch(file_a);
+    at.touch(file_b);
+    scene
+        .ucmd()
+        .arg("-b")
+        .arg("--suffix=")
+        .arg(file_a)
+        .arg(file_b)
+        .succeeds()
+        .no_stderr();
+
+    assert!(at.file_exists(file_a));
+    assert!(at.file_exists(file_b));
+    assert!(at.file_exists(format!("{file_b}~")));
+}
+
+#[test]
 fn test_install_suffix_without_backup_option() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -245,6 +245,25 @@ fn test_symlink_custom_backup_suffix() {
 }
 
 #[test]
+fn test_ln_backup_empty_suffix_defaults_to_tilde() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.write("a", "a\n");
+    at.write("b", "b2\n");
+
+    scene
+        .ucmd()
+        .args(&["-b", "--suffix=", "a", "b"])
+        .succeeds()
+        .no_stderr();
+
+    // b is now a hard link to a, and the original b was backed up to b~
+    assert_eq!(at.read("b"), "a\n");
+    assert_eq!(at.read("b~"), "b2\n");
+}
+
+#[test]
 fn test_symlink_suffix_without_backup_option() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
## Problem

GNU coreutils treats an empty backup suffix as "unset" and falls back to the
default `~`. Our `determine_backup_suffix()` returned the empty string instead,
so with `--backup` and an empty `--suffix=` (or `SIMPLE_BACKUP_SUFFIX=`) the
backup path became identical to the destination. As a result `cp`, `install`
and `mv` silently created no backup, and `ln` failed outright.

Reported in #13168.

## Before / after (vs GNU coreutils 9.11, `LANG=C`)

```console
$ echo new > a; echo old > b
$ cp --backup a b --suffix=
```

| command | GNU 9.11 | uutils before | uutils after |
|---|---|---|---|
| `cp --backup a b --suffix=` | `b~` (old) | no backup | `b~` (old) |
| `install --backup a b --suffix=` | `b~` (old) | no backup | `b~` (old) |
| `mv --backup --suffix= a b` | `b~` (old) | no backup | `b~` (old) |
| `ln --backup --suffix= a b` | `b~` + link | `failed to create hard link 'a' => 'b': Already exists` (exit 1) | `b~` + link |

The precedence `--suffix` > `SIMPLE_BACKUP_SUFFIX` > `~` was already correct;
only the empty-suffix fallback was missing.

## Fix

`determine_backup_suffix()` already maps a suffix containing `/` to the default
`~`. Extend that check to also cover the empty suffix, at the single shared
location used by `cp`, `install`, `ln` and `mv`.

## Tests

- `uucore`: `test_suffix_empty_defaults_to_tilde`
- `cp`: `test_cp_arg_suffix_empty_defaults_to_tilde`
- `install`: `test_install_backup_empty_suffix_defaults_to_tilde`
- `ln`: `test_ln_backup_empty_suffix_defaults_to_tilde` (covers the case that previously failed outright)

Note: the issue also mentions `--backup=nil`; that part is not a bug (`nil` is
the alias for `existing`, and both GNU and uutils already create the backup),
so this PR only addresses the empty-suffix case.

Fixes #13168
