### PR TITLE
dir: report stdout write errors

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{
     display::Quotable,
-    error::{FromIo, UError, UResult, set_exit_code},
+    error::{UError, UResult, set_exit_code, strip_errno},
     format_usage,
     fs::FileInformation,
     fsext::metadata_get_time,
@@ -67,6 +67,9 @@ enum LsError {
 
     #[error("{}", translate!("ls-error-general-io", "error" => _0))]
     IOError(#[from] std::io::Error),
+
+    #[error("{}: {}", translate!("common-write-error"), strip_errno(.0))]
+    WriteError(std::io::Error),
 
     #[error("{}", match .1.kind() {
 		ErrorKind::NotADirectory => translate!("ls-error-not-directory", "path" => .0.quote()),
@@ -107,7 +110,7 @@ impl UError for LsError {
     fn code(&self) -> i32 {
         match self {
             Self::InvalidLineWidth(_) => 2,
-            Self::IOError(_) => 1,
+            Self::IOError(_) | Self::WriteError(_) => 1,
             Self::IOErrorContext(_, _, false) => 1,
             Self::IOErrorContext(_, _, true) => 2,
             Self::BlockSizeParseError(_) => 2,
@@ -1123,10 +1126,8 @@ impl LsOutput for TextOutput<'_> {
     }
 
     fn flush(&mut self) -> UResult<()> {
-        self.state
-            .out
-            .flush()
-            .map_err_context(|| translate!("common-write-error"))
+        self.state.out.flush().map_err(LsError::WriteError)?;
+        Ok(())
     }
 
     fn finalize(&mut self, config: &Config) -> UResult<()> {

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{
     display::Quotable,
-    error::{UError, UResult, set_exit_code},
+    error::{FromIo, UError, UResult, set_exit_code},
     format_usage,
     fs::FileInformation,
     fsext::metadata_get_time,
@@ -1123,8 +1123,10 @@ impl LsOutput for TextOutput<'_> {
     }
 
     fn flush(&mut self) -> UResult<()> {
-        self.state.out.flush()?;
-        Ok(())
+        self.state
+            .out
+            .flush()
+            .map_err_context(|| translate!("common-write-error"))
     }
 
     fn finalize(&mut self, config: &Config) -> UResult<()> {
@@ -1262,6 +1264,7 @@ pub fn list_with_output<O: LsOutput>(
     }
 
     output.finalize(config)?;
+    output.flush()?;
     Ok(())
 }
 

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -83,3 +83,17 @@ fn test_version() {
         .no_stderr()
         .stdout_is(format!("dir {}\n", uucore::crate_version!()));
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_write_error() {
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.touch("file");
+
+    scene
+        .ucmd()
+        .arg("file")
+        .set_stdout(std::fs::File::create("/dev/full").unwrap())
+        .fails()
+        .stderr_is("dir: write error: No space left on device\n");
+}


### PR DESCRIPTION
Fixes #12812.

`dir` buffered its output but did not explicitly flush after finalization. A write failure reported while flushing, such as stdout connected to `/dev/full`, could therefore be lost when the writer was dropped and the command would exit successfully.

Flush output after finalization and attach the standard write-error context. Add a Linux regression test using `/dev/full`.
