### PR TITLE
chgrp: fix error message for `--from nonexisting_group GROUP`

### DIFF
--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -67,8 +67,6 @@ fn get_dest_gid(matches: &ArgMatches) -> UResult<(Option<u32>, String)> {
 }
 
 fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<GidUidOwnerFilter> {
-    let (dest_gid, raw_group) = get_dest_gid(matches)?;
-
     // Handle --from option
     let filter = if let Some(from_group) = matches.get_one::<String>(options::FROM) {
         match parse_gid_from_str(from_group) {
@@ -83,6 +81,8 @@ fn parse_gid_and_uid(matches: &ArgMatches) -> UResult<GidUidOwnerFilter> {
     } else {
         IfFrom::All
     };
+
+    let (dest_gid, raw_group) = get_dest_gid(matches)?;
 
     Ok(GidUidOwnerFilter {
         dest_gid,

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -487,7 +487,7 @@ fn test_from_with_invalid_group() {
 
     ucmd.arg("--from")
         .arg("nonexistent_group")
-        .arg("staff")
+        .arg("nobody") // assumption: group exists
         .arg("test_file")
         .fails()
         .stderr_is(err_msg);

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -480,10 +480,8 @@ fn test_from_option() {
 fn test_from_with_invalid_group() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("test_file");
-    #[cfg(not(target_os = "android"))]
+
     let err_msg = "chgrp: invalid user: 'nonexistent_group'\n";
-    #[cfg(target_os = "android")]
-    let err_msg = "chgrp: invalid user: 'staff'\n";
 
     ucmd.arg("--from")
         .arg("nonexistent_group")

--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -478,14 +478,26 @@ fn test_from_option() {
 #[test]
 #[cfg(not(any(target_os = "android", target_os = "macos")))]
 fn test_from_with_invalid_group() {
-    let (at, mut ucmd) = at_and_ucmd!();
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
     at.touch("test_file");
 
     let err_msg = "chgrp: invalid user: 'nonexistent_group'\n";
 
-    ucmd.arg("--from")
+    scene
+        .ucmd()
+        .arg("--from")
         .arg("nonexistent_group")
         .arg("nobody") // assumption: group exists
+        .arg("test_file")
+        .fails()
+        .stderr_is(err_msg);
+
+    scene
+        .ucmd()
+        .arg("--from")
+        .arg("nonexistent_group")
+        .arg("another_nonexistent_group")
         .arg("test_file")
         .fails()
         .stderr_is(err_msg);


### PR DESCRIPTION
I noticed that `test_from_with_invalid_group` fails on my machine with Arch Linux whereas it works in the CI. The reason was that the test assumed a "staff" group exists, which is not the case on Arch Linux, and so the code didn't return the expected error message.

This PR applies three changes:
* in the test, it uses "nobody" as group that is assumed to exist
* it ensures the error message is the same for `--from nonexisting_group GROUP`, independent of whether `GROUP` exists
* in the test, it removes unreachable code on Android