### PR TITLE
tail: continue processing files after error

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -85,7 +85,9 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
                 tail_stdin(settings, &mut printer, input, &mut observer)?;
             }
             InputKind::File(path) => {
-                tail_file(settings, &mut printer, input, path, &mut observer, 0)?;
+                if let Err(err) = tail_file(settings, &mut printer, input, path, &mut observer, 0) {
+                    show!(err);
+                }
             }
         }
     }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -5217,3 +5217,13 @@ fn test_follow_symlink_target_change() {
         .stdout_contains("A\n")
         .stdout_contains("B\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_no_skip_after_error() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f", "hello");
+    ucmd.args(&["/proc/self/mem", "f"])
+        .fails()
+        .stdout_contains("hello");
+}


### PR DESCRIPTION
Fixes #13137.

When tail encounters an error with one file, it stops execution and skips the rest of files to process.

The fix captures the error, shows it and continues calling `tail_file` on the other arguments.