### PR TITLE
uucore: rename copy_stream to copy_fast to avoid confusion

### DIFF
--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -32,8 +32,7 @@ where
     let mut src = open_source(source, source_nofollow)?;
     let mut dst = create_dest_restrictive(dest, false)?;
     if ioctl_ficlone(&dst, &src).is_err() {
-        // faster than io::copy's copy_file_range and sendfile
-        buf_copy::copy_stream(&mut src, &mut dst)?;
+        buf_copy::copy_fast(&mut src, &mut dst)?;
     }
     Ok(())
 }
@@ -226,7 +225,7 @@ where
         dst_file.set_len(0)?;
     }
 
-    buf_copy::copy_stream(&mut src_file, &mut dst_file)
+    buf_copy::copy_fast(&mut src_file, &mut dst_file)
         .map_err(|e| std::io::Error::other(format!("{e}")))?;
 
     Ok(())

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -117,7 +117,7 @@ pub(crate) fn copy_on_write(
                 dst_file.set_len(0)?;
             }
 
-            buf_copy::copy_stream(&mut src_file, &mut dst_file)
+            buf_copy::copy_fast(&mut src_file, &mut dst_file)
                 .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
                 .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
         } else {

--- a/src/uu/cp/src/platform/other_unix.rs
+++ b/src/uu/cp/src/platform/other_unix.rs
@@ -52,7 +52,7 @@ pub(crate) fn copy_on_write(
             dst_file.set_len(0)?;
         }
 
-        buf_copy::copy_stream(&mut src_file, &mut dst_file)
+        buf_copy::copy_fast(&mut src_file, &mut dst_file)
             .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
             .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
 

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -21,7 +21,7 @@ use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 use std::process;
 use thiserror::Error;
 use uucore::backup_control::{self, BackupMode};
-use uucore::buf_copy::copy_stream;
+use uucore::buf_copy::copy_fast;
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
 use uucore::error::{FromIo, UError, UResult, UUsageError};
@@ -977,7 +977,7 @@ fn copy_file_safe(from: &Path, to_parent_fd: &DirFd, to_filename: &std::ffi::OsS
 
     let mut src = File::open(from)?;
     let mut dst = to_parent_fd.open_file_at(to_filename)?;
-    copy_stream(&mut src, &mut dst)?;
+    copy_fast(&mut src, &mut dst)?;
 
     Ok(())
 }
@@ -1032,7 +1032,7 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
         .mode(0o600)
         .open(to)?;
 
-    copy_stream(&mut handle, &mut dest).map_err(|err| {
+    copy_fast(&mut handle, &mut dest).map_err(|err| {
         InstallError::InstallFailed(from.to_path_buf(), to.to_path_buf(), err.to_string())
     })?;
 

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -1310,8 +1310,7 @@ fn rename_file_fallback(
             & 0o7777;
         let mut dst_file = create_dest_restrictive(to, /* nofollow */ true)
             .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
-        // copy_stream has fast-path for Linux
-        uucore::buf_copy::copy_stream(&mut &src_file, &mut dst_file)
+        uucore::buf_copy::copy_fast(&mut &src_file, &mut dst_file)
             .map_err(|err| io::Error::new(err.kind(), translate!("mv-error-permission-denied")))?;
 
         #[cfg(not(any(target_os = "macos", target_os = "redox")))]

--- a/src/uucore/src/lib/features/buf_copy.rs
+++ b/src/uucore/src/lib/features/buf_copy.rs
@@ -3,34 +3,32 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! This module provides several buffer-based copy/write functions that leverage
-//! the `splice` system call in Linux systems, thus increasing the I/O
-//! performance of copying between two file descriptors. This module is mostly
-//! used by utilities to work around the limitations of Rust's `fs::copy` which
+//! This module provides replacement for std::{io,fs}::copy without specialization for Linux
+//! related with reflink, but with splice syscall for better throughput.
+//! This module is also used as work around for the limitations of Rust's `fs::copy` which
 //! does not handle copying special files (e.g pipes, character/block devices).
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsFd;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn copy_stream(
+pub fn copy_fast(
     src: &mut (impl std::io::Read + AsFd),
     dest: &mut impl AsFd,
 ) -> std::io::Result<()> {
-    // try to splice() system call for throughput
     if crate::pipes::splice_unbounded_auto(src, dest)?.is_err() {
         // fall back on writing "without buffering", or order of output would be wrong
         // unrelated for cp /dev/stdin since cp does not have multiple input? <https://github.com/uutils/coreutils/issues/5186>
-        // RawWriter also removes io::copy's specialization slower than our splice
+        // RawWriter also removes io::copy's specialization e.g. copy_file_range which might use reflink
         std::io::copy(src, &mut crate::io::RawWriter(dest))?;
     }
     Ok(())
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-pub use std::io::copy as copy_stream;
+pub use std::io::copy as copy_fast;
 
 #[cfg(test)]
-#[cfg(any(target_os = "linux", target_os = "android"))] // copy_stream is io::copy on other platforms. nothing to test.
+#[cfg(any(target_os = "linux", target_os = "android"))] // copy_fast is io::copy on other platforms. nothing to test.
 mod tests {
     use super::*;
     use std::fs::File;
@@ -58,7 +56,7 @@ mod tests {
     }
 
     #[test]
-    fn test_copy_stream() {
+    fn test_copy_fast() {
         let mut dest_file = new_temp_file();
 
         let (mut pipe_read, mut pipe_write) = std::io::pipe().unwrap();
@@ -66,7 +64,7 @@ mod tests {
         let thread = thread::spawn(move || {
             pipe_write.write_all(data).unwrap();
         });
-        copy_stream(&mut pipe_read, &mut dest_file).unwrap();
+        copy_fast(&mut pipe_read, &mut dest_file).unwrap();
         thread.join().unwrap();
 
         // We would have been at the end already, so seek again to the start.


### PR DESCRIPTION
This fn actually works as reflink-less fast replacement for `std::io::copy` for non-stream input.
 This change immediately conflicts with https://github.com/uutils/coreutils/pull/13065 . So the change is included.