### PR TITLE
bug(ls): when --tabsize is a negative number ls successeds instead of rejecting it

### DIFF
--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -12,6 +12,7 @@ vdir-usage = vdir [OPTION]... [FILE]...
 ls-after-help = The TIME_STYLE argument can be full-iso, long-iso, iso, locale or +FORMAT. FORMAT is interpreted like in date. Also the TIME_STYLE environment variable sets the default style to use.
 
 # Error messages
+ls-error-invalid-tab-size = invalid tab size: {$size}
 ls-error-invalid-line-width = invalid line width: {$width}
 ls-error-general-io = general io error: {$error}
 ls-error-cannot-access-no-such-file = cannot access {$path}: No such file or directory

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -670,16 +670,16 @@ fn parse_width(width_match: Option<&String>) -> Result<u16, LsError> {
 
 /// Parses the tab size value from the command line
 fn parse_tab_size(size_str: &str) -> Result<usize, Box<LsError>> {
-        size_str
-            .parse::<usize>()
-            .ok()
-            .or_else(|| {
-                size_str
-                    .strip_prefix("0x")
-                    .or_else(|| size_str.strip_prefix("0X"))
-                    .and_then(|hex| usize::from_str_radix(hex, 16).ok())
-            })
-            .ok_or_else(|| Box::new(LsError::InvalidTabSize(size_str.to_string())))
+    size_str
+        .parse::<usize>()
+        .ok()
+        .or_else(|| {
+            size_str
+                .strip_prefix("0x")
+                .or_else(|| size_str.strip_prefix("0X"))
+                .and_then(|hex| usize::from_str_radix(hex, 16).ok())
+        })
+        .ok_or_else(|| Box::new(LsError::InvalidTabSize(size_str.to_string())))
 }
 
 impl Config {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -965,7 +965,8 @@ impl Config {
             match size_str.parse::<usize>() {
                 Ok(val) => Some(val),
                 Err(_) => {
-                    if let Some(clean_hex) = size_str.clone()
+                    if let Some(clean_hex) = size_str
+                        .clone()
                         .strip_prefix("0x")
                         .or_else(|| size_str.strip_prefix("0X"))
                     {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -966,7 +966,8 @@ impl Config {
                 match size_str.parse::<usize>() {
                     Ok(val) => Some(val),
                     Err(_) => {
-                        if let Some(clean_hex) = size_str.to_string()
+                        if let Some(clean_hex) = size_str
+                            .to_string()
                             .strip_prefix("0x")
                             .or_else(|| size_str.strip_prefix("0X"))
                         {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -669,6 +669,19 @@ fn parse_width(width_match: Option<&String>) -> Result<u16, LsError> {
 }
 
 impl Config {
+    fn parse_tab_size(size_str: &str) -> Result<usize, Box<LsError>> {
+        size_str
+            .parse::<usize>()
+            .ok()
+            .or_else(|| {
+                size_str
+                    .strip_prefix("0x")
+                    .or_else(|| size_str.strip_prefix("0X"))
+                    .and_then(|hex| usize::from_str_radix(hex, 16).ok())
+            })
+            .ok_or_else(|| Box::new(LsError::InvalidTabSize(size_str.to_string())))
+    }
+    
     #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
         let context = options.get_flag(options::CONTEXT);
@@ -962,19 +975,9 @@ impl Config {
         let tab_size = if needs_color {
             Some(0)
         } else if let Some(size_str) = options.get_one::<String>(options::format::TAB_SIZE) {
-            match size_str.parse::<usize>() {
-                Ok(val) => Some(val),
-                Err(_) => {
-                    if let Some(clean_hex) = size_str
-                        .clone()
-                        .strip_prefix("0x")
-                        .or_else(|| size_str.strip_prefix("0X"))
-                    {
-                        usize::from_str_radix(clean_hex, 16).ok()
-                    } else {
-                        return Err(Box::new(LsError::InvalidTabSize(size_str.clone())));
-                    }
-                }
+            match Self::parse_tab_size(size_str) {
+                Ok(n) => Some(n),
+                Err(e) => return Err(e),
             }
         } else {
             None

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -966,7 +966,14 @@ impl Config {
                 match size_str.parse::<usize>() {
                     Ok(val) => Some(val),
                     Err(_) => {
-                        return Err(Box::new(LsError::InvalidTabSize(15.to_string())));
+                        if let Some(clean_hex) = size_str.to_string()
+                            .strip_prefix("0x")
+                            .or_else(|| size_str.strip_prefix("0X"))
+                        {
+                            usize::from_str_radix(clean_hex, 16).ok()
+                        } else {
+                            return Err(Box::new(LsError::InvalidTabSize(size_str.to_string())));
+                        }
                     }
                 }
             } else {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -962,12 +962,17 @@ impl Config {
         let tab_size = if needs_color {
             Some(0)
         } else {
-            options
-                .get_one::<String>(options::format::TAB_SIZE)
-                .and_then(|size| size.parse::<usize>().ok())
-                .or_else(|| std::env::var("TABSIZE").ok().and_then(|s| s.parse().ok()))
-        }
-        .unwrap_or(SPACES_IN_TAB);
+            if let Some(size_str) = options.get_one::<String>(options::format::TAB_SIZE) {
+                match size_str.parse::<usize>() {
+                    Ok(val) => Some(val),
+                    Err(_) => {
+                        return Err(Box::new(LsError::InvalidTabSize(15.to_string())));
+                    }
+                }
+            } else {
+                None
+            }
+        };
 
         Ok(Self {
             format,
@@ -1002,7 +1007,7 @@ impl Config {
             line_ending: LineEnding::from_zero_flag(options.get_flag(options::ZERO)),
             dired,
             hyperlink,
-            tab_size,
+            tab_size: tab_size.unwrap_or(SPACES_IN_TAB),
         })
     }
 }

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -961,25 +961,22 @@ impl Config {
 
         let tab_size = if needs_color {
             Some(0)
-        } else {
-            if let Some(size_str) = options.get_one::<String>(options::format::TAB_SIZE) {
-                match size_str.parse::<usize>() {
-                    Ok(val) => Some(val),
-                    Err(_) => {
-                        if let Some(clean_hex) = size_str
-                            .to_string()
-                            .strip_prefix("0x")
-                            .or_else(|| size_str.strip_prefix("0X"))
-                        {
-                            usize::from_str_radix(clean_hex, 16).ok()
-                        } else {
-                            return Err(Box::new(LsError::InvalidTabSize(size_str.to_string())));
-                        }
+        } else if let Some(size_str) = options.get_one::<String>(options::format::TAB_SIZE) {
+            match size_str.parse::<usize>() {
+                Ok(val) => Some(val),
+                Err(_) => {
+                    if let Some(clean_hex) = size_str.clone()
+                        .strip_prefix("0x")
+                        .or_else(|| size_str.strip_prefix("0X"))
+                    {
+                        usize::from_str_radix(clean_hex, 16).ok()
+                    } else {
+                        return Err(Box::new(LsError::InvalidTabSize(size_str.clone())));
                     }
                 }
-            } else {
-                None
             }
+        } else {
+            None
         };
 
         Ok(Self {

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -668,8 +668,8 @@ fn parse_width(width_match: Option<&String>) -> Result<u16, LsError> {
     Ok(ret)
 }
 
-impl Config {
-    fn parse_tab_size(size_str: &str) -> Result<usize, Box<LsError>> {
+/// Parses the tab size value from the command line
+fn parse_tab_size(size_str: &str) -> Result<usize, Box<LsError>> {
         size_str
             .parse::<usize>()
             .ok()
@@ -680,8 +680,9 @@ impl Config {
                     .and_then(|hex| usize::from_str_radix(hex, 16).ok())
             })
             .ok_or_else(|| Box::new(LsError::InvalidTabSize(size_str.to_string())))
-    }
+}
 
+impl Config {
     #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
         let context = options.get_flag(options::CONTEXT);
@@ -975,7 +976,7 @@ impl Config {
         let tab_size = if needs_color {
             Some(0)
         } else if let Some(size_str) = options.get_one::<String>(options::format::TAB_SIZE) {
-            match Self::parse_tab_size(size_str) {
+            match parse_tab_size(size_str) {
                 Ok(n) => Some(n),
                 Err(e) => return Err(e),
             }

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -681,7 +681,7 @@ impl Config {
             })
             .ok_or_else(|| Box::new(LsError::InvalidTabSize(size_str.to_string())))
     }
-    
+
     #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches) -> UResult<Self> {
         let context = options.get_flag(options::CONTEXT);

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -90,6 +90,9 @@ enum LsError {
     #[error("{}", translate!("ls-error-invalid-block-size", "size" => format!("'{_0}'")))]
     BlockSizeParseError(String),
 
+    #[error("{}", translate!("ls-error-invalid-tab-size", "size" => .0.quote()))]
+    InvalidTabSize(String),
+    
     #[error("{}", translate!("ls-error-dired-and-zero-incompatible"))]
     DiredAndZeroAreIncompatible,
 
@@ -111,6 +114,7 @@ impl UError for LsError {
             Self::DiredAndZeroAreIncompatible => 2,
             Self::AlreadyListedError(_) => 2,
             Self::TimeStyleParseError(_) => 2,
+            Self::InvalidTabSize(_) => 2,
         }
     }
 }

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -92,7 +92,7 @@ enum LsError {
 
     #[error("{}", translate!("ls-error-invalid-tab-size", "size" => .0.quote()))]
     InvalidTabSize(String),
-    
+
     #[error("{}", translate!("ls-error-dired-and-zero-incompatible"))]
     DiredAndZeroAreIncompatible,
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5299,6 +5299,7 @@ fn test_tabsize_option() {
 
     scene.ucmd().args(&["-T", "3"]).succeeds();
     scene.ucmd().args(&["--tabsize", "0"]).succeeds();
+    scene.ucmd().arg("--tabsize=-3").fails();
     scene.ucmd().args(&["-T", "0xff"]).succeeds();
     scene.ucmd().arg("-T").fails();
 }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5293,6 +5293,7 @@ fn test_symlink_target_extension_color() {
     assert!(target.contains("31m")); // 31 = red (our configured archive color)
 }
 
+#[test]
 fn test_tabsize_option() {
     let scene = TestScenario::new(util_name!());
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -5293,13 +5293,26 @@ fn test_symlink_target_extension_color() {
     assert!(target.contains("31m")); // 31 = red (our configured archive color)
 }
 
-#[test]
 fn test_tabsize_option() {
     let scene = TestScenario::new(util_name!());
 
     scene.ucmd().args(&["-T", "3"]).succeeds();
     scene.ucmd().args(&["--tabsize", "0"]).succeeds();
-    scene.ucmd().arg("--tabsize=-3").fails();
+    scene
+        .ucmd()
+        .arg("--tabsize=-3")
+        .fails()
+        .stderr_is("ls: invalid tab size: '-3'\n");
+    scene
+        .ucmd()
+        .arg("--tabsize=a")
+        .fails()
+        .stderr_is("ls: invalid tab size: 'a'\n");
+    scene
+        .ucmd()
+        .arg("--tabsize=3.14")
+        .fails()
+        .stderr_is("ls: invalid tab size: '3.14'\n");
     scene.ucmd().args(&["-T", "0xff"]).succeeds();
     scene.ucmd().arg("-T").fails();
 }


### PR DESCRIPTION
this PR resolves #12835
Whenever the value from --tabsize can't be parsed, it'll now throw an error, which message is identical to GNU's one. error code is 2, like in GNU, hexadecimal values are accepted