### PR TITLE
touch: remove unnecessary error msg

### DIFF
--- a/src/uu/touch/locales/en-US.ftl
+++ b/src/uu/touch/locales/en-US.ftl
@@ -21,7 +21,6 @@ touch-error-cannot-touch = cannot touch { $filename }
 touch-error-no-such-file-or-directory = No such file or directory
 touch-error-failed-to-get-attributes = failed to get attributes of { $path }
 touch-error-setting-times-of-path = setting times of { $path }
-touch-error-invalid-date-ts-format = invalid date ts format { $date }
 touch-error-invalid-date-format = invalid date format { $date }
 touch-error-unable-to-parse-date = Unable to parse date: { $date }
 touch-error-windows-stdout-path-failed = GetFinalPathNameByHandleW failed with code { $code }

--- a/src/uu/touch/locales/fr-FR.ftl
+++ b/src/uu/touch/locales/fr-FR.ftl
@@ -22,7 +22,6 @@ touch-error-cannot-touch = impossible de toucher { $filename }
 touch-error-no-such-file-or-directory = Aucun fichier ou répertoire de ce type
 touch-error-failed-to-get-attributes = échec d'obtention des attributs de { $path }
 touch-error-setting-times-of-path = définition des temps de { $path }
-touch-error-invalid-date-ts-format = format de date ts invalide { $date }
 touch-error-invalid-date-format = format de date invalide { $date }
 touch-error-unable-to-parse-date = Impossible d'analyser la date : { $date }
 touch-error-windows-stdout-path-failed = GetFinalPathNameByHandleW a échoué avec le code { $code }

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -819,7 +819,7 @@ fn prepend_century(s: &str) -> UResult<String> {
     let first_two_digits = first_two.parse::<u32>().map_err(|_| {
         USimpleError::new(
             1,
-            translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),
+            translate!("touch-error-invalid-date-format", "date" => s.quote()),
         )
     })?;
     Ok(format!(
@@ -862,7 +862,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
         .map_err(|_| {
             USimpleError::new(
                 1,
-                translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),
+                translate!("touch-error-invalid-date-format", "date" => s.quote()),
             )
         })?;
 
@@ -883,7 +883,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
         .map_err(|_| {
             USimpleError::new(
                 1,
-                translate!("touch-error-invalid-date-ts-format", "date" => s.quote()),
+                translate!("touch-error-invalid-date-format", "date" => s.quote()),
             )
         })?;
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -1020,7 +1020,7 @@ fn test_touch_invalid_timestamp_leading_multibyte_char() {
         new_ucmd!()
             .args(&["-t", ts, "f"])
             .fails_with_code(1)
-            .stderr_only(format!("touch: invalid date ts format '{ts}'\n"));
+            .stderr_only(format!("touch: invalid date format '{ts}'\n"));
     }
 }
 
@@ -1030,7 +1030,7 @@ fn test_touch_invalid_timestamp_reports_original_input() {
         new_ucmd!()
             .args(&["-t", ts, "f"])
             .fails_with_code(1)
-            .stderr_only(format!("touch: invalid date ts format '{ts}'\n"));
+            .stderr_only(format!("touch: invalid date format '{ts}'\n"));
     }
 }
 


### PR DESCRIPTION
This PR removes the error message "invalid date ts format" and uses "invalid date format" instead.