### PR TITLE
tr: handle trailing-backslash warnings for both sets

### DIFF
--- a/src/uu/tr/locales/en-US.ftl
+++ b/src/uu/tr/locales/en-US.ftl
@@ -22,8 +22,8 @@ tr-error-write-error = write error
 
 # Warning messages
 tr-warning-unescaped-backslash = warning: an unescaped backslash at end of string is not portable
-tr-warning-ambiguous-octal-escape = the ambiguous octal escape \{ $origin_octal } is being interpreted as the 2-byte sequence \0{ $actual_octal_tail }, { $outstand_char }
-tr-warning-invalid-utf8 = invalid utf8 sequence
+tr-warning-ambiguous-octal-escape = warning: the ambiguous octal escape \{ $origin_octal } is being interpreted as the 2-byte sequence \0{ $actual_octal_tail }, { $outstand_char }
+tr-warning-invalid-utf8 = warning: invalid utf8 sequence
 
 # Sequence parsing error messages
 tr-error-missing-char-class-name = missing character class name '[::]'

--- a/src/uu/tr/locales/fr-FR.ftl
+++ b/src/uu/tr/locales/fr-FR.ftl
@@ -22,9 +22,9 @@ tr-error-write-error = erreur d'écriture
 
 # Messages d'avertissement
 tr-warning-unescaped-backslash = avertissement : une barre oblique inverse non échappée à la fin de la chaîne n'est pas portable
-tr-warning-ambiguous-octal-escape = l'échappement octal ambigu \{ $origin_octal } est en cours
+tr-warning-ambiguous-octal-escape = avertissement : l'échappement octal ambigu \{ $origin_octal } est en cours
   d'interprétation comme la séquence de 2 octets \0{ $actual_octal_tail }, { $outstand_char }
-tr-warning-invalid-utf8 = séquence UTF-8 non valide
+tr-warning-invalid-utf8 = avertissement : séquence UTF-8 non valide
 
 # Messages d'erreur d'analyse de séquence
 tr-error-missing-char-class-name = nom de classe de caractères manquant '[::]'

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -21,10 +21,28 @@ use std::{
     fmt::{Debug, Display},
     io::{BufRead, Write},
 };
-use uucore::error::{FromIo, UError, UResult};
+use uucore::error::{FromIo, UError, UResult, set_exit_code};
 use uucore::translate;
 
-use uucore::show_warning;
+/// Write a diagnostic to stderr, recording exit status 1 if the write fails.
+///
+/// Unlike `show_warning!`, this does not discard stderr write errors. The
+/// failure is recorded but not propagated, so translation of stdin continues
+/// and the translated stdout is preserved, as GNU does. A successful
+/// diagnostic leaves the stored status unchanged.
+fn emit_diagnostic(message: impl Display) {
+    let mut stderr = std::io::stderr().lock();
+
+    if writeln!(stderr, "{}: {message}", uucore::util_name()).is_err() {
+        set_exit_code(1);
+    }
+}
+
+/// Whether the raw operand ends in an odd-length run of backslashes, i.e. a
+/// final backslash that is not itself escaped.
+fn has_unescaped_trailing_backslash(input: &[u8]) -> bool {
+    input.iter().rev().take_while(|&&b| b == b'\\').count() % 2 == 1
+}
 
 /// Common trait for operations that can process chunks of data
 pub trait ChunkProcessor {
@@ -217,12 +235,18 @@ impl Sequence {
     ) -> Result<(Vec<u8>, Vec<u8>), BadSequence> {
         let is_char_star = |s: &&Self| -> bool { matches!(s, Self::CharStar(_)) };
 
+        // Both operands are parsed before either is validated, so that warnings
+        // and syntax errors from set2 are reported ahead of a semantic
+        // rejection of a syntactically valid set1, as GNU does. Set1 is still
+        // parsed first, so a syntax error in it prevents set2 from being
+        // parsed at all.
         let set1 = Self::from_str(set1_str)?;
+        let mut set2 = Self::from_str(set2_str)?;
+
         if set1.iter().filter(is_char_star).count() != 0 {
             return Err(BadSequence::CharRepeatInSet1);
         }
 
-        let mut set2 = Self::from_str(set2_str)?;
         if set2.iter().filter(is_char_star).count() > 1 {
             return Err(BadSequence::MultipleCharRepeatInSet2);
         }
@@ -350,7 +374,7 @@ impl Sequence {
 
 impl Sequence {
     pub fn from_str(input: &[u8]) -> Result<Vec<Self>, BadSequence> {
-        many0(alt((
+        let parsed = many0(alt((
             Self::parse_char_range,
             Self::parse_char_star,
             Self::parse_char_repeat,
@@ -363,9 +387,16 @@ impl Sequence {
         )))
         .parse(input)
         .map(|(_, r)| r)
-        .unwrap()
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+        // Warn once per operand, after the whole operand has been scanned, so
+        // that this warning follows any warning emitted while parsing it and
+        // precedes a syntax error found in the same operand.
+        if has_unescaped_trailing_backslash(input) {
+            emit_diagnostic(translate!("tr-warning-unescaped-backslash"));
+        }
+
+        parsed.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn parse_octal(input: &[u8]) -> IResult<&[u8], u8> {
@@ -409,12 +440,11 @@ impl Sequence {
                     if let Ok(origin_octal) = std::str::from_utf8(input) {
                         let actual_octal_tail: &str = std::str::from_utf8(&input[0..2]).unwrap();
                         let outstand_char: char = char::from_u32(input[2] as u32).unwrap();
-                        show_warning!(
-                            "{}",
+                        emit_diagnostic(
                             translate!("tr-warning-ambiguous-octal-escape", "origin_octal" => origin_octal, "actual_octal_tail" => actual_octal_tail, "outstand_char" => outstand_char)
                         );
                     } else {
-                        show_warning!("{}", translate!("tr-warning-invalid-utf8"));
+                        emit_diagnostic(translate!("tr-warning-invalid-utf8"));
                     }
                 }
                 result

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -19,7 +19,7 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::fs::is_stdin_directory;
 use uucore::translate;
-use uucore::{format_usage, os_str_as_bytes, show};
+use uucore::{format_usage, os_str_as_bytes};
 
 mod options {
     pub const COMPLEMENT: &str = "complement";
@@ -81,18 +81,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let op = sets[2].quote();
             let msg = translate!("tr-error-extra-operand-simple", "operand" => op);
             return Err(UUsageError::new(1, msg));
-        }
-    }
-
-    if let Some(first) = sets.first() {
-        let slice = os_str_as_bytes(first)?;
-        let trailing_backslashes = slice.iter().rev().take_while(|&&c| c == b'\\').count();
-        if trailing_backslashes % 2 == 1 {
-            // The trailing backslash has a non-backslash character before it.
-            show!(USimpleError::new(
-                0,
-                translate!("tr-warning-unescaped-backslash")
-            ));
         }
     }
 

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1573,6 +1573,116 @@ fn test_trailing_backslash() {
 }
 
 #[test]
+fn test_trailing_backslash_warning_in_set2() {
+    new_ucmd!()
+        .args(&[".", r"\"])
+        .pipe_in(".")
+        .succeeds()
+        .stderr_is("tr: warning: an unescaped backslash at end of string is not portable\n")
+        .stdout_is("\\");
+}
+
+#[test]
+fn test_trailing_backslash_warning_in_both_sets() {
+    new_ucmd!()
+        .args(&[r"\", r"\"])
+        .pipe_in("\\")
+        .succeeds()
+        .stderr_is(concat!(
+            "tr: warning: an unescaped backslash at end of string is not portable\n",
+            "tr: warning: an unescaped backslash at end of string is not portable\n",
+        ))
+        .stdout_is("\\");
+}
+
+#[test]
+fn test_escaped_trailing_backslash_in_set2_does_not_warn() {
+    new_ucmd!()
+        .args(&[".", r"\\"])
+        .pipe_in(".")
+        .succeeds()
+        .no_stderr()
+        .stdout_is("\\");
+}
+
+#[test]
+fn test_set1_syntax_error_prevents_set2_warning() {
+    new_ucmd!()
+        .args(&["z-a", r"\"])
+        .pipe_in("")
+        .fails()
+        .stderr_only("tr: range-endpoints of 'z-a' are in reverse collating sequence order\n");
+}
+
+#[test]
+fn test_set2_warning_precedes_set1_semantic_error() {
+    new_ucmd!()
+        .args(&["[x*]", r"\"])
+        .pipe_in("")
+        .fails()
+        .stderr_is(concat!(
+            "tr: warning: an unescaped backslash at end of string is not portable\n",
+            "tr: the [c*] repeat construct may not appear in string1\n",
+        ));
+}
+
+#[test]
+fn test_set2_syntax_error_precedes_set1_semantic_error() {
+    new_ucmd!()
+        .args(&["[x*]", "z-a"])
+        .pipe_in("")
+        .fails()
+        .stderr_only("tr: range-endpoints of 'z-a' are in reverse collating sequence order\n");
+}
+
+#[test]
+fn test_set2_trailing_warning_precedes_its_syntax_error() {
+    new_ucmd!()
+        .args(&["x", r"z-a\"])
+        .pipe_in("")
+        .fails()
+        .stderr_is(concat!(
+            "tr: warning: an unescaped backslash at end of string is not portable\n",
+            "tr: range-endpoints of 'z-a' are in reverse collating sequence order\n",
+        ));
+}
+
+#[test]
+fn test_parser_warning_precedes_trailing_backslash_warning() {
+    // Only the relative warning order is relevant to this regression.
+    let result = new_ucmd!()
+        .args(&["-d", r"\501\"])
+        .pipe_in("(1Ł)")
+        .succeeds();
+    result.stdout_is("Ł)");
+
+    let stderr = result.stderr_str();
+    let ambiguous_octal = stderr.find("warning: the ambiguous octal escape").unwrap();
+    let trailing_backslash = stderr
+        .find("warning: an unescaped backslash at end of string is not portable")
+        .unwrap();
+    assert!(ambiguous_octal < trailing_backslash);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_warning_write_failures() {
+    // A warning that cannot be written sets the exit status without discarding
+    // the translated output, for both the trailing-backslash and the parser
+    // warning paths.
+    for (args, input, expected_stdout) in
+        [([".", r"\"], ".", "\\"), (["-d", r"\501"], "(1Ł)", "Ł)")]
+    {
+        new_ucmd!()
+            .args(&args)
+            .pipe_in(input)
+            .set_stderr(std::fs::File::create("/dev/full").unwrap())
+            .fails_with_code(1)
+            .stdout_is(expected_stdout);
+    }
+}
+
+#[test]
 fn test_multibyte_octal_sequence() {
     new_ucmd!()
         .args(&["-d", r"\501"])


### PR DESCRIPTION
## What this does

`tr` checks only SET1 for an unescaped trailing backslash, so `tr . '\'` does not emit GNU's portability warning for SET2. Those warning paths discard stderr write errors, so `tr . '\' 2>/dev/full` exits 0 where GNU exits 1.

**Fix:** check each operand at parse completion, so both sets warn in operand order. Parse both operands before semantic validation so SET2 diagnostics precede a SET1 semantic error. A checked writer records exit status 1 when a warning cannot be written and keeps translating, preserving stdout. That writer remains local to `tr`; shared `uucore` diagnostic macros are unchanged, and warning text is localized through Fluent.

Fixes #12961.

## Verification

| Check | Result |
| --- | --- |
| SET2 trailing backslash | unpatched silent, patched warns |
| warning write to `/dev/full` | unpatched exit 0, patched exit 1, stdout preserved |
| operand coverage | both trailing-backslash operands warn twice in order; even run `'\\'` stays silent |
| SET1 syntax error plus SET2 trailing backslash | SET1 error only, SET2 never parsed |
| `tr '[x*]' 'z-a'` ordering | unpatched reports the SET1 `[c*]` error, patched reports GNU's SET2 range error |
| GNU 9.11 black box, 20 cases | exit status, stdout bytes, diagnostic order match |
| GNU `tr.pl`, `tr-case-class.sh`, BusyBox `tr` | pass, pass, 10 passed |
| `test_tr` | passes on Linux, Windows, and WASI |
| gates (`clippy -D warnings`, `fmt`, `cspell`, MSRV 1.88) | clean |

## Review map

- `Sequence::from_str`: warns after scanning the whole operand, so the warning follows parser warnings and precedes a syntax error from that operand.
- `Sequence::solve_set_characters`: parses SET1 then SET2 before any semantic check, preserving SET1 syntax precedence.
- `emit_diagnostic`: writes each localized diagnostic once, recording status 1 on write failure so translation can continue.
- `tr.rs` `uumain`: drops the SET1-only pre-scan and its `show!(USimpleError::new(0, ...))`.
- `tests/by-util/test_tr.rs`: operand coverage, ordering, and `/dev/full` failures with stdout preserved.

