### PR TITLE
ci(FixPR): add explicit least-privilege permissions block

### DIFF
--- a/.github/workflows/FixPR.yml
+++ b/.github/workflows/FixPR.yml
@@ -7,6 +7,9 @@ name: FixPR
 env:
   BRANCH_TARGET: main
 
+permissions:
+  contents: write  # FixPR commits Cargo.lock back to main
+
 on:
   # * only trigger on pull request closed to specific branches
   # ref: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/9


### PR DESCRIPTION
## What this does

`FixPR.yml` is the only workflow of the 21 in `.github/workflows/` with no `permissions:` block, so its `GITHUB_TOKEN` gets the repository's default scopes. This adds an explicit least-privilege block.

## Why `contents: write` (not read)

The workflow runs on `pull_request: [closed]` when `merged == true` and its final step (`EndBug/add-and-commit@v10`) commits `Cargo.lock` back to `main` using `GITHUB_TOKEN`. So it genuinely needs `contents: write` — but nothing else. Making that explicit drops the other default token scopes (packages, actions, etc.) while keeping the auto-commit working.

This mirrors the hardening you already accepted in #12655 (adding an explicit permissions block to a workflow that CodeQL flagged).

## Verification

```
for f in .github/workflows/*.yml; do grep -q 'permissions:' "$f" || echo "NO-PERMISSIONS: $f"; done
# → NO-PERMISSIONS: FixPR.yml   (only one, before this change)
```

Single-block addition, no behavior change.

---

*Disclosure: I used an AI tool to help spot this and prepare the change; I verified it against the workflow and the #12655 precedent myself and take responsibility for it.*
