### PR TITLE
fix(chown,chgrp): print --verbose success lines to stdout

### DIFF
--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -363,11 +363,13 @@ impl ChownExecutor {
 
             match chown_result {
                 Ok(n) => {
-                    if !n.is_empty() {
+                    if n.is_empty() {
+                        0
+                    } else {
                         // GNU: informational verbose/changes lines go to stdout.
-                        return self.write_verbose_line(&n);
+                        // Do not return early: recursive descent still has to run.
+                        self.write_verbose_line(&n)
                     }
-                    0
                 }
                 Err(e) => {
                     if self.verbosity.level != VerbosityLevel::Silent {

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -364,7 +364,8 @@ impl ChownExecutor {
             match chown_result {
                 Ok(n) => {
                     if !n.is_empty() {
-                        show_error!("{n}");
+                        // GNU: informational verbose/changes lines go to stdout.
+                        return self.write_verbose_line(&n);
                     }
                     0
                 }
@@ -678,7 +679,8 @@ impl ChownExecutor {
             ) {
                 Ok(n) => {
                     if !n.is_empty() {
-                        show_error!("{n}");
+                        // GNU: informational verbose/changes lines go to stdout.
+                        ret = ret.max(self.write_verbose_line(&n));
                     }
                     // retain previous errors
                     ret.max(0)
@@ -798,7 +800,8 @@ impl ChownExecutor {
                             entries::gid2grp(dest_gid).unwrap_or_else(|_| dest_gid.to_string())
                         )
                     };
-                    show_error!("{output}");
+                    // GNU: informational verbose/changes output goes to stdout.
+                    return self.write_verbose_line(&output);
                 }
                 _ => (),
             }
@@ -817,7 +820,8 @@ impl ChownExecutor {
                     entries::gid2grp(dest_gid).unwrap_or_else(|_| dest_gid.to_string())
                 )
             };
-            show_error!("{output}");
+            // GNU: informational verbose output goes to stdout.
+            return self.write_verbose_line(&output);
         }
         0
     }

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -233,8 +233,9 @@ fn test_reference_multi_no_equal() {
         .arg("file1")
         .arg("file2")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as ")
-        .stderr_contains("\nchgrp: group of 'file2' retained as ");
+        .stdout_contains("group of 'file1' retained as ")
+        .stdout_contains("\ngroup of 'file2' retained as ")
+        .no_stderr();
 }
 
 #[test]
@@ -248,9 +249,10 @@ fn test_reference_last() {
         .arg("--reference")
         .arg("ref_file")
         .succeeds()
-        .stderr_contains("chgrp: group of 'file1' retained as ")
-        .stderr_contains("\nchgrp: group of 'file2' retained as ")
-        .stderr_contains("\nchgrp: group of 'file3' retained as ");
+        .stdout_contains("group of 'file1' retained as ")
+        .stdout_contains("\ngroup of 'file2' retained as ")
+        .stdout_contains("\ngroup of 'file3' retained as ")
+        .no_stderr();
 }
 
 #[test]
@@ -511,7 +513,8 @@ fn test_verbosity_messages() {
         .arg("--reference=ref_file")
         .arg("target_file")
         .succeeds()
-        .stderr_contains("group of 'target_file' retained as ");
+        .stdout_contains("group of 'target_file' retained as ")
+        .no_stderr();
 }
 
 #[test]

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -105,7 +105,8 @@ fn test_chown_only_owner() {
         .arg("--verbose")
         .arg(file1)
         .succeeds()
-        .stderr_contains("retained as");
+        .stdout_contains("retained as")
+        .no_stderr();
 
     // try to change to another existing user, e.g. 'root'
     scene
@@ -140,7 +141,8 @@ fn test_chown_only_owner_colon() {
         .arg("--verbose")
         .arg(file1)
         .succeeds()
-        .stderr_contains("retained as");
+        .stdout_contains("retained as")
+        .no_stderr();
 
     scene
         .ucmd()
@@ -148,7 +150,7 @@ fn test_chown_only_owner_colon() {
         .arg("--verbose")
         .arg(file1)
         .succeeds()
-        .stderr_contains("retained as")
+        .stdout_contains("retained as")
         .stderr_contains("warning: '.' should be ':'");
 
     scene
@@ -205,9 +207,10 @@ fn test_chown_dot_separator_warning() {
     result.stderr_contains("warning: '.' should be ':'");
     // "retained as" on Linux, "changed ownership" on BSDs (group inherited from parent dir)
     assert!(
-        result.stderr_str().contains("retained as")
-            || result.stderr_str().contains("changed ownership"),
-        "expected verbose ownership output, got: {}",
+        result.stdout_str().contains("retained as")
+            || result.stdout_str().contains("changed ownership"),
+        "expected verbose ownership output, got stdout={:?} stderr={:?}",
+        result.stdout_str(),
         result.stderr_str()
     );
 
@@ -238,7 +241,8 @@ fn test_chown_only_colon() {
     if skipping_test_is_okay(&result, "No such id") {
         return;
     }
-    result.stderr_contains("retained as"); // TODO: verbose is not printed to stderr in GNU chown
+    result.stdout_contains("retained as");
+    result.no_stderr(); // GNU prints --verbose retained/changed lines to stdout
 
     // test chown : file.txt
     // expected:
@@ -309,7 +313,7 @@ fn test_chown_owner_group() {
     if skipping_test_is_okay(&result, "chown: invalid group:") {
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     scene
         .ucmd()
@@ -371,7 +375,7 @@ fn test_chown_various_input() {
     if skipping_test_is_okay(&result, "chown: invalid group:") {
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     // check that username.groupname is understood
     let result = scene
@@ -383,7 +387,7 @@ fn test_chown_various_input() {
     if skipping_test_is_okay(&result, "chown: invalid group:") {
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     // Fails as user.name doesn't exist in the CI
     // but it is valid
@@ -420,7 +424,7 @@ fn test_chown_only_group() {
         .arg("--verbose")
         .arg(file1)
         .run();
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
     result.success();
 
     // FreeBSD user on CI is part of wheel group
@@ -458,7 +462,7 @@ fn test_chown_only_user_id() {
         // stderr: "chown: invalid user: '1001'
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     scene
         .ucmd()
@@ -552,7 +556,7 @@ fn test_chown_only_group_id() {
         // With mac into the CI, we can get this answer
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     // Apparently on CI "macos-latest, x86_64-apple-darwin, feat_os_unix"
     // the process has the rights to change from runner:staff to runner:wheel
@@ -628,7 +632,7 @@ fn test_chown_owner_group_id() {
         // stderr: "chown: invalid user: '1001:116'
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     let result = scene
         .ucmd()
@@ -641,7 +645,7 @@ fn test_chown_owner_group_id() {
         // stderr: "chown: invalid user: '1001.116'
         return;
     }
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     scene
         .ucmd()
@@ -683,7 +687,7 @@ fn test_chown_owner_group_mix() {
         .arg("--verbose")
         .arg(file1)
         .run();
-    result.stderr_contains("retained as");
+    result.stdout_contains("retained as");
 
     scene
         .ucmd()
@@ -721,8 +725,8 @@ fn test_chown_recursive() {
         .arg("a")
         .arg("z")
         .succeeds()
-        .stderr_contains("ownership of 'a/a' retained as")
-        .stderr_contains("ownership of 'z/y' retained as");
+        .stdout_contains("ownership of \'a/a\' retained as")
+        .stdout_contains("ownership of \'z/y\' retained as");
 }
 
 #[test]
@@ -895,8 +899,8 @@ fn test_chown_reference_file() {
         .arg("a")
         .arg("b")
         .succeeds()
-        .stderr_contains("ownership of 'b' retained as")
-        .no_stdout();
+        .stdout_contains("ownership of 'b' retained as")
+        .no_stderr();
 }
 
 #[test]
@@ -963,26 +967,26 @@ fn test_chown_symlink_cycles() {
 
     if cfg!(target_os = "macos") || cfg!(target_os = "openbsd") || cfg!(target_os = "android") {
         result
-            .stderr_contains(format!("ownership of 'a' retained as {user_name}"))
-            .stderr_contains(format!("ownership of 'a/b' retained as {user_name}"))
-            .stderr_contains(format!("ownership of 'a/b/c' retained as {user_name}"))
-            .stderr_does_not_contain(format!("ownership of 'a/b/c/d' retained as {user_name}"))
-            .stderr_does_not_contain(format!("ownership of 'a/b/c/d/b' retained as {user_name}"))
-            .stderr_does_not_contain(format!(
+            .stdout_contains(format!("ownership of 'a' retained as {user_name}"))
+            .stdout_contains(format!("ownership of 'a/b' retained as {user_name}"))
+            .stdout_contains(format!("ownership of 'a/b/c' retained as {user_name}"))
+            .stdout_does_not_contain(format!("ownership of 'a/b/c/d' retained as {user_name}"))
+            .stdout_does_not_contain(format!("ownership of 'a/b/c/d/b' retained as {user_name}"))
+            .stdout_does_not_contain(format!(
                 "ownership of 'a/b/c/d/b/c' retained as {user_name}"
             ));
     } else {
         result
             .success()
-            .stderr_contains(format!("ownership of 'a' retained as {user_name}"))
-            .stderr_contains(format!("ownership of 'a/b' retained as {user_name}"))
-            .stderr_contains(format!("ownership of 'a/b/c' retained as {user_name}"))
-            .stderr_contains(format!("ownership of 'a/b/c/d' retained as {user_name}"))
-            .stderr_does_not_contain(format!("ownership of 'a/b/c/d/b' retained as {user_name}"))
-            .stderr_does_not_contain(format!(
+            .stdout_contains(format!("ownership of 'a' retained as {user_name}"))
+            .stdout_contains(format!("ownership of 'a/b' retained as {user_name}"))
+            .stdout_contains(format!("ownership of 'a/b/c' retained as {user_name}"))
+            .stdout_contains(format!("ownership of 'a/b/c/d' retained as {user_name}"))
+            .stdout_does_not_contain(format!("ownership of 'a/b/c/d/b' retained as {user_name}"))
+            .stdout_does_not_contain(format!(
                 "ownership of 'a/b/c/d/b/c' retained as {user_name}"
             ))
-            .stderr_does_not_contain(format!(
+            .stdout_does_not_contain(format!(
                 "ownership of 'a/b/c/d/b/c/d' retained as {user_name}"
             ));
     }
@@ -1017,13 +1021,13 @@ fn test_chown_symlink_two_links_same_dir() {
     if cfg!(target_os = "linux") {
         result
             .success()
-            .stderr_contains(format!(
+            .stdout_contains(format!(
                 "ownership of 'base/realdir/file' retained as {user_name}"
             ))
-            .stderr_contains(format!(
+            .stdout_contains(format!(
                 "ownership of 'base/link1/file' retained as {user_name}"
             ))
-            .stderr_contains(format!(
+            .stdout_contains(format!(
                 "ownership of 'base/link2/file' retained as {user_name}"
             ));
     }

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -725,8 +725,8 @@ fn test_chown_recursive() {
         .arg("a")
         .arg("z")
         .succeeds()
-        .stdout_contains("ownership of \'a/a\' retained as")
-        .stdout_contains("ownership of \'z/y\' retained as");
+        .stdout_contains("ownership of 'a/a' retained as")
+        .stdout_contains("ownership of 'z/y' retained as");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
`chown`/`chgrp --verbose` was printing successful `changed`/`retained` lines to stderr with a `chown:`/`chgrp:` prefix because `report_ownership_change_success` and the `wrap_chown` Ok path used `show_error!`.

GNU prints those informational lines to **stdout** with **no** util-name prefix. This PR routes success-path verbose/changes output through `println!` and leaves real errors on stderr.

## Changes
- `src/uucore/src/lib/features/perms.rs`: success verbose/changes → stdout
- `tests/by-util/test_chown.rs`, `tests/by-util/test_chgrp.rs`: assert retained/changed lines on stdout

## Test plan
- [ ] CI `test_chown` / `test_chgrp`
- [ ] Manual: `chgrp --verbose "$(id -gn)" file >out 2>err` → line in `out`, empty `err`, no `chgrp:` prefix

Fixes #13408
