### PR TITLE
numfmt: do not panic on a multibyte whitespace field separator

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -845,7 +845,7 @@ pub fn write_formatted_with_whitespace<W: std::io::Write + ?Sized>(
             // add delimiter before second and subsequent fields
             let prefix = if n > 1 {
                 writer.write_all(b" ").unwrap();
-                &prefix[1..]
+                &prefix[prefix.chars().next().map_or(0, char::len_utf8)..]
             } else {
                 prefix
             };

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -432,6 +432,16 @@ fn test_format_selected_field() {
 }
 
 #[test]
+fn test_field_with_multibyte_whitespace_separator() {
+    // A multibyte Unicode whitespace separator (U+3000) before a selected field
+    // is normalized to a single space rather than sliced mid-character.
+    new_ucmd!()
+        .args(&["--field", "2", "1　2"])
+        .succeeds()
+        .stdout_only("1 2\n");
+}
+
+#[test]
 fn test_format_selected_fields() {
     new_ucmd!()
         .args(&["--from=auto", "--field", "1,4,3", "1K 2K 3K 4K 5K 6K"])


### PR DESCRIPTION
Fixes #13482.

`write_formatted_with_whitespace` normalized the delimiter before the 2nd+ selected field by writing a single space and dropping the first byte of the leading whitespace run with `&prefix[1..]`. That assumed an ASCII separator, but `WhitespaceSplitter` splits on Unicode `char::is_whitespace`, so a multibyte separator (e.g. U+3000 IDEOGRAPHIC SPACE) made `&prefix[1..]` slice inside the character and abort:

```console
$ numfmt --field 2 $'1　2'
thread 'main' panicked at src/uu/numfmt/src/format.rs:848:24:
byte index 1 is not a char boundary; it is inside '\u{3000}' (bytes 0..3) of `　`
$ echo $?
134
```

This drops the first *character* (by its UTF-8 length) instead of the first byte, so the slice always lands on a char boundary. Output becomes `1 2`, exit 0.