### PR TITLE
date: preserve invalid timezone format strings

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -100,7 +100,7 @@ struct ParsedSpec<'a> {
 
 /// Try to parse a format spec at the start of `s`.
 ///
-/// Implements the grammar `%[_0^#+-]*[0-9]*:*[a-zA-Z]` anchored at the
+/// Implements the grammar `%[_0^#+-]*[0-9]*:{0,3}[a-zA-Z]` anchored at the
 /// beginning of `s`. Returns `None` if `s` does not start with `%` or no
 /// valid specifier follows.
 fn parse_format_spec(s: &str) -> Option<ParsedSpec<'_>> {
@@ -129,9 +129,9 @@ fn parse_format_spec(s: &str) -> Option<ParsedSpec<'_>> {
         None
     };
 
-    // Specifier: zero or more `:` followed by a single ASCII letter.
+    // Specifier: up to three `:` followed by a single ASCII letter.
     let spec_start = pos;
-    while pos < bytes.len() && bytes[pos] == b':' {
+    while pos < bytes.len() && bytes[pos] == b':' && pos - spec_start < 3 {
         pos += 1;
     }
     if pos >= bytes.len() || !bytes[pos].is_ascii_alphabetic() {
@@ -1006,6 +1006,7 @@ mod tests {
             ("%:z", Some(("", None, ":z", 3))),
             ("%::z", Some(("", None, "::z", 4))),
             ("%:::z", Some(("", None, ":::z", 5))),
+            ("%::::z", None),
             ("%-3:z", Some(("-", Some(3), ":z", 5))),
             // ---- only the spec is consumed; trailing text is ignored ----
             ("%Y-%m-%d", Some(("", None, "Y", 2))),

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -601,6 +601,14 @@ fn test_invalid_format_string() {
 }
 
 #[test]
+fn test_invalid_format_string_with_too_many_colons() {
+    new_ucmd!()
+        .arg("+%_::::z")
+        .succeeds()
+        .stdout_is("%_::::z\n");
+}
+
+#[test]
 fn test_capitalized_numeric_time_zone() {
     // %z     +hhmm numeric time zone (e.g., -0400)
     // # is supposed to capitalize, which makes little sense here, but keep coverage


### PR DESCRIPTION
Fixes #12876.

`date` accepted arbitrarily many colons before a format specifier, causing an invalid string such as `%_::::z` to consume and discard the `_` modifier.

Limit timezone colon modifiers to three so invalid format strings are preserved literally, matching GNU. Add parser and command-level regression coverage.
