### PR TITLE
uucore, uptime: replace unsafe libc::clock_gettime by rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,7 +466,7 @@ rstest_reuse = "0.7.0"
 rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
 # raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
-rustix = { version = "1.1.4", features = ["param", "use-libc-auxv"] }
+rustix = { version = "1.1.4", features = ["param", "use-libc-auxv", "time"] }
 same-file = "1.0.6"
 self_cell = "1.0.4"
 selinux = "0.6"

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -98,30 +98,11 @@ fn get_macos_boot_time_sysctl() -> Option<time_t> {
 /// Returns a UResult with the uptime in seconds if successful, otherwise an UptimeError.
 #[cfg(target_os = "openbsd")]
 pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
-    use libc::CLOCK_BOOTTIME;
-    use libc::clock_gettime;
+    use rustix::time::{ClockId, clock_gettime};
 
-    use libc::c_int;
-    use libc::timespec;
+    let tp = clock_gettime(ClockId::Boottime);
 
-    let mut tp: timespec = timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-
-    // OpenBSD prototype: clock_gettime(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
-    let ret: c_int = unsafe { clock_gettime(CLOCK_BOOTTIME, &raw mut tp) };
-
-    if ret == 0 {
-        #[cfg(target_pointer_width = "64")]
-        let uptime: i64 = tp.tv_sec;
-        #[cfg(not(target_pointer_width = "64"))]
-        let uptime: i64 = tp.tv_sec.into();
-
-        Ok(uptime)
-    } else {
-        Err(UptimeError::SystemUptime)?
-    }
+    Ok(tp.tv_sec as i64)
 }
 
 /// Get the system uptime

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -97,6 +97,7 @@ fn get_macos_boot_time_sysctl() -> Option<time_t> {
 ///
 /// Returns a UResult with the uptime in seconds if successful, otherwise an UptimeError.
 #[cfg(target_os = "openbsd")]
+#[allow(clippy::unnecessary_wraps, reason = "needed on some platforms")]
 pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
     use rustix::time::{ClockId, clock_gettime};
 


### PR DESCRIPTION
this PR closes #13287
this pr replaces libc with rustix for get_uptime() for openbsd