### PR TITLE
fix(cp): change error to align with GNU

### DIFF
--- a/src/uu/cp/locales/en-US.ftl
+++ b/src/uu/cp/locales/en-US.ftl
@@ -88,6 +88,7 @@ cp-error-selinux-error = SELinux error: { $error }
 cp-error-selinux-context-conflict = cannot combine --context (-Z) with --preserve=context
 cp-error-cannot-create-fifo = cannot create fifo { $path }: File exists
 cp-error-cannot-create-special-file = cannot create special file { $path }: { $error }
+cp-error-cannot-create-regular-file = cannot create regular file { $path }
 cp-error-invalid-attribute = invalid attribute { $value }
 cp-error-failed-to-create-whole-tree = failed to create whole tree
 cp-error-failed-to-create-directory = Failed to create directory: { $error }

--- a/src/uu/cp/locales/fr-FR.ftl
+++ b/src/uu/cp/locales/fr-FR.ftl
@@ -88,6 +88,7 @@ cp-error-selinux-error = Erreur SELinux : { $error }
 cp-error-selinux-context-conflict = impossible de combiner --context (-Z) avec --preserve=context
 cp-error-cannot-create-fifo = impossible de créer le fifo { $path } : Le fichier existe
 cp-error-cannot-create-special-file = impossible de créer le fichier spécial { $path } : { $error }
+cp-error-cannot-create-regular-file = impossible de créer le fichier standard { $path }
 cp-error-invalid-attribute = attribut invalide { $value }
 cp-error-failed-to-create-whole-tree = échec de la création de l'arborescence complète
 cp-error-failed-to-create-directory = Échec de la création du répertoire : { $error }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2431,7 +2431,15 @@ fn handle_copy_mode(
                 .truncate(false)
                 .create(true)
                 .open(dest)
-                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+                .map_err(|e| {
+                    CpError::IoErrContext(
+                        e,
+                        translate!(
+                            "cp-error-cannot-create-regular-file",
+                            "path" => dest.quote()
+                        ),
+                    )
+                })?;
         }
     }
 

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -32,10 +32,12 @@ where
 {
     let mut src = open_source(source, source_nofollow)
         .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    let dest_context =
-        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
-    let mut dst =
-        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
+    let mut dst = create_dest_restrictive(&dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
+        )
+    })?;
     if ioctl_ficlone(&dst, &src).is_err() {
         buf_copy::copy_fast(&mut src, &mut dst)
             .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
@@ -87,10 +89,12 @@ where
 {
     let src_file =
         open_source(&source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    let dest_context =
-        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
-    let dst_file = create_dest_restrictive(&dest, false)
-        .map_err(|e| CpError::IoErrContext(e, dest_context))?;
+    let dst_file = create_dest_restrictive(&dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
+        )
+    })?;
     if ioctl_ficlone(dst_file, src_file).is_err() {
         return match fallback {
             CloneFallback::Error => Err(CpError::IoErrContext(
@@ -145,11 +149,13 @@ where
     P: AsRef<Path>,
 {
     let src_file =
-        open_source(source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    let dest_context =
-        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
-    let dst_file =
-        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
+        open_source(&source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dst_file = create_dest_restrictive(&dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
+        )
+    })?;
 
     let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
 
@@ -189,11 +195,13 @@ where
     P: AsRef<Path>,
 {
     let mut src_file =
-        open_source(source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    let dest_context =
-        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
-    let dst_file =
-        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
+        open_source(&source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dst_file = create_dest_restrictive(&dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
+        )
+    })?;
 
     let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
 

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -38,10 +38,8 @@ where
             translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
         )
     })?;
-    if ioctl_ficlone(&dst, &src).is_err() {
-        buf_copy::copy_fast(&mut src, &mut dst)
-            .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    }
+    buf_copy::copy_fast(&mut src, &mut dst)
+        .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
     Ok(())
 }
 

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use uucore::buf_copy;
+use uucore::display::Quotable;
 use uucore::safe_copy::{create_dest_restrictive, open_source};
 use uucore::translate;
 
@@ -24,14 +25,21 @@ use crate::{
 // only applies `O_NOFOLLOW` to the *source* open. The destination is
 // followed if it is a pre-existing symlink, matching GNU cp -d/-P which
 // only forbid dereferencing on the source side.
-fn fs_copy<P, Q>(source: P, dest: Q, source_nofollow: bool) -> std::io::Result<()>
+fn fs_copy<P, Q>(source: P, dest: Q, source_nofollow: bool, context: &str) -> CopyResult<()>
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
 {
-    let mut src = open_source(source, source_nofollow)?;
-    let mut dst = create_dest_restrictive(dest, false)?;
-    buf_copy::copy_fast(&mut src, &mut dst)?;
+    let mut src = open_source(source, source_nofollow)
+        .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dest_context =
+        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
+    let mut dst =
+        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
+    if ioctl_ficlone(&dst, &src).is_err() {
+        buf_copy::copy_fast(&mut src, &mut dst)
+            .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    }
     Ok(())
 }
 
@@ -67,19 +75,32 @@ enum CopyMethod {
 /// Use the Linux `ioctl_ficlone` API to do a copy-on-write clone.
 ///
 /// `fallback` controls what to do if the system call fails.
-fn clone<P>(source: P, dest: P, fallback: CloneFallback, nofollow: bool) -> std::io::Result<()>
+fn clone<P>(
+    source: P,
+    dest: P,
+    fallback: CloneFallback,
+    nofollow: bool,
+    context: &str,
+) -> CopyResult<()>
 where
     P: AsRef<Path>,
 {
-    let src_file = open_source(&source, nofollow)?;
-    let dst_file = create_dest_restrictive(&dest, false)?;
+    let src_file =
+        open_source(&source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dest_context =
+        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
+    let dst_file = create_dest_restrictive(&dest, false)
+        .map_err(|e| CpError::IoErrContext(e, dest_context))?;
     if ioctl_ficlone(dst_file, src_file).is_err() {
         return match fallback {
-            CloneFallback::Error => Err(std::io::Error::last_os_error()),
-            CloneFallback::FSCopy => fs_copy(source, dest, nofollow),
-            CloneFallback::SparseCopy => sparse_copy(source, dest, nofollow),
+            CloneFallback::Error => Err(CpError::IoErrContext(
+                std::io::Error::last_os_error(),
+                context.to_owned(),
+            )),
+            CloneFallback::FSCopy => fs_copy(source, dest, nofollow, context),
+            CloneFallback::SparseCopy => sparse_copy(source, dest, nofollow, context),
             CloneFallback::SparseCopyWithoutHole => {
-                sparse_copy_without_hole(source, dest, nofollow)
+                sparse_copy_without_hole(source, dest, nofollow, context)
             }
         };
     }
@@ -119,15 +140,21 @@ fn check_sparse_detection(source: &Path, nofollow: bool) -> Result<bool, std::io
 
 /// Optimized [`sparse_copy`] doesn't create holes for large sequences of zeros in non `sparse_files`
 /// Used when `--sparse=auto`
-fn sparse_copy_without_hole<P>(source: P, dest: P, nofollow: bool) -> std::io::Result<()>
+fn sparse_copy_without_hole<P>(source: P, dest: P, nofollow: bool, context: &str) -> CopyResult<()>
 where
     P: AsRef<Path>,
 {
-    let src_file = open_source(source, nofollow)?;
-    let dst_file = create_dest_restrictive(dest, false)?;
+    let src_file =
+        open_source(source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dest_context =
+        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
+    let dst_file =
+        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
 
-    let size = src_file.metadata()?.size();
-    ftruncate(&dst_file, size)?;
+    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
+
+    let size = src_file.metadata().map_err(&ctx_err)?.size();
+    ftruncate(&dst_file, size).map_err(|e| CpError::IoErrContext(e.into(), context.to_owned()))?;
     let mut current_offset = 0;
     // Maximize the data read at once to 16 MiB to avoid memory hogging with large files
     // 16 MiB chunks should saturate an SSD
@@ -144,8 +171,12 @@ where
             // Ensure we don't read past the end of the file or the start of the next hole
             let read_len = std::cmp::min((len - i) as usize, step);
             let buf = &mut buf[..read_len];
-            src_file.read_exact_at(buf, current_offset + i)?;
-            dst_file.write_all_at(buf, current_offset + i)?;
+            src_file
+                .read_exact_at(buf, current_offset + i)
+                .map_err(&ctx_err)?;
+            dst_file
+                .write_all_at(buf, current_offset + i)
+                .map_err(&ctx_err)?;
         }
         current_offset = hole;
     }
@@ -153,17 +184,29 @@ where
 }
 /// Perform a sparse copy from one file to another.
 /// Creates a holes for large sequences of zeros in `non_sparse_files`, used for `--sparse=always`
-fn sparse_copy<P>(source: P, dest: P, nofollow: bool) -> std::io::Result<()>
+fn sparse_copy<P>(source: P, dest: P, nofollow: bool, context: &str) -> CopyResult<()>
 where
     P: AsRef<Path>,
 {
-    let mut src_file = open_source(source, nofollow)?;
-    let dst_file = create_dest_restrictive(dest, false)?;
+    let mut src_file =
+        open_source(source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let dest_context =
+        translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote());
+    let dst_file =
+        create_dest_restrictive(dest, false).map_err(|e| CpError::IoErrContext(e, dest_context))?;
 
-    let size: usize = src_file.metadata()?.size().try_into().unwrap();
-    ftruncate(&dst_file, size.try_into().unwrap())?;
+    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
 
-    let blksize = dst_file.metadata()?.blksize();
+    let size: usize = src_file
+        .metadata()
+        .map_err(&ctx_err)?
+        .size()
+        .try_into()
+        .unwrap();
+    ftruncate(&dst_file, size.try_into().unwrap())
+        .map_err(|e| CpError::IoErrContext(e.into(), context.to_owned()))?;
+
+    let blksize = dst_file.metadata().map_err(&ctx_err)?.blksize();
     let mut buf: Vec<u8> = vec![0; blksize.try_into().unwrap()];
     let mut current_offset: usize = 0;
 
@@ -171,10 +214,12 @@ where
     // file extent mappings:
     // https://www.kernel.org/doc/html/latest/filesystems/fiemap.html
     while current_offset < size {
-        let this_read = src_file.read(&mut buf)?;
+        let this_read = src_file.read(&mut buf).map_err(&ctx_err)?;
         let buf = &buf[..this_read];
         if buf.iter().any(|&x| x != 0) {
-            dst_file.write_all_at(buf, current_offset.try_into().unwrap())?;
+            dst_file
+                .write_all_at(buf, current_offset.try_into().unwrap())
+                .map_err(&ctx_err)?;
         }
         current_offset += this_read;
     }
@@ -188,7 +233,7 @@ fn check_dest_is_fifo(dest: &Path) -> bool {
 }
 
 /// Copy the contents of a stream from `source` to `dest`.
-fn copy_stream<P>(source: P, dest: P, nofollow: bool) -> std::io::Result<()>
+fn copy_stream<P>(source: P, dest: P, nofollow: bool, context: &str) -> CopyResult<()>
 where
     P: AsRef<Path>,
 {
@@ -210,21 +255,30 @@ where
     //
     // TODO Update the code below to respect the case where
     // `--preserve=ownership` is not true.
-    let mut src_file = open_source(&source, nofollow)?;
+    let mut src_file =
+        open_source(&source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
     // Use the same restrictive initial mode as the regular file path so that
     // the dest does not momentarily sit with broader perms. The `0o622 &
     // !umask` form previously used here could still allow group/other write
     // under a permissive umask. See #10011.
-    let mut dst_file = create_dest_restrictive(&dest, false)?;
+    let mut dst_file = create_dest_restrictive(&dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.as_ref().quote()),
+        )
+    })?;
 
-    let dest_is_stream = is_stream(&dst_file.metadata()?);
+    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
+
+    let dest_is_stream = is_stream(&dst_file.metadata().map_err(&ctx_err)?);
     if !dest_is_stream {
         // `copy_stream` doesn't clear the dest file, if dest is not a stream, we should clear it manually.
-        dst_file.set_len(0)?;
+        dst_file.set_len(0).map_err(&ctx_err)?;
     }
 
     buf_copy::copy_fast(&mut src_file, &mut dst_file)
-        .map_err(|e| std::io::Error::other(format!("{e}")))?;
+        .map_err(|e| std::io::Error::other(format!("{e}")))
+        .map_err(&ctx_err)?;
 
     Ok(())
 }
@@ -251,7 +305,7 @@ pub(crate) fn copy_on_write(
             copy_debug.reflink = OffloadReflinkDebug::No;
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Avoided;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let mut copy_method = CopyMethod::Default;
                 let result = handle_reflink_never_sparse_always(source, dest, nofollow);
@@ -261,8 +315,8 @@ pub(crate) fn copy_on_write(
                 }
 
                 match copy_method {
-                    CopyMethod::FSCopy => fs_copy(source, dest, nofollow),
-                    _ => sparse_copy(source, dest, nofollow),
+                    CopyMethod::FSCopy => fs_copy(source, dest, nofollow, context),
+                    _ => sparse_copy(source, dest, nofollow, context),
                 }
             }
         }
@@ -271,13 +325,13 @@ pub(crate) fn copy_on_write(
 
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Avoided;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let result = handle_reflink_never_sparse_never(source, nofollow);
                 if let Ok(debug) = result {
                     copy_debug = debug;
                 }
-                fs_copy(source, dest, nofollow)
+                fs_copy(source, dest, nofollow, context)
             }
         }
         (ReflinkMode::Never, SparseMode::Auto) => {
@@ -285,7 +339,7 @@ pub(crate) fn copy_on_write(
 
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Avoided;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let mut copy_method = CopyMethod::Default;
                 let result = handle_reflink_never_sparse_auto(source, dest, nofollow);
@@ -296,9 +350,9 @@ pub(crate) fn copy_on_write(
 
                 match copy_method {
                     CopyMethod::SparseCopyWithoutHole => {
-                        sparse_copy_without_hole(source, dest, nofollow)
+                        sparse_copy_without_hole(source, dest, nofollow, context)
                     }
-                    _ => fs_copy(source, dest, nofollow),
+                    _ => fs_copy(source, dest, nofollow, context),
                 }
             }
         }
@@ -307,7 +361,7 @@ pub(crate) fn copy_on_write(
             // SparseMode::Always
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Avoided;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let mut copy_method = CopyMethod::Default;
                 let result = handle_reflink_auto_sparse_always(source, dest, nofollow);
@@ -317,8 +371,10 @@ pub(crate) fn copy_on_write(
                 }
 
                 match copy_method {
-                    CopyMethod::FSCopy => clone(source, dest, CloneFallback::FSCopy, nofollow),
-                    _ => clone(source, dest, CloneFallback::SparseCopy, nofollow),
+                    CopyMethod::FSCopy => {
+                        clone(source, dest, CloneFallback::FSCopy, nofollow, context)
+                    }
+                    _ => clone(source, dest, CloneFallback::SparseCopy, nofollow, context),
                 }
             }
         }
@@ -327,20 +383,20 @@ pub(crate) fn copy_on_write(
             copy_debug.reflink = OffloadReflinkDebug::No;
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Avoided;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let result = handle_reflink_auto_sparse_never(source, nofollow);
                 if let Ok(debug) = result {
                     copy_debug = debug;
                 }
 
-                clone(source, dest, CloneFallback::FSCopy, nofollow)
+                clone(source, dest, CloneFallback::FSCopy, nofollow, context)
             }
         }
         (ReflinkMode::Auto, SparseMode::Auto) => {
             if source_is_stream {
                 copy_debug.offload = OffloadReflinkDebug::Unsupported;
-                copy_stream(source, dest, nofollow)
+                copy_stream(source, dest, nofollow, context)
             } else {
                 let mut copy_method = CopyMethod::Default;
                 let result = handle_reflink_auto_sparse_auto(source, dest, nofollow);
@@ -350,10 +406,14 @@ pub(crate) fn copy_on_write(
                 }
 
                 match copy_method {
-                    CopyMethod::SparseCopyWithoutHole => {
-                        clone(source, dest, CloneFallback::SparseCopyWithoutHole, nofollow)
-                    }
-                    _ => clone(source, dest, CloneFallback::FSCopy, nofollow),
+                    CopyMethod::SparseCopyWithoutHole => clone(
+                        source,
+                        dest,
+                        CloneFallback::SparseCopyWithoutHole,
+                        nofollow,
+                        context,
+                    ),
+                    _ => clone(source, dest, CloneFallback::FSCopy, nofollow, context),
                 }
             }
         }
@@ -362,13 +422,13 @@ pub(crate) fn copy_on_write(
             copy_debug.sparse_detection = SparseDebug::No;
             copy_debug.reflink = OffloadReflinkDebug::Yes;
 
-            clone(source, dest, CloneFallback::Error, nofollow)
+            clone(source, dest, CloneFallback::Error, nofollow, context)
         }
         (ReflinkMode::Always, _) => {
             return Err(translate!("cp-error-reflink-always-sparse-auto").into());
         }
     };
-    result.map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    result?;
     Ok(copy_debug)
 }
 

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -103,18 +103,31 @@ pub(crate) fn copy_on_write(
         }
         copy_debug.reflink = OffloadReflinkDebug::Yes;
         if source_is_stream {
-            let mut src_file = File::open(source)?;
+            let mut src_file =
+                File::open(source).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
             let mode = 0o622 & !get_umask();
             let mut dst_file = OpenOptions::new()
                 .create(true)
                 .write(true)
                 .mode(mode)
-                .open(dest)?;
+                .open(dest)
+                .map_err(|e| {
+                    CpError::IoErrContext(
+                        e,
+                        translate!("cp-error-cannot-create-regular-file", "path" => dest.quote()),
+                    )
+                })?;
 
-            let dest_is_stream = is_stream(&dst_file.metadata()?);
+            let dest_is_stream = is_stream(
+                &dst_file
+                    .metadata()
+                    .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?,
+            );
             if !dest_is_stream {
                 // `copy_stream` doesn't clear the dest file, if dest is not a stream, we should clear it manually.
-                dst_file.set_len(0)?;
+                dst_file
+                    .set_len(0)
+                    .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
             }
 
             buf_copy::copy_fast(&mut src_file, &mut dst_file)

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 use uucore::buf_copy;
 use uucore::display::Quotable;
+use uucore::safe_copy::{create_dest_restrictive, open_source};
 use uucore::translate;
 
 use uucore::mode::get_umask;
@@ -28,7 +29,7 @@ pub(crate) fn copy_on_write(
     sparse_mode: SparseMode,
     context: &str,
     source_is_stream: bool,
-    _nofollow: bool,
+    nofollow: bool,
 ) -> CopyResult<CopyDebug> {
     if sparse_mode != SparseMode::Auto {
         return Err(translate!("cp-error-sparse-not-supported")
@@ -134,7 +135,16 @@ pub(crate) fn copy_on_write(
                 .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
                 .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
         } else {
-            fs::copy(source, dest).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            let mut src_file = open_source(source, nofollow)
+                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+            let mut dst_file = create_dest_restrictive(dest, false).map_err(|e| {
+                CpError::IoErrContext(
+                    e,
+                    translate!("cp-error-cannot-create-regular-file", "path" => dest.quote()),
+                )
+            })?;
+            std::io::copy(&mut src_file, &mut dst_file)
+                .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
         }
     }
 

--- a/src/uu/cp/src/platform/other_unix.rs
+++ b/src/uu/cp/src/platform/other_unix.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 use uucore::buf_copy;
+use uucore::display::Quotable;
 use uucore::safe_copy::{create_dest_restrictive, open_source};
 use uucore::translate;
 
@@ -43,8 +44,12 @@ pub(crate) fn copy_on_write(
     if source_is_stream {
         let mut src_file = open_source(source, nofollow)
             .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-        let mut dst_file = create_dest_restrictive(dest, false)
-            .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+        let mut dst_file = create_dest_restrictive(dest, false).map_err(|e| {
+            CpError::IoErrContext(
+                e,
+                translate!("cp-error-cannot-create-regular-file", "path" => dest.quote()),
+            )
+        })?;
 
         let dest_is_stream = is_stream(&dst_file.metadata()?);
         if !dest_is_stream {
@@ -65,8 +70,12 @@ pub(crate) fn copy_on_write(
     // dest is followed, matching GNU cp.
     let mut src_file =
         open_source(source, nofollow).map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
-    let mut dst_file = create_dest_restrictive(dest, false)
-        .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
+    let mut dst_file = create_dest_restrictive(dest, false).map_err(|e| {
+        CpError::IoErrContext(
+            e,
+            translate!("cp-error-cannot-create-regular-file", "path" => dest.quote()),
+        )
+    })?;
     std::io::copy(&mut src_file, &mut dst_file)
         .map_err(|e| CpError::IoErrContext(e, context.to_owned()))?;
 

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -4639,7 +4639,28 @@ fn test_cp_attributes_only_dest_open_error() {
     at.write("s.txt", "hi");
     ucmd.args(&["--attributes-only", "s.txt", "/dev/null/n.txt"])
         .fails_with_code(1)
-        .stderr_contains("cp: 's.txt' -> '/dev/null/n.txt'");
+        .stderr_contains("cp: cannot create regular file '/dev/null/n.txt'");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_cannot_create_regular_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("source.txt", "hello");
+    ucmd.arg("source.txt")
+        .arg("/dev/null/n.txt")
+        .fails_with_code(1)
+        .stderr_contains("cp: cannot create regular file '/dev/null/n.txt'");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_cp_cannot_create_regular_file_attributes_only() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("source.txt", "hello");
+    ucmd.args(&["--attributes-only", "source.txt", "/dev/null/n.txt"])
+        .fails_with_code(1)
+        .stderr_only("cp: cannot create regular file '/dev/null/n.txt': Not a directory\n");
 }
 
 #[test]


### PR DESCRIPTION
Change the cp error message:

```
cp: '<src_file>' -> '<dest_file>': <reason>
```

to GNU's format:
```
cp: cannot create regular file '<dest_file>': <reason>
```

Fixes: #13302 