### PR TITLE
stty: avoid overflow when rounding max baud rate

### DIFF
--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -748,14 +748,14 @@ fn parse_baud_with_rounding(normalized: &str) -> Option<u32> {
         }
 
         match first_digit.cmp(&5) {
-            Ordering::Greater => value += 1,
+            Ordering::Greater => value = value.checked_add(1)?,
             Ordering::Equal => {
                 // Check if any non-zero digit follows
                 if rest.iter().any(|&c| c != '0') {
-                    value += 1;
+                    value = value.checked_add(1)?;
                 } else {
                     // Banker's rounding: round to nearest even
-                    value += value & 1;
+                    value = value.checked_add(value & 1)?;
                 }
             }
             Ordering::Less => {} // Round down, already validated
@@ -1486,6 +1486,14 @@ mod tests {
             assert_eq!(string_to_baud("", flags::BaudType::Both), None);
             assert_eq!(string_to_baud("abc", flags::BaudType::Both), None);
         }
+    }
+
+    #[test]
+    fn test_parse_baud_with_rounding_rejects_u32_overflow() {
+        assert_eq!(parse_baud_with_rounding("4294967295.4"), Some(u32::MAX));
+        assert_eq!(parse_baud_with_rounding("4294967295.6"), None);
+        assert_eq!(parse_baud_with_rounding("4294967295.5"), None);
+        assert_eq!(parse_baud_with_rounding("4294967295.5001"), None);
     }
 
     // Tests for string_to_combo


### PR DESCRIPTION
## Description

Fixes #13317.

`parse_baud_with_rounding` now rejects fractional baud rates that would round past `u32::MAX` instead of overflowing during the rounding step. Values that round down to `u32::MAX` still parse successfully.

Note: I used Codex to help prepare this change, reviewed the final diff, and ran the listed checks locally. I did not use or reference GNU source code.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p uu_stty test_parse_baud_with_rounding_rejects_u32_overflow`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p uu_stty`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" make UTILS='stty' test`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p uu_stty --all-targets -- -D warnings`