### PR TITLE
docs: fix macOS tier 1 targets and platform compatibility table

### DIFF
--- a/docs/src/platforms.md
+++ b/docs/src/platforms.md
@@ -22,7 +22,7 @@ The platforms in tier 1 and the platforms that we test in CI are listed below.
 | Operating system | Tested targets           |
 | ---------------- | ------------------------ |
 | **Linux**        | `x86_64-unknown-linux-gnu` <br> `x86_64-unknown-linux-musl` <br> `arm-unknown-linux-gnueabihf` <br> `i686-unknown-linux-gnu` <br> `aarch64-unknown-linux-gnu` |
-| **macOS**        | `x86_64-apple-darwin`    |
+| **macOS**        | `x86_64-apple-darwin` <br> `aarch64-apple-darwin` |
 | **Windows**      | `i686-pc-windows-msvc` <br> `x86_64-pc-windows-gnu` <br> `x86_64-pc-windows-msvc` |
 | **FreeBSD**      | `x86_64-unknown-freebsd` |
 | **OpenBSD**      | `x86_64-unknown-openbsd` |

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -283,10 +283,16 @@ fn main() -> io::Result<()> {
     println!("Gathering utils per platform");
     let utils_per_platform = {
         let mut map = HashMap::new();
-        for platform in ["unix", "macos", "windows", "unix_android"] {
+        // macOS uses the generic Unix feature set; there is no dedicated `feat_os_macos`.
+        for (platform, features) in [
+            ("unix", "feat_os_unix"),
+            ("macos", "feat_os_unix"),
+            ("windows", "feat_os_windows"),
+            ("unix_android", "feat_os_unix_android"),
+        ] {
             let platform_utils: Vec<String> = String::from_utf8(
                 process::Command::new("./util/show-utils.sh")
-                    .arg(format!("--features=feat_os_{platform}"))
+                    .arg(format!("--features={features}"))
                     .output()?
                     .stdout,
             )

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -283,7 +283,6 @@ fn main() -> io::Result<()> {
     println!("Gathering utils per platform");
     let utils_per_platform = {
         let mut map = HashMap::new();
-        // macOS uses the generic Unix feature set; there is no dedicated `feat_os_macos`.
         for (platform, features) in [
             ("unix", "feat_os_unix"),
             ("macos", "feat_os_unix"),

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -285,7 +285,6 @@ fn main() -> io::Result<()> {
         let mut map = HashMap::new();
         for (platform, features) in [
             ("unix", "feat_os_unix"),
-            ("macos", "feat_os_unix"),
             ("windows", "feat_os_windows"),
             ("unix_android", "feat_os_unix_android"),
         ] {
@@ -352,7 +351,7 @@ fn main() -> io::Result<()> {
                 "| {:<16} | {:<5} | {:<5} | {:<7} | {:<7} | {:<7} |",
                 format!("**{name}**"),
                 check_supported(name, "linux"),
-                check_supported(name, "macos"),
+                check_supported(name, "unix"),
                 check_supported(name, "windows"),
                 check_supported(name, "unix"),
                 check_supported(name, "unix_android"),
@@ -493,7 +492,8 @@ impl MDWriter<'_, '_> {
             ("linux", "linux"),
             // freebsd is disabled for now because mdbook does not use font-awesome 5 yet.
             // ("unix", "freebsd"),
-            ("macos", "apple"),
+            // macOS uses the same feature set as generic Unix.
+            ("unix", "apple"),
             ("windows", "windows"),
         ] {
             if self.name.contains("sum")


### PR DESCRIPTION
This PR fixes two documentation issues regarding macOS:

1. Add `aarch64-apple-darwin` to the tier 1 macOS targets, as it is already tested in CI (see `.github/workflows/CICD.yml`).
2. Fix `uudoc.rs` to use `feat_os_unix` for macOS instead of the non-existent `feat_os_macos`, which caused the platform compatibility table to show almost no macOS support.