### PR TITLE
Bump `crossbeam-epoch` from `0.9.18` to `0.9.20`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
This PR bumps `crossbeam-epoch` from `0.9.18` to `0.9.20` to address the issue from https://rustsec.org/advisories/RUSTSEC-2026-0204 and to make the `cargo-deny` job in the CI pass again.