### PR TITLE
nohup: report command execution errors

### DIFF
--- a/src/uu/nohup/locales/en-US.ftl
+++ b/src/uu/nohup/locales/en-US.ftl
@@ -12,6 +12,7 @@ nohup-error-cannot-replace = Cannot replace { $name }: { $err }
 nohup-error-open-failed = failed to open { $path }: { $err }
 nohup-error-open-failed-both = failed to open { $first_path }: { $first_err }
   failed to open { $second_path }: { $second_err }
+nohup-error-failed-to-run-command = failed to run command { $command }: { $error }
 
 # Status messages
 nohup-ignoring-input-appending-output = ignoring input and appending output to { $path }

--- a/src/uu/nohup/locales/fr-FR.ftl
+++ b/src/uu/nohup/locales/fr-FR.ftl
@@ -12,6 +12,7 @@ nohup-error-cannot-replace = Impossible de remplacer { $name } : { $err }
 nohup-error-open-failed = échec de l'ouverture de { $path } : { $err }
 nohup-error-open-failed-both = échec de l'ouverture de { $first_path } : { $first_err }
   échec de l'ouverture de { $second_path } : { $second_err }
+nohup-error-failed-to-run-command = échec de l'exécution de la commande { $command } : { $error }
 
 # Messages de statut
 nohup-ignoring-input-appending-output = entrée ignorée et sortie ajoutée à { $path }

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -19,7 +19,7 @@ use std::process;
 use std::sync::LazyLock;
 use thiserror::Error;
 use uucore::display::Quotable;
-use uucore::error::{UError, UResult, set_exit_code};
+use uucore::error::{UError, UResult, set_exit_code, strip_errno};
 use uucore::translate;
 use uucore::{format_usage, show_error};
 
@@ -91,6 +91,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<&String> = cmd_iter.collect();
 
     let err = process::Command::new(cmd).args(args).exec();
+
+    show_error!(
+        "{}",
+        translate!("nohup-error-failed-to-run-command", "command" => cmd.quote(), "error" => strip_errno(&err))
+    );
 
     match err.kind() {
         ErrorKind::NotFound => set_exit_code(EXIT_ENOENT),

--- a/tests/by-util/test_nohup.rs
+++ b/tests/by-util/test_nohup.rs
@@ -203,9 +203,10 @@ fn test_nohup_fallback_to_home() {
 // or 126 when command exists but is not executable
 #[test]
 fn test_nohup_command_not_found() {
-    let result = new_ucmd!()
-        .arg("this-command-definitely-does-not-exist-anywhere")
-        .fails();
+    let command = "this-command-definitely-does-not-exist-anywhere";
+    let result = new_ucmd!().arg(command).fails();
+
+    result.stderr_contains(format!("failed to run command '{command}'"));
 
     // Accept either 126 (cannot execute) or 127 (command not found)
     let code = result.try_exit_status().and_then(|s| s.code());


### PR DESCRIPTION
Fixes #12693.

`nohup` used the error returned by `exec` only to select the exit status, without reporting why the command could not be started.

Display the underlying execution error before returning, matching GNU's diagnostic while preserving the existing exit codes. `strip_errno` removes Rust's platform-specific `(os error N)` suffix.

Extend the existing command-not-found test to check the diagnostic.
