### PR TITLE
pr: fix non-utf-8 argument handling

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -375,7 +375,7 @@ pub fn uu_app() -> Command {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args = args.collect_ignore();
+    let args = args.collect_lossy();
 
     let opt_args = recreate_arguments(&args);
 

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1071,3 +1071,15 @@ fn test_merge_empty_input() {
         .succeeds()
         .no_output();
 }
+
+#[cfg(unix)]
+#[test]
+fn test_non_unicode_argument() {
+    let param = uucore::os_str_from_bytes(b"some-\xFFfile")
+        .expect("Only unix platforms can test non-unicode names");
+
+    new_ucmd!()
+        .arg(&param)
+        .fails_with_code(1)
+        .stderr_contains("No such file or directory");
+}


### PR DESCRIPTION
Fixes #12997.

`uu_pr` arguments are collected using `collect_ignore`, therefore ignoring arguments that contain non-unicode characters, such as `\xFF`.

The fix changes this to use `collect_lossy`.