### PR TITLE
touch: report original input in -t timestamp error message

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -862,7 +862,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
         .map_err(|_| {
             USimpleError::new(
                 1,
-                translate!("touch-error-invalid-date-ts-format", "date" => ts.quote()),
+                translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),
             )
         })?;
 
@@ -883,7 +883,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
         .map_err(|_| {
             USimpleError::new(
                 1,
-                translate!("touch-error-invalid-date-ts-format", "date" => ts.quote()),
+                translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),
             )
         })?;
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -1025,6 +1025,16 @@ fn test_touch_invalid_timestamp_leading_multibyte_char() {
 }
 
 #[test]
+fn test_touch_invalid_timestamp_reports_original_input() {
+    for ts in ["2026-04-10", "26-04-10", "00000000"] {
+        new_ucmd!()
+            .args(&["-t", ts, "f"])
+            .fails_with_code(1)
+            .stderr_only(format!("touch: invalid date ts format '{ts}'\n"));
+    }
+}
+
+#[test]
 #[cfg(not(target_os = "freebsd"))]
 fn test_touch_symlink_with_no_deref() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Fixes #13132

`touch -t 2026-04-10` reported `invalid date ts format '202026-04-10'`,
echoing the century-prefixed internal form built by `parse_timestamp`
instead of the user's original input. The two error paths
(`strtime::parse` failure and DST `unambiguous` failure) now reference the
original string, matching the `prepend_century` error path which already
did so.

```
$ coreutils touch -t 2026-04-10 a   # before
touch: invalid date ts format '202026-04-10'
$ coreutils touch -t 2026-04-10 a   # after
touch: invalid date ts format '2026-04-10'
```

Adds a regression test covering the 8-, 10- and 13-character branches.