### PR TITLE
benchmarks: reduce CodSpeed CI load to avoid cache API rate limits

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-      - '*'
+      - main
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -25,6 +25,9 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
     strategy:
+      # Stagger the jobs: 70 concurrent runners hitting the GitHub cache API
+      # (rust-cache + sccache + CodSpeed) at once triggers HTTP 429s.
+      max-parallel: 12
       matrix:
         type: [simulation, memory]
         package: [


### PR DESCRIPTION
Run on push only for main (PR branches already get a pull_request run with identical results) and cap the 70-job matrix at 12 concurrent jobs so the GitHub cache API is not hit by all of them at once.