### PR TITLE
kill: report write errors when listing signals instead of panicking

### DIFF
--- a/src/uu/kill/locales/en-US.ftl
+++ b/src/uu/kill/locales/en-US.ftl
@@ -12,3 +12,4 @@ kill-error-no-process-id = no process ID specified
 kill-error-invalid-signal = { $signal }: invalid signal
 kill-error-parse-argument = failed to parse argument { $argument }: { $error }
 kill-error-sending-signal = sending signal to { $pid } failed
+kill-error-write-error = write error: { $err }

--- a/src/uu/kill/locales/fr-FR.ftl
+++ b/src/uu/kill/locales/fr-FR.ftl
@@ -12,3 +12,4 @@ kill-error-no-process-id = aucun ID de processus spécifié
 kill-error-invalid-signal = { $signal } : signal invalide
 kill-error-parse-argument = échec de l'analyse de l'argument { $argument } : { $error }
 kill-error-sending-signal = échec de l'envoi du signal au processus { $pid }
+kill-error-write-error = erreur d'écriture : { $err }

--- a/src/uu/kill/src/kill.rs
+++ b/src/uu/kill/src/kill.rs
@@ -11,9 +11,9 @@ use rustix::process::{
     test_kill_current_process_group, test_kill_process, test_kill_process_group,
 };
 use std::cmp::Ordering;
-use std::io;
+use std::io::{self, BufWriter, Write};
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::error::{FromIo, UError, UResult, USimpleError, strip_errno};
 use uucore::translate;
 
 use uucore::signals::{
@@ -78,8 +78,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
             kill(sig, &pids);
         }
-        Mode::Table => table(),
-        Mode::List => list(&pids_or_signals),
+        Mode::Table => table()?,
+        Mode::List => list(&pids_or_signals)?,
     }
 
     Ok(())
@@ -159,12 +159,27 @@ fn handle_obsolete(args: &mut Vec<String>) -> UResult<Option<usize>> {
     Ok(None)
 }
 
-fn table() {
+// Turn a stdout write failure into a user-facing error carrying the OS error
+// message (e.g. "write error: No space left on device"), so a failed write to a
+// full/closed stdout is reported instead of panicking inside `println!`.
+fn stdout_write_error(err: io::Error) -> Box<dyn UError> {
+    USimpleError::new(
+        1,
+        translate!("kill-error-write-error", "err" => strip_errno(&err)),
+    )
+}
+
+fn table() -> UResult<()> {
+    // Buffer the listing so a failed write surfaces as one clean error at flush
+    // rather than the runtime's implicit-flush message on top of ours.
+    let mut out = BufWriter::new(io::stdout().lock());
     for signal_value in 0..=signal_number_upper_bound() {
         if let Some(signal_name) = signal_list_name_by_value(signal_value) {
-            println!("{signal_value: >#2} {signal_name}");
+            writeln!(out, "{signal_value: >#2} {signal_name}").map_err(stdout_write_error)?;
         }
     }
+    out.flush().map_err(stdout_write_error)?;
+    Ok(())
 }
 
 fn normalize_list_signal_value(signal_value: usize) -> Option<usize> {
@@ -181,40 +196,45 @@ fn normalize_list_signal_value(signal_value: usize) -> Option<usize> {
 }
 
 fn print_signal(signal_name_or_value: &str) -> UResult<()> {
-    if let Ok(signal_value) = signal_name_or_value.parse::<usize>() {
+    // Resolve the signal to the text kill would print, so the write path is the
+    // same for every branch (a single buffered write + flush).
+    let output = if let Some(signal_value) = signal_name_or_value
+        .parse::<usize>()
+        .ok()
+        .and_then(normalize_list_signal_value)
+    {
         // GNU kill accepts plain signal numbers, values masked to the low 8 bits,
         // and exit statuses that encode `128 + signal`.
-        if let Some(signal_value) = normalize_list_signal_value(signal_value) {
-            println!(
-                "{}",
-                signal_list_name_by_value(signal_value).unwrap_or_else(|| signal_value.to_string())
-            );
-            return Ok(());
-        }
-    }
+        signal_list_name_by_value(signal_value).unwrap_or_else(|| signal_value.to_string())
+    } else if let Some(signal_value) = signal_list_value_by_name_or_number(signal_name_or_value) {
+        signal_value.to_string()
+    } else {
+        return Err(USimpleError::new(
+            1,
+            translate!("kill-error-invalid-signal", "signal" => signal_name_or_value.quote()),
+        ));
+    };
 
-    if let Some(signal_value) = signal_list_value_by_name_or_number(signal_name_or_value) {
-        println!("{signal_value}");
-        return Ok(());
-    }
-
-    Err(USimpleError::new(
-        1,
-        translate!("kill-error-invalid-signal", "signal" => signal_name_or_value.quote()),
-    ))
+    let mut out = BufWriter::new(io::stdout().lock());
+    writeln!(out, "{output}").map_err(stdout_write_error)?;
+    out.flush().map_err(stdout_write_error)?;
+    Ok(())
 }
 
-fn print_signals() {
+fn print_signals() -> UResult<()> {
+    let mut out = BufWriter::new(io::stdout().lock());
     for signal_value in 0..=signal_number_upper_bound() {
         if let Some(signal_name) = signal_list_name_by_value(signal_value) {
-            println!("{signal_name}");
+            writeln!(out, "{signal_name}").map_err(stdout_write_error)?;
         }
     }
+    out.flush().map_err(stdout_write_error)?;
+    Ok(())
 }
 
-fn list(signals: &Vec<String>) {
+fn list(signals: &Vec<String>) -> UResult<()> {
     if signals.is_empty() {
-        print_signals();
+        print_signals()?;
     } else {
         for signal in signals {
             if let Err(e) = print_signal(signal) {
@@ -222,6 +242,7 @@ fn list(signals: &Vec<String>) {
             }
         }
     }
+    Ok(())
 }
 
 fn rustix_to_io(result: rustix::io::Result<()>) -> io::Result<()> {

--- a/tests/by-util/test_kill.rs
+++ b/tests/by-util/test_kill.rs
@@ -491,6 +491,25 @@ fn test_kill_with_signal_and_table() {
         .fails();
 }
 
+// Listing signals to a full device must report the write error and exit
+// non-zero, not panic/abort. Covers -l, -l <name>, --list <number>, and --table.
+#[cfg(target_os = "linux")]
+#[test]
+fn test_kill_list_signals_write_error_is_reported() {
+    for args in [
+        vec!["-l"],
+        vec!["-l", "TERM"],
+        vec!["--list", "9"],
+        vec!["--table"],
+    ] {
+        new_ucmd!()
+            .args(&args)
+            .set_stdout(std::fs::File::create("/dev/full").unwrap())
+            .fails()
+            .stderr_is("kill: write error: No space left on device\n");
+    }
+}
+
 /// Test that `kill -1` (signal without PID) reports "no process ID" error
 /// instead of being misinterpreted as pid=-1 which would kill all processes.
 /// This matches GNU kill behavior.


### PR DESCRIPTION
Fixes #13297

`kill -l`, `kill -l <sig>`, `kill --list`, and `kill --table` print their output
with `println!`, whose internal `io::stdout().write_fmt().unwrap()` aborts the
process (SIGABRT, exit 134) when the stdout write fails. 

Adds a `kill-error-write-error` locale key (en-US, fr-FR) and a regression test
that lists signals to `/dev/full`.
