### PR TITLE
cp: don't panic on write error when printing --verbose output

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2263,18 +2263,22 @@ fn print_verbose_output(
     progress_bar: Option<&ProgressBar>,
     source: &Path,
     dest: &Path,
-) {
+) -> CopyResult<()> {
     if let Some(pb) = progress_bar {
         // Suspend (hide) the progress bar so the println won't overlap with the progress bar.
-        pb.suspend(|| {
-            print_paths(parents, source, dest);
-        });
+        pb.suspend(|| print_paths(parents, source, dest))
     } else {
-        print_paths(parents, source, dest);
+        print_paths(parents, source, dest)
     }
 }
 
-fn print_paths(parents: bool, source: &Path, dest: &Path) {
+fn print_paths(parents: bool, source: &Path, dest: &Path) -> CopyResult<()> {
+    use std::io::Write;
+
+    // Buffer the output so a failed write (e.g. stdout redirected to a full
+    // disk) surfaces as one error instead of panicking inside println!.
+    let mut out = io::BufWriter::new(io::stdout().lock());
+    let write_err = |e| CpError::IoErrContext(e, translate!("cp-error-write"));
     if parents {
         // For example, if copying file `a/b/c` and its parents
         // to directory `d/`, then print
@@ -2283,11 +2287,13 @@ fn print_paths(parents: bool, source: &Path, dest: &Path) {
         //     a/b -> d/a/b
         //
         for (x, y) in aligned_ancestors(source, dest) {
-            println!("{} -> {}", x.display(), y.display());
+            writeln!(out, "{} -> {}", x.display(), y.display()).map_err(write_err)?;
         }
     }
 
-    println!("{}", context_for(source, dest));
+    writeln!(out, "{}", context_for(source, dest)).map_err(write_err)?;
+    out.flush().map_err(write_err)?;
+    Ok(())
 }
 
 /// Handles the copy mode for a file copy operation.
@@ -2612,7 +2618,7 @@ fn copy_file(
             fs::hard_link(new_source, dest)?;
 
             if options.verbose {
-                print_verbose_output(options.parents, progress_bar, source, dest);
+                print_verbose_output(options.parents, progress_bar, source, dest)?;
             }
 
             return Ok(());
@@ -2662,7 +2668,7 @@ fn copy_file(
     )?;
 
     if options.verbose && performed_action != PerformedAction::Skipped {
-        print_verbose_output(options.parents, progress_bar, source, dest);
+        print_verbose_output(options.parents, progress_bar, source, dest)?;
     }
 
     // TODO: implement something similar to gnu's lchown

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -104,6 +104,23 @@ fn test_cp_stream_to_full() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_cp_verbose_write_error_is_reported() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("source_file");
+    ucmd.arg("--verbose")
+        .arg("source_file")
+        .arg("dest_file")
+        .set_stdout(std::fs::File::create("/dev/full").unwrap())
+        .fails()
+        .stderr_is("cp: write error: No space left on device\n");
+
+    // The copy itself should still succeed even though reporting it on
+    // stdout failed.
+    assert!(at.file_exists("dest_file"));
+}
+
+#[test]
 fn test_cp_cp() {
     let (at, mut ucmd) = at_and_ucmd!();
     // Invoke our binary to make the copy.


### PR DESCRIPTION
println! panics if the write fails, e.g. stdout redirected to a full disk. Buffered the output and made it return a normal error instead, matching GNU's wording.

Fixes #13060