### PR TITLE
truncate: a few trivial refactorings

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -187,9 +187,7 @@ pub fn uu_app() -> Command {
 /// If the file could not be opened, or there was a problem setting the
 /// size of the file.
 fn do_file_truncate(filename: &Path, create: bool, size: u64) -> UResult<()> {
-    let path = Path::new(filename);
-
-    match OpenOptions::new().write(true).create(create).open(path) {
+    match OpenOptions::new().write(true).create(create).open(filename) {
         Ok(file) => file.set_len(size),
         Err(e) if e.kind() == ErrorKind::NotFound && !create => Ok(()),
         Err(e) => Err(e),

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -3,7 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) RFILE refsize rfilename fsize tsize
+// spell-checker:ignore (ToDO) RFILE fsize
+
 use clap::{Arg, ArgAction, Command};
 use std::ffi::OsString;
 use std::fs::{OpenOptions, metadata};
@@ -100,8 +101,7 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let app = uu_app();
-    let matches = uucore::clap_localization::handle_clap_result(app, args)?;
+    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let files: Vec<OsString> = matches
         .get_many::<OsString>(options::ARG_FILES)

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -109,19 +109,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .unwrap_or_default();
 
     if files.is_empty() {
-        Err(UUsageError::new(
+        return Err(UUsageError::new(
             1,
             translate!("truncate-error-missing-file-operand"),
-        ))
-    } else {
-        let io_blocks = matches.get_flag(options::IO_BLOCKS);
-        let no_create = matches.get_flag(options::NO_CREATE);
-        let reference = matches
-            .get_one::<String>(options::REFERENCE)
-            .map(String::from);
-        let size = matches.get_one::<String>(options::SIZE).map(String::from);
-        truncate(no_create, io_blocks, reference, size, &files)
+        ));
     }
+
+    let io_blocks = matches.get_flag(options::IO_BLOCKS);
+    let no_create = matches.get_flag(options::NO_CREATE);
+    let reference = matches
+        .get_one::<String>(options::REFERENCE)
+        .map(String::from);
+    let size = matches.get_one::<String>(options::SIZE).map(String::from);
+
+    truncate(no_create, io_blocks, reference, size, &files)
 }
 
 pub fn uu_app() -> Command {

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -122,7 +122,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(String::from);
     let size = matches.get_one::<String>(options::SIZE).map(String::from);
 
-    truncate(no_create, io_blocks, reference, size, &files)
+    truncate(&files, no_create, io_blocks, reference, size)
 }
 
 pub fn uu_app() -> Command {
@@ -199,10 +199,10 @@ fn do_file_truncate(filename: &Path, create: bool, size: u64) -> UResult<()> {
 }
 
 fn file_truncate(
+    filename: &OsString,
     no_create: bool,
     reference_size: Option<u64>,
     mode: &TruncateMode,
-    filename: &OsString,
 ) -> UResult<()> {
     let path = Path::new(filename);
 
@@ -236,11 +236,11 @@ fn file_truncate(
 }
 
 fn truncate(
+    filenames: &[OsString],
     no_create: bool,
-    _: bool,
+    _io_blocks: bool, // TODO: implement handling
     reference: Option<String>,
     size: Option<String>,
-    filenames: &[OsString],
 ) -> UResult<()> {
     let reference_size = match reference {
         Some(reference_path) => {
@@ -284,7 +284,7 @@ fn truncate(
     // Process every file: a failure on one (e.g. a directory) must not
     // prevent the remaining files from being truncated.
     for filename in filenames {
-        show_if_err!(file_truncate(no_create, reference_size, &mode, filename));
+        show_if_err!(file_truncate(filename, no_create, reference_size, &mode));
     }
 
     Ok(())


### PR DESCRIPTION
This PR applies a few trivial refactorings:
* it removes an unnecessary `Path::new` call
* it removes an unnecessary `app` variable
* it adds an early return in `uumain`
* it changes the signatures of two of the three "truncate" functions so that the first param of all functions is a filename or a slice of filenames