### PR TITLE
runcon: report a stdout write error instead of panicking

### DIFF
--- a/src/uu/runcon/locales/en-US.ftl
+++ b/src/uu/runcon/locales/en-US.ftl
@@ -21,6 +21,7 @@ runcon-error-no-command = No command is specified
 runcon-error-selinux-not-enabled = runcon may be used only on a SELinux kernel
 runcon-error-operation-failed = { $operation } failed
 runcon-error-operation-failed-on = { $operation } failed on { $operand }
+runcon-error-write = write error: { $error }
 
 # Operation names
 runcon-operation-getting-current-context = Getting security context of the current process

--- a/src/uu/runcon/locales/fr-FR.ftl
+++ b/src/uu/runcon/locales/fr-FR.ftl
@@ -21,6 +21,7 @@ runcon-error-no-command = Aucune commande n'est spécifiée
 runcon-error-selinux-not-enabled = runcon ne peut être utilisé que sur un noyau SELinux
 runcon-error-operation-failed = { $operation } a échoué
 runcon-error-operation-failed-on = { $operation } a échoué sur { $operand }
+runcon-error-write = erreur d'écriture : { $error }
 
 # Noms d'opération
 runcon-operation-getting-current-context = Obtention du contexte de sécurité du processus actuel

--- a/src/uu/runcon/src/errors.rs
+++ b/src/uu/runcon/src/errors.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::str::Utf8Error;
 
 use uucore::display::Quotable;
-use uucore::error::UError;
+use uucore::error::{UError, strip_errno};
 use uucore::translate;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -57,6 +57,9 @@ pub(crate) enum Error {
         operand1: OsString,
         source: io::Error,
     },
+
+    #[error("{}", translate!("runcon-error-write", "error" => strip_errno(.0)))]
+    Write(io::Error),
 }
 
 impl Error {
@@ -132,6 +135,7 @@ impl UError for Error {
             Self::SELinux { .. } => error_exit_status::ANOTHER_ERROR,
             Self::Io { .. } => error_exit_status::ANOTHER_ERROR,
             Self::Io1 { .. } => error_exit_status::ANOTHER_ERROR,
+            Self::Write(_) => error_exit_status::ANOTHER_ERROR,
         }
     }
 }

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -18,6 +18,7 @@ use uucore::format_usage;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::io;
+use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::process::CommandExt;
 use std::process;
@@ -242,12 +243,14 @@ fn print_current_context() -> Result<()> {
         .to_c_string()
         .map_err(|r| Error::from_selinux("runcon-operation-getting-current-context", r))?;
 
-    if let Some(context) = context {
+    let mut out = io::stdout().lock();
+    let result = if let Some(context) = context {
         let context = context.as_ref().to_str()?;
-        println!("{context}");
+        writeln!(out, "{context}").and_then(|()| out.flush())
     } else {
-        println!();
-    }
+        writeln!(out).and_then(|()| out.flush())
+    };
+    result.map_err(Error::Write)?;
     Ok(())
 }
 

--- a/tests/by-util/test_runcon.rs
+++ b/tests/by-util/test_runcon.rs
@@ -46,6 +46,18 @@ fn print() {
     }
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn print_context_write_error_reported_not_panic() {
+    use std::fs::OpenOptions;
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+    new_ucmd!()
+        .set_stdout(dev_full)
+        .fails_with_code(1)
+        .stderr_is("runcon: write error: No space left on device\n");
+}
+
 #[test]
 fn invalid() {
     new_ucmd!().arg("invalid").fails_with_code(1);


### PR DESCRIPTION
Fixes #13379

`runcon` with no arguments prints the current SELinux context with `println!`, which aborts (exit 134) when the stdout write fails — e.g. output redirected to a full device. GNU reports the write error and exits 1.

`print_current_context` now writes to a locked stdout and propagates the `io::Error` as a new `Error::Write`, so a write failure is reported as `write error: <reason>` (exit 1), matching GNU.

Before:

```console
$ runcon > /dev/full
thread 'main' panicked at library/std/src/io/stdio.rs:...:
failed printing to stdout: No space left on device (os error 28)
Aborted (core dumped)          # exit 134
```

After:

```console
$ runcon > /dev/full
runcon: write error: No space left on device        # exit 1
```

This matches GNU byte-for-byte (`/usr/bin/runcon: write error: No space left on device`, exit 1) and is the same write-error class as chcon (#13061) and kill (#13297). A regression test is added (`/dev/full`, Linux-gated).
