### PR TITLE
pr: fix panic on large page width and reject oversized -W/-w

### DIFF
--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -104,3 +104,4 @@ pr-error-invalid-pages-range = invalid --pages argument '{$start}:{$end}'
 pr-error-starting-page-exceeds-page-count = starting page number {$start} exceeds page count {$count}
 pr-error-invalid-expand-tab-argument ='-e' extra characters or invalid number in the argument: ‘{$arg}’
 pr-error-invalid-number-argument ='-n' extra characters or invalid number in the argument: ‘{$arg}’
+pr-error-page-width-too-large = '{$flag} PAGE_WIDTH' invalid number of characters: {$value}: Value too large for defined data type

--- a/src/uu/pr/locales/fr-FR.ftl
+++ b/src/uu/pr/locales/fr-FR.ftl
@@ -103,3 +103,4 @@ pr-error-invalid-pages-range = argument --pages invalide '{$start}:{$end}'
 pr-error-starting-page-exceeds-page-count = le numéro de page de début {$start} dépasse le nombre de pages {$count}
 pr-error-invalid-expand-tab-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-e': '{$arg}'
 pr-error-invalid-number-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-n': '{$arg}'
+pr-error-page-width-too-large = '{$flag} PAGE_WIDTH' nombre de caractères invalide : {$value} : Valeur trop grande pour le type de données défini

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -861,9 +861,10 @@ fn build_options(
     // `i32::MAX` up front rather than crashing later during layout.
     if column_width > i32::MAX as usize {
         return Err(PrError::EncounteredErrors {
-            msg: format!(
-                "'-w PAGE_WIDTH' invalid number of characters: {}: Value too large for defined data type",
-                matches
+            msg: translate!(
+                "pr-error-page-width-too-large",
+                "flag" => "-w",
+                "value" => matches
                     .get_one::<String>(options::COLUMN_WIDTH)
                     .map(String::as_str)
                     .unwrap_or_default()
@@ -891,9 +892,10 @@ fn build_options(
     // `i32::MAX` up front rather than crashing later during layout.
     if page_width.is_some_and(|w| w > i32::MAX as usize) {
         return Err(PrError::EncounteredErrors {
-            msg: format!(
-                "'-W PAGE_WIDTH' invalid number of characters: {}: Value too large for defined data type",
-                matches
+            msg: translate!(
+                "pr-error-page-width-too-large",
+                "flag" => "-W",
+                "value" => matches
                     .get_one::<String>(options::PAGE_WIDTH)
                     .map(String::as_str)
                     .unwrap_or_default()

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -857,8 +857,7 @@ fn build_options(
         });
     }
 
-    // GNU pr stores the width in a C `int`, so it rejects anything above
-    // `i32::MAX` up front rather than crashing later during layout.
+    // GNU pr stores the width in a C `int`, so reject anything above `i32::MAX`.
     if column_width > i32::MAX as usize {
         return Err(PrError::EncounteredErrors {
             msg: translate!(
@@ -888,8 +887,7 @@ fn build_options(
         });
     }
 
-    // GNU pr stores the page width in a C `int`; reject anything above
-    // `i32::MAX` up front rather than crashing later during layout.
+    // GNU pr stores the page width in a C `int`, so reject anything above `i32::MAX`.
     if page_width.is_some_and(|w| w > i32::MAX as usize) {
         return Err(PrError::EncounteredErrors {
             msg: translate!(
@@ -1529,13 +1527,7 @@ fn get_formatted_line_number(opts: &OutputOptions, line_number: usize, index: us
     }
 }
 
-/// Writes the five line page header (unless disabled by the
-/// `NO_HEADER_TRAILER_OPTION` option) to `out`.
-///
-/// The centering padding is streamed with [`write_offset_spaces`] rather than
-/// built with a `{:width$}` format argument. A wide page width can make the
-/// padding exceed the formatter's `u16` count limit (which panics) or require a
-/// huge allocation, so it is written incrementally instead.
+/// Writes the five line page header to `out` (unless disabled by `NO_HEADER_TRAILER_OPTION`), streaming the centering padding to avoid the `{:width$}` formatter's `u16` panic and huge allocations.
 fn write_header(
     out: &mut impl Write,
     options: &OutputOptions,

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -857,6 +857,21 @@ fn build_options(
         });
     }
 
+    // GNU pr stores the width in a C `int`, so it rejects anything above
+    // `i32::MAX` up front rather than crashing later during layout.
+    if column_width > i32::MAX as usize {
+        return Err(PrError::EncounteredErrors {
+            msg: format!(
+                "'-w PAGE_WIDTH' invalid number of characters: {}: Value too large for defined data type",
+                matches
+                    .get_one::<String>(options::COLUMN_WIDTH)
+                    .map(String::as_str)
+                    .unwrap_or_default()
+                    .quote()
+            ),
+        });
+    }
+
     let page_width = if matches.get_flag(options::JOIN_LINES) {
         None
     } else {
@@ -869,6 +884,21 @@ fn build_options(
     if page_width == Some(0) {
         return Err(PrError::EncounteredErrors {
             msg: "invalid --page-width argument '0'".to_string(),
+        });
+    }
+
+    // GNU pr stores the page width in a C `int`; reject anything above
+    // `i32::MAX` up front rather than crashing later during layout.
+    if page_width.is_some_and(|w| w > i32::MAX as usize) {
+        return Err(PrError::EncounteredErrors {
+            msg: format!(
+                "'-W PAGE_WIDTH' invalid number of characters: {}: Value too large for defined data type",
+                matches
+                    .get_one::<String>(options::PAGE_WIDTH)
+                    .map(String::as_str)
+                    .unwrap_or_default()
+                    .quote()
+            ),
         });
     }
 
@@ -1252,13 +1282,9 @@ fn write_page(
     let line_separator = options.line_separator.as_bytes();
     let page_separator = options.page_separator_char.as_bytes();
 
-    let header = header_content(options, page);
     let trailer_content = trailer_content(options);
 
-    for x in header {
-        writer.write_all(x.as_bytes())?;
-        writer.write_all(line_separator)?;
-    }
+    write_header(writer, options, page, line_separator)?;
 
     write_columns(writer, lines, options)?;
 
@@ -1501,11 +1527,21 @@ fn get_formatted_line_number(opts: &OutputOptions, line_number: usize, index: us
     }
 }
 
-/// Returns a five line header content if displaying header is not disabled by
-/// using `NO_HEADER_TRAILER_OPTION` option.
-fn header_content(options: &OutputOptions, page: usize) -> Vec<String> {
+/// Writes the five line page header (unless disabled by the
+/// `NO_HEADER_TRAILER_OPTION` option) to `out`.
+///
+/// The centering padding is streamed with [`write_offset_spaces`] rather than
+/// built with a `{:width$}` format argument. A wide page width can make the
+/// padding exceed the formatter's `u16` count limit (which panics) or require a
+/// huge allocation, so it is written incrementally instead.
+fn write_header(
+    out: &mut impl Write,
+    options: &OutputOptions,
+    page: usize,
+    line_separator: &[u8],
+) -> Result<(), std::io::Error> {
     if !options.display_header_and_trailer {
-        return Vec::new();
+        return Ok(());
     }
 
     // The header should be formatted with proper spacing:
@@ -1523,28 +1559,31 @@ fn header_content(options: &OutputOptions, page: usize) -> Vec<String> {
     let filename_len = filename.chars().count();
     let page_len = page_part.chars().count();
 
-    let header_line = if date_len + filename_len + page_len + 2 < total_width {
-        // The filename should be centered between the date and page parts
+    // Two blank lines precede the header line.
+    out.write_all(line_separator)?;
+    out.write_all(line_separator)?;
+
+    if date_len + filename_len + page_len + 2 < total_width {
+        // The filename should be centered between the date and page parts.
         let space_for_filename = total_width - date_len - page_len;
         let padding_before_filename = (space_for_filename - filename_len) / 2;
         let padding_after_filename = space_for_filename - filename_len - padding_before_filename;
 
-        format!(
-            "{date_part}{:padding_before_filename$}{filename}{:padding_after_filename$}{page_part}",
-            "", ""
-        )
+        out.write_all(date_part.as_bytes())?;
+        write_offset_spaces(out, padding_before_filename)?;
+        out.write_all(filename.as_bytes())?;
+        write_offset_spaces(out, padding_after_filename)?;
+        out.write_all(page_part.as_bytes())?;
     } else {
-        // If content is too long, just use single spaces
-        format!("{date_part} {filename} {page_part}")
-    };
+        // If content is too long, just use single spaces.
+        write!(out, "{date_part} {filename} {page_part}")?;
+    }
+    out.write_all(line_separator)?;
 
-    vec![
-        String::new(),
-        String::new(),
-        header_line,
-        String::new(),
-        String::new(),
-    ]
+    // Two blank lines follow the header line.
+    out.write_all(line_separator)?;
+    out.write_all(line_separator)?;
+    Ok(())
 }
 
 /// Returns five empty lines as trailer content if displaying trailer

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -478,6 +478,37 @@ fn test_offset_invalid() {
 }
 
 #[test]
+fn test_page_width_too_large() {
+    // GNU pr stores the width in a C `int` and rejects anything above `i32::MAX`
+    // ('2147483647') up front. `-W`/`--page-width` and `-w`/`--width` both report
+    // it as "PAGE_WIDTH".
+    let arg = "2147483648";
+    new_ucmd!()
+        .args(&["-W", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-W PAGE_WIDTH' invalid number of characters: '{arg}': Value too large for defined data type\n"
+        ));
+    new_ucmd!()
+        .args(&["-w", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-w PAGE_WIDTH' invalid number of characters: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_large_page_width_does_not_panic() {
+    // A page width whose centering padding exceeds the `{:width$}` formatter's
+    // `u16` count limit previously panicked ("Formatting argument out of range")
+    // while building the header. The header padding is now streamed instead.
+    new_ucmd!()
+        .args(&["-W", "200000"])
+        .pipe_in("hello\nworld\n")
+        .succeeds();
+}
+
+#[test]
 fn test_with_date_format() {
     let whitespace = " ".repeat(50);
     let blank_lines = "\n".repeat(61);

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -479,9 +479,7 @@ fn test_offset_invalid() {
 
 #[test]
 fn test_page_width_too_large() {
-    // GNU pr stores the width in a C `int` and rejects anything above `i32::MAX`
-    // ('2147483647') up front. `-W`/`--page-width` and `-w`/`--width` both report
-    // it as "PAGE_WIDTH".
+    // GNU pr rejects a width above `i32::MAX`, reported as "PAGE_WIDTH" for both `-W` and `-w`.
     let arg = "2147483648";
     new_ucmd!()
         .args(&["-W", arg])
@@ -499,9 +497,7 @@ fn test_page_width_too_large() {
 
 #[test]
 fn test_large_page_width_does_not_panic() {
-    // A page width whose centering padding exceeds the `{:width$}` formatter's
-    // `u16` count limit previously panicked ("Formatting argument out of range")
-    // while building the header. The header padding is now streamed instead.
+    // A wide page width used to panic building the header via `{:width$}`; padding is now streamed.
     new_ucmd!()
         .args(&["-W", "200000"])
         .pipe_in("hello\nworld\n")


### PR DESCRIPTION
## Summary

`pr -W N` (page width) and `pr -w N` (column width) panic on a large `N`:

```console
$ printf 'hello\n' | pr -W 200000
thread 'main' panicked at 'Formatting argument out of range', src/uu/pr/src/pr.rs

$ printf 'hello\n' | pr -W 18446744073709551615
thread 'main' panicked ... Formatting argument out of range
```

The page header is centered with `format!("{:width$}")`. The format count is a `u16`, so once the centering padding exceeds `u16::MAX` the formatter panics while rendering the header.

Fix (two parts, both following existing `pr` precedent):

1. **Stream the header padding** with the existing `write_offset_spaces` helper instead of `format!("{:width$}")`, mirroring the `-o`/`--indent` fix in #12994. Accepted widths now render without an oversized format count.
2. **Reject `-W`/`-w` above `i32::MAX`** up front with GNU's message, since GNU stores the width in a C `int`:

   ```console
   $ pr -W 2147483648
   pr: '-W PAGE_WIDTH' invalid number of characters: '2147483648': Value too large for defined data type
   ```

   GNU accepts `2147483647` and rejects `2147483648`; this matches exactly and continues the `-W 0` parity work from #12767.

## Test

Added `test_page_width_too_large` (both `-W` and `-w` reject `i32::MAX + 1` with the GNU message) and `test_large_page_width_does_not_panic` (`-W 200000`, previously a panic, now succeeds). Full `pr` suite passes (67 tests); `cargo clippy --features pr --all-targets -- -D warnings`, `cargo fmt`, and cspell are clean.