### PR TITLE
unexpand: reject too-large --tabs increment instead of overflowing

### DIFF
--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -117,9 +117,7 @@ fn parse_tabstops(s: &str) -> Result<TabConfig, ParseError> {
     // Only add an extra tab stop if increment is non-zero
     if let Some(inc) = increment_size.filter(|&i| i > 0) {
         let last = *nums.last().unwrap();
-        // A near-maximal last stop plus the increment can exceed `usize::MAX`.
-        // Reject it as too large (matching GNU) instead of overflowing, which
-        // aborts under overflow checks and wraps to a bogus stop otherwise.
+        // Reject a last stop + increment that overflows usize instead of panicking/wrapping (matches GNU).
         let next = last.checked_add(inc).ok_or(ParseError::TabSizeTooLarge)?;
         nums.push(next);
     }

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -117,7 +117,11 @@ fn parse_tabstops(s: &str) -> Result<TabConfig, ParseError> {
     // Only add an extra tab stop if increment is non-zero
     if let Some(inc) = increment_size.filter(|&i| i > 0) {
         let last = *nums.last().unwrap();
-        nums.push(last + inc);
+        // A near-maximal last stop plus the increment can exceed `usize::MAX`.
+        // Reject it as too large (matching GNU) instead of overflowing, which
+        // aborts under overflow checks and wraps to a bogus stop otherwise.
+        let next = last.checked_add(inc).ok_or(ParseError::TabSizeTooLarge)?;
+        nums.push(next);
     }
 
     if let (false, _) = nums

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -254,9 +254,7 @@ fn test_tabs_shortcut_with_too_large_size() {
 
 #[test]
 fn test_extended_tabstop_increment_overflow() {
-    // `--tabs=N,+M` adds one stop at `N + M`. When `N` is near `usize::MAX`,
-    // that sum must be rejected as too large rather than overflowing (which
-    // aborts under overflow checks and wraps to a bogus stop otherwise).
+    // `--tabs=N,+M` with N near usize::MAX must be rejected, not overflow the N+M stop.
     let arg = format!("--tabs={},+1", usize::MAX);
     new_ucmd!()
         .arg(arg)

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -253,6 +253,18 @@ fn test_tabs_shortcut_with_too_large_size() {
 }
 
 #[test]
+fn test_extended_tabstop_increment_overflow() {
+    // `--tabs=N,+M` adds one stop at `N + M`. When `N` is near `usize::MAX`,
+    // that sum must be rejected as too large rather than overflowing (which
+    // aborts under overflow checks and wraps to a bogus stop otherwise).
+    let arg = format!("--tabs={},+1", usize::MAX);
+    new_ucmd!()
+        .arg(arg)
+        .fails()
+        .stderr_contains("tab stop value is too large");
+}
+
+#[test]
 fn test_is_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
     let dir_name = "dir";


### PR DESCRIPTION
## Summary

`unexpand --tabs=N,+M` adds one tab stop at `N + M`. When `N` is near `usize::MAX`, that addition overflowed:

- under overflow checks (debug builds) it aborts:

  ```console
  $ printf '\t\n' | unexpand --tabs=18446744073709551615,+1
  thread 'main' panicked at src/uu/unexpand/src/unexpand.rs:120: attempt to add with overflow
  ```

- in release builds it wraps to `0`, which then fails the "tab sizes must be ascending" check for the wrong reason.

Use `checked_add` and reject the value as `TabSizeTooLarge` ("tab stop value is too large"), matching GNU and the existing handling of a single over-large tab number in `parse_tab_num`.

Fixes #13378.

## Test

Added `test_extended_tabstop_increment_overflow` asserting `--tabs=<usize::MAX>,+1` fails with "tab stop value is too large". All 37 `unexpand` tests pass; `cargo clippy --features unexpand --all-targets -- -D warnings` and `cargo fmt` are clean.
