### PR TITLE
chown, chgrp: report a verbose stdout write error instead of panicking

### DIFF
--- a/src/uu/chgrp/src/main.rs
+++ b/src/uu/chgrp/src/main.rs
@@ -3,4 +3,4 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-uucore::bin!(uu_chgrp);
+uucore::bin!(uu_chgrp, no_flush);

--- a/src/uu/chown/src/main.rs
+++ b/src/uu/chown/src/main.rs
@@ -3,4 +3,4 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-uucore::bin!(uu_chown);
+uucore::bin!(uu_chown, no_flush);

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -10,7 +10,9 @@
 use crate::display::Quotable;
 use crate::error::{UResult, USimpleError, strip_errno};
 pub use crate::features::entries;
-use crate::show_error;
+use crate::{show_error, translate};
+
+use thiserror::Error;
 
 use clap::{Arg, ArgMatches, Command};
 
@@ -36,6 +38,12 @@ use std::os::unix::fs::MetadataExt;
 
 use std::os::unix::ffi::OsStrExt;
 use std::path::{MAIN_SEPARATOR, Path};
+
+#[derive(Debug, Error)]
+enum PermsError {
+    #[error("{}: {}", translate!("common-write-error"), strip_errno(.0))]
+    Write(IOError),
+}
 
 /// The various level of verbosity
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -278,9 +286,14 @@ pub fn get_metadata(file: &Path, follow: bool) -> Result<Metadata, std::io::Erro
 
 impl ChownExecutor {
     pub fn exec(&self) -> UResult<()> {
+        use std::io::Write;
         let mut ret = 0;
         for f in &self.files {
             ret |= self.traverse(f);
+        }
+        if let Err(e) = std::io::stdout().flush() {
+            show_error!("{}", PermsError::Write(e));
+            ret |= 1;
         }
         if ret != 0 {
             return Err(ret.into());
@@ -293,11 +306,11 @@ impl ChownExecutor {
         let path = root.as_ref();
         let Some(meta) = self.obtain_meta(path, self.dereference) else {
             if self.verbosity.level == VerbosityLevel::Verbose {
-                println!(
+                self.write_verbose_line(&format!(
                     "failed to change ownership of {} to {}",
                     path.quote(),
                     self.raw_owner
-                );
+                ));
             }
             return 1;
         };
@@ -367,8 +380,7 @@ impl ChownExecutor {
                 path,
                 meta.uid(),
                 self.dest_gid.map(|_| meta.gid()),
-            );
-            0
+            )
         };
 
         if self.recursive {
@@ -550,12 +562,13 @@ impl ChownExecutor {
                     // Report the successful ownership change using the shared helper
                     self.report_ownership_change_success(&entry_path, meta.uid(), meta.gid());
                 }
-            } else {
-                self.print_verbose_ownership_retained_as(
-                    &entry_path,
-                    meta.uid(),
-                    self.dest_gid.map(|_| meta.gid()),
-                );
+            } else if self.print_verbose_ownership_retained_as(
+                &entry_path,
+                meta.uid(),
+                self.dest_gid.map(|_| meta.gid()),
+            ) != 0
+            {
+                *ret = 1;
             }
 
             // Recurse into subdirectories. Open with the same symlink behavior
@@ -645,11 +658,14 @@ impl ChownExecutor {
             }
 
             if !self.matched(meta.uid(), meta.gid()) {
-                self.print_verbose_ownership_retained_as(
+                if self.print_verbose_ownership_retained_as(
                     path,
                     meta.uid(),
                     self.dest_gid.map(|_| meta.gid()),
-                );
+                ) != 0
+                {
+                    ret = 1;
+                }
                 continue;
             }
             ret = match wrap_chown(
@@ -704,7 +720,14 @@ impl ChownExecutor {
         }
     }
 
-    fn print_verbose_ownership_retained_as(&self, path: &Path, uid: u32, gid: Option<u32>) {
+    /// Write a verbose line to stdout without panicking. Returns 1 on write
+    /// failure; the error is reported once at the final flush in `exec`.
+    fn write_verbose_line(&self, line: &str) -> i32 {
+        use std::io::Write;
+        i32::from(writeln!(std::io::stdout(), "{line}").is_err())
+    }
+
+    fn print_verbose_ownership_retained_as(&self, path: &Path, uid: u32, gid: Option<u32>) -> i32 {
         if self.verbosity.level == VerbosityLevel::Verbose {
             let ownership = match (self.dest_uid, self.dest_gid, gid) {
                 (Some(_), Some(_), Some(gid)) => format!(
@@ -717,12 +740,14 @@ impl ChownExecutor {
                 }
                 _ => entries::uid2usr(uid).unwrap_or_else(|_| uid.to_string()),
             };
-            if self.verbosity.groups_only {
-                println!("group of {} retained as {ownership}", path.quote());
+            let line = if self.verbosity.groups_only {
+                format!("group of {} retained as {ownership}", path.quote())
             } else {
-                println!("ownership of {} retained as {ownership}", path.quote());
-            }
+                format!("ownership of {} retained as {ownership}", path.quote())
+            };
+            return self.write_verbose_line(&line);
         }
+        0
     }
 
     /// Try to open directory with error reporting

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -663,3 +663,18 @@ fn test_chgrp_exit_code_not_being_overwritten_by_last_file() {
         .arg("dir")
         .fails();
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn verbose_missing_file_write_error_is_reported_not_panic() {
+    use std::fs::OpenOptions;
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+    new_ucmd!()
+        .arg("--verbose")
+        .arg(getegid().to_string())
+        .arg("does-not-exist")
+        .set_stdout(dev_full)
+        .fails_with_code(1)
+        .stderr_contains("chgrp: write error: No space left on device");
+}

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -1029,3 +1029,19 @@ fn test_chown_symlink_two_links_same_dir() {
     }
     // cSpell:enable
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn verbose_missing_file_write_error_is_reported_not_panic() {
+    use std::fs::OpenOptions;
+    use uucore::process::geteuid;
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+    new_ucmd!()
+        .arg("--verbose")
+        .arg(geteuid().to_string())
+        .arg("does-not-exist")
+        .set_stdout(dev_full)
+        .fails_with_code(1)
+        .stderr_contains("chown: write error: No space left on device");
+}


### PR DESCRIPTION
Fixes #10572

The verbose output in the shared `ChownExecutor` (`uucore/src/lib/features/perms.rs`) was printed with `println!`, which aborts (exit 134) when stdout can't be written — e.g. output redirected to a full device. Because the site is shared, **both `chown` and `chgrp` abort**, so this also covers the `chgrp` case of the same bug:

```console
$ chown -v $(whoami) missing > /dev/full        # and: chgrp -v <group> missing > /dev/full
thread 'main' panicked at library/std/src/io/stdio.rs:...:
failed printing to stdout: No space left on device
Aborted (core dumped)          # exit 134
```

Verbose lines now go through a helper that propagates the write failure: on error it reports `write error: <reason>` to stderr and returns a non-zero code, matching GNU (exit 1). The three stdout `println!` sites (the `obtain_meta` → `None` branch in `traverse`, and both `print_verbose_ownership_retained_as` lines) use it, and `print_verbose_ownership_retained_as` now returns its exit code to its callers.

After:

```console
$ chgrp -v <group> missing > /dev/full
chgrp: cannot dereference 'missing': No such file or directory
chgrp: write error: No space left on device          # exit 1
```

This matches GNU (exit 1, `write error: No space left on device`). Regression tests are added for both `chgrp` and `chown` (`/dev/full`, Linux-gated), each exercising the trigger with only stdout on the full sink.
