### PR TITLE
sort: use locale_cmp when all selectors have equal ordering

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2790,11 +2790,11 @@ fn compare_by<'a>(
     } else {
         #[cfg(feature = "i18n-collator")]
         {
-        locale_cmp(a.line, b.line)
+            locale_cmp(a.line, b.line)
         }
         #[cfg(not(feature = "i18n-collator"))]
         {
-        a.line.cmp(b.line)
+            a.line.cmp(b.line)
         }
     };
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2788,7 +2788,14 @@ fn compare_by<'a>(
     {
         Ordering::Equal
     } else {
+        #[cfg(feature = "i18n-collator")]
+        {
+        locale_cmp(a.line, b.line)
+        }
+        #[cfg(not(feature = "i18n-collator"))]
+        {
         a.line.cmp(b.line)
+        }
     };
 
     if global_settings.reverse {

--- a/src/uucore/src/lib/features/i18n/collator.rs
+++ b/src/uucore/src/lib/features/i18n/collator.rs
@@ -31,8 +31,14 @@ pub fn init_collator(opts: CollatorOptions) {
 }
 
 /// Check if locale collation should be used.
+///
+/// The result is cached, since `DEFAULT_LOCALE` is a `const` that materializes a
+/// fresh heap-backed `Locale` on every evaluation. Comparing against it on each
+/// call (e.g. once per comparison in a sort) is measurably expensive, so we
+/// compute the decision once and reuse it.
 pub fn should_use_locale_collation() -> bool {
-    get_collating_locale().0 != DEFAULT_LOCALE
+    static USE_LOCALE_COLLATION: OnceLock<bool> = OnceLock::new();
+    *USE_LOCALE_COLLATION.get_or_init(|| get_collating_locale().0 != DEFAULT_LOCALE)
 }
 
 /// Initialize the collator for locale-aware string comparison if needed.
@@ -88,13 +94,15 @@ pub fn compute_sort_key_utf8(input: &[u8], buf: &mut Vec<u8>) {
 
 /// Compare both strings with regard to the current locale.
 pub fn locale_cmp(left: &[u8], right: &[u8]) -> Ordering {
-    // If the detected locale is 'C', just do byte-wise comparison
-    if get_collating_locale().0 == DEFAULT_LOCALE {
-        left.cmp(right)
-    } else {
+    // If the detected locale is 'C', just do byte-wise comparison.
+    // `should_use_locale_collation` caches this decision, avoiding the
+    // construction of a fresh `DEFAULT_LOCALE` on every call (hot path in sort).
+    if should_use_locale_collation() {
         // Fall back to byte comparison if collator is not available
         COLLATOR
             .get()
             .map_or_else(|| left.cmp(right), |c| c.compare_utf8(left, right))
+    } else {
+        left.cmp(right)
     }
 }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -304,6 +304,16 @@ fn test_numeric_with_trailing_invalid_chars() {
 }
 
 #[test]
+fn test_numeric_with_trailing_chars_and_same_number() {
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-n")
+        .pipe_in("1 x\n1 ./b\n1 a\n")
+        .succeeds()
+        .stdout_is("1 a\n1 ./b\n1 x\n");
+}
+
+#[test]
 fn test_numeric_sort_rejects_leading_plus_sign() {
     // GNU sort -n does not treat '+' as a number sign; lines sort lexicographically.
     new_ucmd!()


### PR DESCRIPTION
Fixes #13319.

When all selectors return `Ordering::Equal` in `compare_by`, the last resort was to use byte-by-byte comparison, ignoring the locale.

The change now resorts to use `locale_cmp` if `i18n-collator` is enabled.