### PR TITLE
docs: fix DEVELOPMENT.md links in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,10 +300,10 @@ features.
 ## Improving the GNU compatibility
 
 Please make sure you have installed
-[GNU utils and prerequisites](DEVELOPMENT.md#gnu-utils-and-prerequisites) and
+[GNU utils and prerequisites](./DEVELOPMENT.md#gnu-utils-and-prerequisites) and
 can execute commands described in
-[Comparing with GNU](DEVELOPMENT.md#comparing-with-gnu) section of
-[DEVELOPMENT.md](DEVELOPMENT.md)
+[Comparing with GNU](./DEVELOPMENT.md#comparing-with-gnu) section of
+[DEVELOPMENT.md](./DEVELOPMENT.md)
 
 The Python script `./util/remaining-gnu-error.py` shows the list of failing
 tests in the CI.
@@ -330,8 +330,8 @@ To improve the GNU compatibility, the following process is recommended:
 ## Code coverage
 
 To generate code coverage report locally please follow
-[Code coverage report](DEVELOPMENT.md#code-coverage-report) section of
-[DEVELOPMENT.md](DEVELOPMENT.md)
+[Code coverage report](./DEVELOPMENT.md#code-coverage-report) section of
+[DEVELOPMENT.md](./DEVELOPMENT.md)
 
 ## Other implementations
 


### PR DESCRIPTION
## Summary
The published contributing page (`…/docs/contributing.html#improving-the-gnu-compatibility`) turned relative `DEVELOPMENT.md` links into `DEVELOPMENT.html` URLs that 404.

This updates the GNU compatibility and code coverage links (and the other `DEVELOPMENT.md` references in `CONTRIBUTING.md`) to GitHub blob URLs so they resolve from the docs site.

## Test plan
- [x] Inspect rendered markdown links point at `https://github.com/uutils/coreutils/blob/main/DEVELOPMENT.md…`
- [ ] Confirm section on the published contributing page no longer 404s after merge/docs deploy

Fixes #7201
