### PR TITLE
numfmt: add --from=auto test for multibyte whitespace separator

### DIFF
--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -439,6 +439,12 @@ fn test_field_with_multibyte_whitespace_separator() {
         .args(&["--field", "2", "1　2"])
         .succeeds()
         .stdout_only("1 2\n");
+
+    new_ucmd!()
+        .args(&["--from=auto", "--field", "2"])
+        .pipe_in("1K\u{3000}2K\n")
+        .succeeds()
+        .stdout_only("1K 2000\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Rebased onto `main` after the panic fix landed in 7807c8d (#13482, now closed).

This PR adds pipe-input regression coverage for `--from=auto --field=2` when fields are separated by U+3000 IDEOGRAPHIC SPACE.

## Test plan
- [x] `cargo test test_field_with_multibyte_whitespace_separator`