### PR TITLE
ci: Change the spell detection strategy

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -149,6 +149,11 @@ jobs:
   style_spellcheck:
     name: Style/spelling
     runs-on: ${{ matrix.job.os }}
+    env:
+      # Spelling is enforced locally by the cspell pre-commit hook, where it is
+      # cheap to fix. Here it is advisory: unknown words show up as annotations
+      # on the diff instead of blocking the merge.
+      STYLE_FAIL_ON_FAULT: false
     strategy:
       matrix:
         job:
@@ -232,9 +237,6 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
 
-      - name: Install cspell
-        run: npm install -g cspell
-
       - name: Cache pre-commit environments
         uses: actions/cache@v6
         with:
@@ -244,4 +246,8 @@ jobs:
             pre-commit-${{ runner.os }}-
 
       - name: Run pre-commit
-        run: pre-commit run
+        env:
+          # cspell is enforced locally and reported by Style/spelling; the rust
+          # hooks are already covered by the Style/format and Style/lint jobs.
+          SKIP: cspell,rust-linting,rust-clippy,cargo-lock-check
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,22 @@ repos:
         files: \.ftl$
         args: [--config, .github/fluent_linter_config.yml, src/uu/]
 
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v10.0.1
+    hooks:
+      - id: cspell
+        # Pinned so the check does not depend on the node version a contributor
+        # happens to have installed; cspell v10 requires node >= 22.18.
+        language_version: '22.18.0'
+        args:
+          - --config
+          - .vscode/cSpell.json
+          - --no-must-find-files
+          - --no-progress
+          - --no-summary
+          - --gitignore
+          - --files # must stay last: pre-commit appends the filenames here
+
   - repo: local
     hooks:
       - id: rust-linting
@@ -51,12 +67,6 @@ repos:
         pass_filenames: false
         files: 'Cargo\.(toml|lock)$'
         language: system
-      - id: cspell
-        name: Code spell checker (cspell)
-        description: Run cspell to check for spelling errors (if available).
-        entry: bash -c 'if command -v cspell >/dev/null 2>&1; then cspell --no-must-find-files -- "$@"; else echo "cspell not found, skipping spell check"; exit 0; fi' --
-        pass_filenames: true
-        language: system
 
 ci:
-  skip: [rust-linting, rust-clippy, cargo-lock-check, cspell]
+  skip: [rust-linting, rust-clippy, cargo-lock-check]


### PR DESCRIPTION
I think we wasted too much time on typo detection. Let's avoid failing the build just for that
