### PR TITLE
touch: parse unpadded dates in local time

### DIFF
--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -126,9 +126,6 @@ mod format {
     pub(crate) const YYYYMMDDHHMMSS: &str = "%Y-%m-%d %H:%M:%S.%f";
     // "%Y-%m-%d %H:%M:%S" 12 chars
     pub(crate) const YYYYMMDDHHMMS: &str = "%Y-%m-%d %H:%M:%S";
-    // "%Y-%m-%d %H:%M" 12 chars
-    // Used for example in tests/touch/no-rights.sh
-    pub(crate) const YYYY_MM_DD_HH_MM: &str = "%Y-%m-%d %H:%M";
     // "%Y%m%d%H%M" 12 chars
     pub(crate) const YYYYMMDDHHMM: &str = "%Y%m%d%H%M";
     // "%Y-%m-%d %H:%M +offset"
@@ -765,7 +762,6 @@ fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
     for fmt in [
         format::YYYYMMDDHHMMS,
         format::YYYYMMDDHHMMSS,
-        format::YYYY_MM_DD_HH_MM,
         format::YYYYMMDDHHMM_OFFSET,
     ] {
         if let Ok(parsed) = strtime::parse(fmt, s)

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -622,6 +622,22 @@ fn test_touch_set_date7() {
     assert_eq!(mtime, expected);
 }
 
+#[test]
+fn test_touch_set_date_without_leading_zeroes() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_touch_set_date_without_leading_zeroes";
+
+    ucmd.env("TZ", "UTC-8")
+        .args(&["-d", "2026-6-27 13:12", file])
+        .succeeds()
+        .no_stderr();
+
+    let expected = FileTime::from_unix_time(1_782_537_120, 0);
+    let (atime, mtime) = get_file_times(&at, file);
+    assert_eq!(atime, expected);
+    assert_eq!(mtime, expected);
+}
+
 /// Regression test for https://github.com/uutils/coreutils/issues/11804
 ///
 /// Setting a pre-epoch date like `0000-01-01` used to panic on 32-bit targets


### PR DESCRIPTION
Fixes #13134.

`%Y-%m-%d %H:%M` was handled by a special-case parser that converted the parsed civil time using UTC. As a result, timestamps without an explicit timezone were shifted by the local UTC offset.

Remove that format from the UTC-specific fast path and let the existing `parse_datetime_at_date` fallback handle it. The format remains accepted, but is now interpreted in the configured local timezone.

A regression test uses a non-UTC `TZ` value and the input from the issue.