### PR TITLE
paste: reset the delimiter list per file in serial mode

### DIFF
--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -151,6 +151,11 @@ fn paste(
 
             stdout.write_all(&output)?;
             stdout.write_all(line_ending_byte_array_ref)?;
+
+            // In serial mode each input file is concatenated onto its own
+            // output line, so the delimiter list has to restart from its first
+            // element for the next file rather than carrying the cycle over.
+            delimiter_state.reset_to_first_delimiter();
         }
     } else {
         let mut eof = vec![false; input_source_vec_len];
@@ -307,7 +312,6 @@ impl<'a> DelimiterState<'a> {
     }
 
     /// This should only be used to return to the start of the delimiter list after a file has been processed.
-    /// This should only be used when the "serial" option is disabled.
     /// This is a no-op unless there are multiple delimiters.
     fn reset_to_first_delimiter(&mut self) {
         if let DelimiterState::MultipleDelimiters {

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -276,6 +276,25 @@ FIRST!SECOND@THIRD#FOURTH!ABCDEFG
     }
 }
 
+// With `-s`, each input file is written as its own output line, so the
+// delimiter list must restart from its first element for every file instead
+// of carrying the cycle over from the previous one.
+#[test]
+fn test_serial_delimiter_list_resets_per_file() {
+    for option_style in ["-d", "--delimiters"] {
+        for serial in ["-s", "--serial"] {
+            let (at, mut ucmd) = at_and_ucmd!();
+            at.write("f1", "a\nb\n");
+            at.write("f2", "c\nd\ne\n");
+            at.write("f3", "f\ng\n");
+
+            ucmd.args(&[option_style, ":|", serial, "f1", "f2", "f3"])
+                .succeeds()
+                .stdout_only("a:b\nc:d|e\nf:g\n");
+        }
+    }
+}
+
 #[test]
 #[cfg(unix)]
 fn test_non_utf8_input() {


### PR DESCRIPTION
### Description

In `paste -s` (serial) mode, the multiple-delimiter (`-d`) cycle was created once and carried across files. Each input file is its own output line, so the delimiter list must restart from its first element per file — GNU does this, and uutils's own non-serial branch already does it — so subsequent files began at the wrong delimiter:

```console
$ printf 'a\nb\n' > f1; printf 'c\nd\ne\n' > f2; printf 'f\ng\n' > f3
$ paste -s -d ':|' f1 f2 f3
# before: a:b / c:d|e / f|g      (3rd file continued at '|')
# after:  a:b / c:d|e / f:g      (matches GNU)
```

### Fix

`DelimiterState::reset_to_first_delimiter()` already exists and is called per output line in the non-serial branch; call it at the end of each file iteration in the serial loop too, and drop the stale doc comment that said the reset must not be used in serial mode.

### Tests

Added `test_serial_delimiter_list_resets_per_file` (fails on the previous code, passes now). Verified red→green against GNU coreutils across a delimiter/file matrix; `cargo test -p uu_paste` passes (15/15), clippy + fmt clean.

Fixes #13438
