### PR TITLE
cp: prevent panic in aligned_ancestors on shallow source paths

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2213,31 +2213,15 @@ fn delete_path(path: &Path, options: &Options) -> CopyResult<()> {
 /// assert_eq!(actual, expected);
 /// ```
 fn aligned_ancestors<'a>(source: &'a Path, dest: &'a Path) -> Vec<(&'a Path, &'a Path)> {
-    // Collect the ancestors of each. For example, if `source` is
-    // "a/b/c", then the ancestors are "a/b/c", "a/b", "a/", and "".
-    let source_ancestors: Vec<&Path> = source.ancestors().collect();
-    let dest_ancestors: Vec<&Path> = dest.ancestors().collect();
-
-    // For this particular application, we don't care about the null
-    // path "" and we don't care about the full path (e.g. "a/b/c"),
-    // so we exclude those.
-    let n = source_ancestors.len();
-    let source_ancestors = &source_ancestors[1..n - 1];
-
-    // Get the matching number of elements from the ancestors of the
-    // destination path (for example, get "d/a" and "d/a/b").
-    let k = source_ancestors.len();
-    let dest_ancestors = &dest_ancestors[1..=k];
-
-    // Now we have two slices of the same length, so we zip them.
-    let mut result = vec![];
-    for (x, y) in source_ancestors
-        .iter()
-        .rev()
-        .zip(dest_ancestors.iter().rev())
-    {
-        result.push((*x, *y));
-    }
+    // Assuming dest.ancestors().len() >= source.ancestors().len(), so zip is bounded by source's depth.
+    // skip(1) drops the full paths; pop() drops source's root ancestor.
+    let mut result: Vec<_> = source
+        .ancestors()
+        .skip(1)
+        .zip(dest.ancestors().skip(1))
+        .collect();
+    result.pop();
+    result.reverse();
     result
 }
 
@@ -2999,6 +2983,25 @@ mod tests {
             (Path::new("a"), Path::new("d/a")),
             (Path::new("a/b"), Path::new("d/a/b")),
         ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_aligned_ancestors_empty_source() {
+        let actual = aligned_ancestors(Path::new(""), Path::new("dest"));
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_aligned_ancestors_single_component_source() {
+        let actual = aligned_ancestors(Path::new("a"), Path::new("d/a"));
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_aligned_ancestors_two_component_source() {
+        let actual = aligned_ancestors(Path::new("a/b"), Path::new("d/a/b"));
+        let expected = vec![(Path::new("a"), Path::new("d/a"))];
         assert_eq!(actual, expected);
     }
     #[test]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1573,6 +1573,23 @@ fn test_cp_parents_dest_not_directory() {
 }
 
 #[test]
+fn test_cp_parents_empty_source_does_not_panic() {
+    // Regression: --parents with an empty source path previously caused a panic
+    // in aligned_ancestors due to slice indexing [1..0] (start > end).
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dest");
+    ucmd.arg("--parents")
+        .arg("")
+        .arg("dest")
+        .fails()
+        .stderr_only(if cfg!(not(target_os = "windows")) {
+            "cp: cannot stat '': No such file or directory\n"
+        } else {
+            "cp: The system cannot find the path specified. (os error 3)\n"
+        });
+}
+
+#[test]
 #[cfg(not(target_os = "openbsd"))]
 fn test_cp_parents_with_permissions_copy_file() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
## Problem

The `aligned_ancestors` function in `src/uu/cp/src/cp.rs` panicked when called with an empty source path, which has only 1 ancestor.
The root cause was unsafe slice indexing:

```rust
let n = source_ancestors.len();
let source_ancestors = &source_ancestors[1..n - 1]; // panics when n == 1
```

When `n == 1` (empty source `""`), the range `[1..0]` has start > end and panics.

### Reproduction

```sh
$ mkdir -p /tmp/dest
$ cp --parents "" /tmp/dest

thread 'main' panicked at src/uu/cp/src/cp.rs:2226:45:
slice index starts at 1 but ends at 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Fix

Rewrote `aligned_ancestors` to use iterator combinators instead of manual slice indexing.


Also reduced allocations from 3 `Vec`s (two ancestor collects + result) to 1 (the zip collect).

## Tests

Added 3 unit tests in `src/uu/cp/src/cp.rs`:

- `test_aligned_ancestors_empty_source` — empty source path (regression: previously panicked)
- `test_aligned_ancestors_single_component_source` — single-component source (boundary: no intermediates)
- `test_aligned_ancestors_two_component_source` — two-component source (boundary: 1 intermediate)

Added 1 integration test in `tests/by-util/test_cp.rs`:

- `test_cp_parents_empty_source_does_not_panic` — verifies `cp --parents "" dest`
  fails gracefully with a "cannot stat" error instead of panicking

