### PR TITLE
install: remove unused cfg

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -1144,7 +1144,6 @@ fn finalize_installed_file(
     b: &Behavior,
     backup_path: Option<PathBuf>,
 ) -> UResult<()> {
-    #[cfg(not(windows))]
     if b.strip {
         strip_file(to, b)?;
     }


### PR DESCRIPTION
Windows native strip exists https://packages.msys2.org/packages/mingw-w64-ucrt-x86_64-binutils