### PR TITLE
numfmt: reject an oversized --from-unit/--to-unit instead of panicking

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -200,8 +200,12 @@ fn parse_unit_size(s: &str) -> Result<usize> {
             if number.is_empty() {
                 return Ok(multiplier);
             }
-            if let Ok(n) = number.parse::<usize>() {
-                return Ok(n * multiplier);
+            if let Some(size) = number
+                .parse::<usize>()
+                .ok()
+                .and_then(|n| n.checked_mul(multiplier))
+            {
+                return Ok(size);
             }
         }
     }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -878,7 +878,13 @@ fn test_to_unit() {
 #[test]
 fn test_invalid_unit_size() {
     let commands = vec!["from", "to"];
-    let invalid_sizes = vec!["A", "0", "18446744073709551616"];
+    let invalid_sizes = vec![
+        "A",
+        "0",
+        "18446744073709551616",
+        "18446744073709551615K",
+        "18014398509481984Ki",
+    ];
 
     for command in commands {
         for invalid_size in &invalid_sizes {


### PR DESCRIPTION
Fixes #13481.

`parse_unit_size` computed the unit size as `n * multiplier` with an unchecked multiplication. A large numeric part with a suffix overflows `usize`, surfacing as two panics:
- **remainder-by-zero (release build):** when the product wraps to exactly `0` (e.g. `--to-unit=18014398509481984Ki`, `2^54 * 1024 = 2^64`), the zero unit later reaches `integer % to_unit` and aborts (exit 134);
- **multiply overflow:** a merely-huge value (e.g. `--from-unit=18446744073709551615K`) overflows the multiply itself under `overflow-checks`, and wraps silently in the default release build.

```console
$ numfmt --to-unit=18014398509481984Ki --to=none 1000
thread 'main' panicked at src/uu/numfmt/src/format.rs:567:8:
attempt to calculate the remainder with a divisor of zero
$ echo $?
134
```

This uses `checked_mul` so an out-of-range product falls through to the existing `invalid unit size` error (exit 1) — matching GNU numfmt, whose `unit_to_umax` rejects any value that overflows `uintmax_t`:

```console
$ numfmt --to-unit=18014398509481984Ki --to=none 1000
numfmt: invalid unit size: '18014398509481984Ki'
$ echo $?
1
```

Extended `test_invalid_unit_size` with both overflow inputs.