### PR TITLE
sort: avoid reopening non-seekable inputs

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2278,13 +2278,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         });
     }
 
-    // Verify that we can open all input files.
-    // It is the correct behavior to close all files afterwards,
-    // and to reopen them at a later point. This is different from how the output file is handled,
-    // probably to prevent running out of file descriptors.
-    for file in &files {
-        open(file)?;
-    }
+    let opened_inputs = if settings.merge || settings.check {
+        Vec::new()
+    } else {
+        files.iter().map(open).collect::<UResult<Vec<_>>>()?
+    };
 
     let output = Output::new(matches.get_one::<OsString>(options::OUTPUT))?;
 
@@ -2303,7 +2301,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     settings.init_precomputed(needs_locale_collation);
 
-    let result = exec(&mut files, &settings, output, &mut tmp_dir);
+    let result = exec(&mut files, opened_inputs, &settings, output, &mut tmp_dir);
     // Wait here if `SIGINT` was received,
     // for signal handler to do its work and terminate the program.
     tmp_dir.wait_if_signal();
@@ -2554,6 +2552,7 @@ pub fn uu_app() -> Command {
 
 fn exec(
     files: &mut [OsString],
+    opened_inputs: Vec<Box<dyn Read + Send>>,
     settings: &GlobalSettings,
     output: Output,
     tmp_dir: &mut TmpDirWrapper,
@@ -2570,7 +2569,7 @@ fn exec(
             check::check(files.first().unwrap(), settings)
         }
     } else {
-        let mut lines = files.iter().map(open);
+        let mut lines = opened_inputs.into_iter().map(Ok);
         ext_sort(&mut lines, settings, output, tmp_dir)
     }
 }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1550,6 +1550,30 @@ fn test_sigpipe_panic() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_fifo_without_trailing_newline() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkfifo("FIFO");
+
+    let mut child = ucmd.arg("FIFO").run_no_wait();
+    let fifo = at.plus("FIFO");
+    let writer = std::thread::spawn(move || std::fs::write(fifo, "hello").unwrap());
+    writer.join().unwrap();
+
+    for _ in 0..50 {
+        if child.is_not_alive() {
+            break;
+        }
+        child.delay(100);
+    }
+    if child.is_alive() {
+        child.kill();
+        panic!("sort did not exit after the FIFO writer closed");
+    }
+    child.wait().unwrap().success().stdout_is("hello\n");
+}
+
+#[test]
 fn test_conflict_check_out() {
     let cases = [
         ("-c=silent", "sort: options '-Co' are incompatible\n"),


### PR DESCRIPTION
Fixes #13172.

`sort` pre-opened every input to validate it before opening it again for processing. For a non-seekable input, the validation open could consume the only writer connection; the subsequent open then waited indefinitely for another writer.

When the first seek identifies a non-seekable input, keep that reader open and use it for processing instead of detecting FIFO inputs with metadata. Add a regression test covering an unterminated named FIFO input.
