### PR TITLE
ls: allow --sort, --format, --time, --block-size without '='

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -160,7 +160,6 @@ pub fn uu_app() -> Command {
                 "commas",
             ]))
             .hide_possible_values(true)
-            .require_equals(true)
             .overrides_with_all([
                 options::FORMAT,
                 options::format::COLUMNS,
@@ -385,7 +384,6 @@ pub fn uu_app() -> Command {
                 PossibleValue::new("birth").alias("creation"),
             ]))
             .hide_possible_values(true)
-            .require_equals(true)
             .overrides_with_all([options::TIME, options::time::ACCESS, options::time::CHANGE]),
     )
     .arg(
@@ -440,7 +438,6 @@ pub fn uu_app() -> Command {
                 "extension",
                 "width",
             ]))
-            .require_equals(true)
             .overrides_with_all([
                 options::SORT,
                 options::sort::SIZE,
@@ -627,7 +624,6 @@ pub fn uu_app() -> Command {
     .arg(
         Arg::new(options::size::BLOCK_SIZE)
             .long(options::size::BLOCK_SIZE)
-            .require_equals(true)
             .value_name("BLOCK_SIZE")
             .help(translate!("ls-help-block-size"))
             .overrides_with_all([options::size::SI, options::size::HUMAN_READABLE]),

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7443,3 +7443,38 @@ fn test_ls_al_no_capabilities_insufficient_on_wasi() {
         out.stdout_str()
     );
 }
+
+/// Regression tests for #13280: --sort, --format, --time, --block-size must
+/// accept their argument with a space (not only with '=').
+#[test]
+fn test_sort_accepts_space_separated_argument() {
+    // --sort name (space, not =) must work like --sort=name
+    new_ucmd!()
+        .args(&["--sort", "name"])
+        .succeeds()
+        .no_stderr();
+}
+
+#[test]
+fn test_format_accepts_space_separated_argument() {
+    new_ucmd!()
+        .args(&["--format", "long"])
+        .succeeds()
+        .no_stderr();
+}
+
+#[test]
+fn test_time_accepts_space_separated_argument() {
+    new_ucmd!()
+        .args(&["--time", "mtime"])
+        .succeeds()
+        .no_stderr();
+}
+
+#[test]
+fn test_block_size_accepts_space_separated_argument() {
+    new_ucmd!()
+        .args(&["--block-size", "1K"])
+        .succeeds()
+        .no_stderr();
+}


### PR DESCRIPTION
## Summary

`ls --sort name /` fails with:

```
error: equal sign is needed when assigning values to '--sort=<field>'
```

The four options `--sort`, `--format`, `--time`, and `--block-size` had
`.require_equals(true)` in their clap definition, which forced the
`--opt=value` syntax and rejected the space-separated `--opt value`
form.  GNU ls accepts both forms.

## Fix

Remove `.require_equals(true)` from the four affected options.

The optional-value flags `--color`, `--classify`, and `--hyperlink` are
**not** changed — they use `num_args(0..=1)` with a `default_missing_value`,
and they legitimately need `require_equals` so clap can tell whether
the next word is the option's value or a file operand.

`--sort`, `--format`, `--time`, and `--block-size` always consume
exactly one value, so the space-separated form is unambiguous.

## Changes

- `src/uu/ls/src/ls.rs`: remove `.require_equals(true)` from `FORMAT`,
  `TIME`, `SORT`, and `size::BLOCK_SIZE`.
- `tests/by-util/test_ls.rs`: four regression tests, one per option.

Fixes #13280