### PR TITLE
dd: write complete blocks without buffering them first

### DIFF
--- a/src/uu/dd/src/bufferedoutput.rs
+++ b/src/uu/dd/src/bufferedoutput.rs
@@ -68,13 +68,34 @@ impl<'a> BufferedOutput<'a> {
     /// block. The returned [`WriteStat`] object will include the
     /// number of blocks written during execution of this function.
     pub(crate) fn write_blocks(&mut self, buf: &[u8]) -> std::io::Result<WriteStat> {
+        let obs = self.inner.settings.obs;
+
+        // Fast path: with no partial block pending, the complete blocks can
+        // go straight to the inner writer, instead of being copied into the
+        // internal buffer only to be written and cleared again. This is the
+        // common case: whenever the incoming length is a multiple of `obs`
+        // -- as it is for the copy loop's usual full-sized reads -- nothing
+        // is left pending for the next call.
+        if self.buf.is_empty() {
+            let complete = buf.len() - buf.len() % obs;
+            if complete == 0 {
+                // Not even one complete block: buffer the whole thing and
+                // write zero blocks.
+                self.buf.extend_from_slice(buf);
+                return Ok(WriteStat::default());
+            }
+            let wstat = self.inner.write_blocks(&buf[..complete])?;
+            self.buf.extend_from_slice(&buf[complete..]);
+            return Ok(wstat);
+        }
+
         // Split the incoming buffer into two parts: the bytes to write
         // and the bytes to buffer for next time.
         //
         // If `buf` does not include enough bytes to form a full block,
         // just buffer the whole thing and write zero blocks.
         let n = self.buf.len() + buf.len();
-        let rem = n % self.inner.settings.obs;
+        let rem = n % obs;
         let i = buf.len().saturating_sub(rem);
         let (to_write, to_buffer) = buf.split_at(i);
 

--- a/src/uu/dd/src/bufferedoutput.rs
+++ b/src/uu/dd/src/bufferedoutput.rs
@@ -70,17 +70,10 @@ impl<'a> BufferedOutput<'a> {
     pub(crate) fn write_blocks(&mut self, buf: &[u8]) -> std::io::Result<WriteStat> {
         let obs = self.inner.settings.obs;
 
-        // Fast path: with no partial block pending, the complete blocks can
-        // go straight to the inner writer, instead of being copied into the
-        // internal buffer only to be written and cleared again. This is the
-        // common case: whenever the incoming length is a multiple of `obs`
-        // -- as it is for the copy loop's usual full-sized reads -- nothing
-        // is left pending for the next call.
+        // Avoid copying complete blocks through the internal buffer.
         if self.buf.is_empty() {
             let complete = buf.len() - buf.len() % obs;
             if complete == 0 {
-                // Not even one complete block: buffer the whole thing and
-                // write zero blocks.
                 self.buf.extend_from_slice(buf);
                 return Ok(WriteStat::default());
             }


### PR DESCRIPTION
`BufferedOutput::write_blocks` copies the incoming bytes into its internal buffer, hands that buffer to the inner writer, clears it, and then re-buffers the trailing partial block — even when nothing was pending and the incoming bytes already form complete blocks. That is the common case: the copy loop hands over a multiple of the output block size on every iteration, so each iteration paid for a full memcpy of the block.

## Change

With an empty internal buffer, write the complete blocks straight from the caller's slice and buffer only the remainder. The existing path is untouched and still handles a pending partial block. Pure optimization — no behavioural change.

## Measurements

Instruction counts via cachegrind on the CodSpeed simulation binaries (`cargo codspeed build -m simulation -p uu_dd`), same toolchain, both built from this PR's base:

| Benchmark | `main` | this PR | Δ |
| --- | ---: | ---: | ---: |
| `dd_copy_separate_blocks` | 55,916,646 | 5,447,251 | **−90.26%** |
| `dd_copy_default` | 36,615,676 | 30,718,154 | **−16.11%** |
| `dd_copy_with_seek` | 8,511,906 | 8,488,175 | −0.28% |
| `dd_copy_with_skip` | 8,412,120 | 8,389,437 | −0.27% |
| `dd_copy_4k_blocks` | 4,742,612 | 4,730,524 | −0.25% |
| `dd_copy_8k_blocks` | 4,408,987 | 4,401,037 | −0.18% |
| `dd_copy_partial` | 3,222,128 | 3,220,704 | −0.04% |
| `dd_copy_64k_blocks` | 5,107,029 | 5,105,557 | −0.03% |
| `dd_copy_1m_blocks` | 9,410,822 | 9,410,932 | +0.00% |

The two large wins are the configurations that actually use the buffered output path: `dd_copy_separate_blocks` (`ibs=8K obs=16K`) and `dd_copy_default` (no `bs`, so output is buffered). The measurement is deterministic — repeated runs of the same binary vary by ~2 instructions out of 36M.

Peak heap is unchanged: 236,549 → 236,546 bytes (DHAT, `ibs=8K obs=16K`, both binaries built in the same target directory).

## Testing

- `cargo test -p uu_dd` and the dd integration suite pass.
- Byte- and statistics-equivalence against `main` over 17 configurations (odd `ibs`/`obs`, `ibs`>`obs` and `obs`>`ibs`, `bs`, `conv=sync`/`block`/`unblock`/`swab`, `count`, `count_bytes`, `skip`/`seek`, `obs=1M`, `ibs=1M obs=7`): output and the `records in`/`records out` lines are identical in every one.
- `cargo fmt`, the repository clippy invocation (`util/run-clippy.py --features all --workspace`) and cspell are clean.

## Note

This touches the same function as #13459, which fixes a correctness bug in the pending-partial-block path. The two are independent — this PR only adds the empty-buffer fast path and leaves the existing branch alone — but they overlap textually, so whichever lands second needs a trivial rebase.
