### PR TITLE
checksum: handle stdin before directory checks

### DIFF
--- a/src/uucore/src/lib/features/checksum/compute.rs
+++ b/src/uucore/src/lib/features/checksum/compute.rs
@@ -242,16 +242,8 @@ where
             return Err(Box::new(ChecksumError::RawMultipleFiles));
         }
 
-        let filepath = Path::new(filename);
         let stdin_buf;
         let file_buf;
-        if filepath.is_dir() {
-            show!(USimpleError::new(
-                1,
-                translate!("error-is-a-directory", "file" => filepath.display())
-            ));
-            continue;
-        }
 
         // Handle the file input
         let mut file = io::BufReader::with_capacity(
@@ -260,6 +252,14 @@ where
                 stdin_buf = io::stdin();
                 Box::new(stdin_buf) as Box<dyn io::Read>
             } else {
+                let filepath = Path::new(filename);
+                if filepath.is_dir() {
+                    show!(USimpleError::new(
+                        1,
+                        translate!("error-is-a-directory", "file" => filepath.display())
+                    ));
+                    continue;
+                }
                 file_buf = match File::open(filepath) {
                     Ok(file) => {
                         #[cfg(any(

--- a/tests/by-util/test_b2sum.rs
+++ b/tests/by-util/test_b2sum.rs
@@ -58,6 +58,23 @@ macro_rules! test_digest_with_len {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .arg(LENGTH_ARG)
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -73,6 +73,16 @@ fn test_stdin() {
 }
 
 #[test]
+fn test_stdin_with_dash_directory() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("-");
+
+    ucmd.pipe_in_fixture("lorem_ipsum.txt")
+        .succeeds()
+        .stdout_is_fixture("crc_stdin.expected");
+}
+
+#[test]
 fn test_empty_file() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_md5sum.rs
+++ b/tests/by-util/test_md5sum.rs
@@ -53,6 +53,22 @@ macro_rules! test_digest {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));

--- a/tests/by-util/test_sha1sum.rs
+++ b/tests/by-util/test_sha1sum.rs
@@ -53,6 +53,22 @@ macro_rules! test_digest {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));

--- a/tests/by-util/test_sha224sum.rs
+++ b/tests/by-util/test_sha224sum.rs
@@ -51,6 +51,22 @@ macro_rules! test_digest {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));

--- a/tests/by-util/test_sha256sum.rs
+++ b/tests/by-util/test_sha256sum.rs
@@ -40,6 +40,8 @@ macro_rules! test_digest {
             #[test]
             fn test_stdin() {
                 let ts = TestScenario::new(util_name!());
+                // A directory named "-" must not shadow stdin.
+                ts.fixtures.mkdir("-");
                 assert_eq!(
                     ts.fixtures.read(EXPECTED_FILE),
                     get_hash!(

--- a/tests/by-util/test_sha256sum.rs
+++ b/tests/by-util/test_sha256sum.rs
@@ -40,7 +40,21 @@ macro_rules! test_digest {
             #[test]
             fn test_stdin() {
                 let ts = TestScenario::new(util_name!());
-                // A directory named "-" must not shadow stdin.
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
                 ts.fixtures.mkdir("-");
                 assert_eq!(
                     ts.fixtures.read(EXPECTED_FILE),

--- a/tests/by-util/test_sha384sum.rs
+++ b/tests/by-util/test_sha384sum.rs
@@ -51,6 +51,22 @@ macro_rules! test_digest {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));

--- a/tests/by-util/test_sha512sum.rs
+++ b/tests/by-util/test_sha512sum.rs
@@ -51,6 +51,22 @@ macro_rules! test_digest {
             }
 
             #[test]
+            fn test_stdin_with_dash_directory() {
+                let ts = TestScenario::new(util_name!());
+                ts.fixtures.mkdir("-");
+                assert_eq!(
+                    ts.fixtures.read(EXPECTED_FILE),
+                    get_hash!(
+                        ts.ucmd()
+                            .pipe_in_fixture(INPUT_FILE)
+                            .succeeds()
+                            .no_stderr()
+                            .stdout_str()
+                    )
+                );
+            }
+
+            #[test]
             fn test_check() {
                 let ts = TestScenario::new(util_name!());
                 println!("File content='{}'", ts.fixtures.read(INPUT_FILE));


### PR DESCRIPTION
Fixes #13390.

Checksum computation checked whether each operand was a directory before handling `-` as standard input. As a result, a literal `./-` directory caused implicit or explicit stdin input to fail.

Handle `-` before filesystem checks so it remains stdin regardless of entries in the working directory. Extend the existing `sha256sum` stdin test with a `-` directory regression fixture.
