### PR TITLE
printf, csplit: fix formatting for zero value when precision is zero

### DIFF
--- a/src/uucore/src/lib/features/format/num_format.rs
+++ b/src/uucore/src/lib/features/format/num_format.rs
@@ -73,7 +73,9 @@ pub enum NumberAlignment {
 
 pub struct SignedInt {
     pub width: usize,
-    pub precision: usize,
+    // None if no precision is given. Some(0) is an explicit `.0`, which prints
+    // no digits at all for a zero value.
+    pub precision: Option<usize>,
     pub positive_sign: PositiveSign,
     pub alignment: NumberAlignment,
 }
@@ -82,10 +84,10 @@ impl Formatter<i64> for SignedInt {
     fn fmt(&self, writer: impl Write, x: i64) -> std::io::Result<()> {
         // -i64::MIN is actually 1 larger than i64::MAX, so we need to cast to i128 first.
         let abs = (x as i128).abs();
-        let s = if self.precision > 0 {
-            zero_pad_to(&abs.to_string(), self.precision)
-        } else {
-            abs.to_string()
+        let s = match (self.precision, abs) {
+            (Some(0), 0) => String::new(),
+            (Some(precision), _) => zero_pad_to(&abs.to_string(), precision),
+            (None, _) => abs.to_string(),
         };
 
         let sign_indicator = get_sign_indicator(self.positive_sign, x.is_negative());
@@ -112,8 +114,8 @@ impl Formatter<i64> for SignedInt {
         };
 
         let precision = match precision {
-            Some(CanAsterisk::Fixed(x)) => x,
-            None => 0,
+            Some(CanAsterisk::Fixed(x)) => Some(x),
+            None => None,
             Some(CanAsterisk::Asterisk(_)) => return Err(FormatError::WrongSpecType),
         };
 
@@ -129,7 +131,9 @@ impl Formatter<i64> for SignedInt {
 pub struct UnsignedInt {
     pub variant: UnsignedIntVariant,
     pub width: usize,
-    pub precision: usize,
+    // None if no precision is given. Some(0) is an explicit `.0`, which prints
+    // no digits at all for a zero value.
+    pub precision: Option<usize>,
     pub alignment: NumberAlignment,
 }
 
@@ -149,11 +153,22 @@ impl Formatter<u64> for UnsignedInt {
         let prefix = match (x, self.variant) {
             (1.., UnsignedIntVariant::Hexadecimal(Case::Lowercase, Prefix::Yes)) => "0x",
             (1.., UnsignedIntVariant::Hexadecimal(Case::Uppercase, Prefix::Yes)) => "0X",
-            (1.., UnsignedIntVariant::Octal(Prefix::Yes)) if s.len() >= self.precision => "0",
+            (1.., UnsignedIntVariant::Octal(Prefix::Yes))
+                if s.len() >= self.precision.unwrap_or(0) =>
+            {
+                "0"
+            }
             _ => "",
         };
 
-        s = format!("{prefix}{}", zero_pad_to(&s, self.precision));
+        // `%#o` is the exception: the `#` flag still forces a single `0`.
+        s = match (self.precision, x) {
+            (Some(0), 0) => match self.variant {
+                UnsignedIntVariant::Octal(Prefix::Yes) => String::from("0"),
+                _ => String::new(),
+            },
+            (precision, _) => format!("{prefix}{}", zero_pad_to(&s, precision.unwrap_or(0))),
+        };
         write_output(writer, String::new(), s, self.width, self.alignment)
     }
 
@@ -196,8 +211,8 @@ impl Formatter<u64> for UnsignedInt {
         };
 
         let precision = match precision {
-            Some(CanAsterisk::Fixed(x)) => x,
-            None => 0,
+            Some(CanAsterisk::Fixed(x)) => Some(x),
+            None => None,
             Some(CanAsterisk::Asterisk(_)) => return Err(FormatError::WrongSpecType),
         };
 
@@ -800,7 +815,7 @@ mod test {
             UnsignedInt {
                 variant: UnsignedIntVariant::Octal(Prefix::Yes),
                 width: 0,
-                precision: 0,
+                precision: Some(0),
                 alignment: NumberAlignment::Left,
             }
             .fmt(&mut s, x)
@@ -1254,12 +1269,24 @@ mod test {
     }
 
     #[test]
-    #[ignore = "Need issue #7509 to be fixed"]
     fn format_signed_int_precision_zero() {
         let format = Format::<SignedInt, i64>::parse("%.0d").unwrap();
         assert_eq!(fmt(&format, 123i64), "123");
         // From cppreference.com: "If both the converted value and the precision are ​0​ the conversion results in no characters."
         assert_eq!(fmt(&format, 0i64), "");
+        assert_eq!(fmt(&format, -5i64), "-5");
+        assert_eq!(
+            fmt(&Format::<SignedInt, i64>::parse("%+.0d").unwrap(), 0i64),
+            "+"
+        );
+        assert_eq!(
+            fmt(&Format::<SignedInt, i64>::parse("% .0d").unwrap(), 0i64),
+            " "
+        );
+        assert_eq!(
+            fmt(&Format::<SignedInt, i64>::parse("X%6.0dX").unwrap(), 0i64),
+            "X      X"
+        );
     }
 
     #[test]
@@ -1278,23 +1305,18 @@ mod test {
         assert_eq!(f("%+6u", 123u64), "   123"); // '+' is ignored for unsigned numbers.
         assert_eq!(f("% u", 123u64), "123"); // ' ' is ignored for unsigned numbers.
         assert_eq!(f("%#x", 0), "0"); // No prefix for 0
-    }
-
-    #[test]
-    #[ignore = "Need issues #7509 and #7510 to be fixed"]
-    fn format_unsigned_int_broken() {
-        // TODO: Merge this back into format_unsigned_int.
-        let f = |fmt_str: &str, n: u64| {
-            let format = Format::<UnsignedInt, u64>::parse(fmt_str).unwrap();
-            fmt(&format, n)
-        };
-
-        // #7509
-        assert_eq!(f("%.0o", 0), "");
-        assert_eq!(f("%#0o", 0), "0"); // Already correct, but probably an accident.
-        assert_eq!(f("%.0x", 0), "");
-        // #7510
+        assert_eq!(f("%u", 0), "0");
         assert_eq!(f("%#06x", 123u64), "0x007b");
+        // A zero value with an explicit precision of zero prints no digits.
+        assert_eq!(f("%.0u", 0), "");
+        assert_eq!(f("%.0o", 0), "");
+        assert_eq!(f("%.0x", 0), "");
+        assert_eq!(f("%#.0x", 0), "");
+        assert_eq!(f("%#.0o", 0), "0"); // `#` still forces a single 0
+        assert_eq!(f("%#0o", 0), "0");
+        assert_eq!(f("X%#6.0oX", 0), "X     0X");
+        assert_eq!(f("%.0u", 123u64), "123");
+        assert_eq!(f("%#.0o", 5), "05");
     }
 
     #[test]

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -414,10 +414,12 @@ impl Spec {
                 position,
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
-                let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
+                let precision = resolve_asterisk_precision(*precision, args);
                 let i = args.next_i64(*position);
 
-                check_precision(precision)?;
+                if let Some(precision) = precision {
+                    check_precision(precision)?;
+                }
 
                 num_format::SignedInt {
                     width,
@@ -440,10 +442,12 @@ impl Spec {
                 position,
             } => {
                 let (width, neg_width) = resolve_asterisk_width(*width, args).unwrap_or((0, false));
-                let precision = resolve_asterisk_precision(*precision, args).unwrap_or_default();
+                let precision = resolve_asterisk_precision(*precision, args);
                 let i = args.next_u64(*position);
 
-                check_precision(precision)?;
+                if let Some(precision) = precision {
+                    check_precision(precision)?;
+                }
 
                 num_format::UnsignedInt {
                     variant: *variant,
@@ -526,7 +530,7 @@ fn resolve_asterisk_precision(
         None => None,
         Some(CanAsterisk::Asterisk(loc)) => match args.next_i64(loc) {
             v if v >= 0 => usize::try_from(v).ok(),
-            v if v < 0 => Some(0usize),
+            // A negative precision is treated as if the precision were omitted.
             _ => None,
         },
         Some(CanAsterisk::Fixed(w)) => Some(w),
@@ -709,14 +713,14 @@ mod tests {
             );
 
             assert_eq!(
-                Some(0),
+                None,
                 resolve_asterisk_precision(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
                     &mut FormatArguments::new(&[FormatArgument::SignedInt(-42)]),
                 )
             );
             assert_eq!(
-                Some(0),
+                None,
                 resolve_asterisk_precision(
                     Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
                     &mut FormatArguments::new(&[FormatArgument::Unparsed("-42".into())]),

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1432,6 +1432,21 @@ fn precision_format() {
 }
 
 #[test]
+fn zero_precision_format() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "10", "--suffix-format", "%.0d"])
+        .succeeds()
+        .stdout_only("18\n123\n");
+
+    let count = glob(&at.plus_as_string("xx*"))
+        .expect("there should be splits created")
+        .count();
+    assert_eq!(count, 2);
+    assert_eq!(at.read("xx"), generate(1, 10));
+    assert_eq!(at.read("xx1"), generate(10, 51));
+}
+
+#[test]
 fn zero_error() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("in");

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1051,6 +1051,20 @@ fn float_with_zero_precision_should_pad() {
 }
 
 #[test]
+fn int_with_zero_precision_and_zero_value() {
+    new_ucmd!().args(&["%.0d", "0"]).succeeds().stdout_only("");
+    new_ucmd!()
+        .args(&["%#.0o", "0"])
+        .succeeds()
+        .stdout_only("0");
+    // A negative `*` precision counts as no precision at all.
+    new_ucmd!()
+        .args(&["%.*d", "-1", "0"])
+        .succeeds()
+        .stdout_only("0");
+}
+
+#[test]
 fn float_non_finite() {
     new_ucmd!()
         .args(&[


### PR DESCRIPTION
`printf '%.0d' 0` prints `0`, but C says a zero value with a precision of zero produces no characters. csplit uses the same formatter, so `csplit -b '%.0d'` names its first file `xx0` where GNU names it `xx`.

The integer formatters now carry `Option<usize>` precision like `Float` already did, so an explicit `.0` is distinct from no precision. `%#o` still forces a single `0`.

A negative `*` precision now counts as no precision, matching GNU. Without that `%.*d -1 0` would start printing nothing, and `%.*s -1` and `%.*f -1` change too.

Picks up the approach from the stalled #8351.

Fixes #7509
Fixes #13119
