### PR TITLE
fix: regression upstream gnu od (#11613)

### DIFF
--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -1376,3 +1376,21 @@ fn test_is_a_directory() {
         .fails_with_code(1)
         .stderr_is("od: a: Is a directory\n");
 }
+
+// Regression: offset must be 4, not 3, and -N must be respected
+#[test]
+fn test_od_strings_with_n_flag() {
+    let input = b"foo\0bar\0";
+
+    new_ucmd!()
+        .args(&["--strings", "-N7"])
+        .run_piped_stdin(&input[..])
+        .success()
+        .stdout_only("0000000 foo\n0000004 bar\n");
+
+    new_ucmd!()
+        .args(&["--strings", "-N8"])
+        .run_piped_stdin(&input[..])
+        .success()
+        .stdout_only("0000000 foo\n0000004 bar\n");
+}


### PR DESCRIPTION
Verified, this is fixed upstream, not a uutils bug.

```bash
root@pc ~/r/coreutils (fix/issue-11613)# od --version
od (GNU coreutils) 9.11
Copyright (C) 2026 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering.
root@pc ~/r/coreutils (fix/issue-11613)# printf "foo\0bar\0" | /usr/bin/od --strings -N7
                                         printf "foo\0bar\0" | /usr/bin/od --strings -N8
                                         printf "foo\0bar\0" | cargo run -- od --strings -N7
                                         printf "foo\0bar\0" | cargo run -- od --strings -N8
0000000 foo
0000004 bar
0000000 foo
0000004 bar
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/coreutils od --strings -N7`
0000000 foo
0000004 bar
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/coreutils od --strings -N8`
0000000 foo
0000004 bar
root@pc ~/r/coreutils (fix/issue-11613)# 
```

Fixes #11613