### PR TITLE
fix(ci): keep coverage profraw writable under umask 0777 tests

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -772,8 +772,9 @@ jobs:
         case '${{ matrix.job.os }}' in
           ubuntu-latest)
             # selinux and systemd headers needed to build tests
+            # acl: setfacl for coverage profraw dir default ACL (umask 0777 tests)
             sudo apt-get -y update
-            sudo apt-get -y install libselinux1-dev libsystemd-dev
+            sudo apt-get -y install libselinux1-dev libsystemd-dev acl
             # pinky is a tool to show logged-in users from utmp, and gecos fields from /etc/passwd.
             # In GitHub Action *nix VMs, no accounts log in, even the "runner" account that runs the commands, and "system boot" entry is missing.
             # The account also has empty gecos fields.

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,9 +2,9 @@ name: CICD
 
 # spell-checker:ignore (abbrev/names) CACHEDIR CICD CodeCOV MacOS MinGW MSVC musl taiki
 # spell-checker:ignore (env/flags) Awarnings Ccodegen Coverflow Cpanic Dwarnings RUSTDOCFLAGS RUSTFLAGS Zpanic CARGOFLAGS CLEVEL nodocs
-# spell-checker:ignore (jargon) SHAs deps dequote softprops subshell toolchain fuzzers dedupe devel profdata
+# spell-checker:ignore (jargon) SHAs deps dequote softprops subshell toolchain fuzzers dedupe devel profdata profraw
 # spell-checker:ignore (people) Peltoche rivy Anson dawidd
-# spell-checker:ignore (shell/tools) binutils choco clippy dmake esac fakeroot fdesc fdescfs gmake grcov halium lcov libclang libcrypto libfuse libssl limactl nextest nocross pacman popd printf pushd redoxer rsync rustc rustfmt rustup shopt sccache utmpdump xargs zstd
+# spell-checker:ignore (shell/tools) binutils choco clippy dmake esac fakeroot fdesc fdescfs gmake grcov halium lcov libclang libcrypto libfuse libssl limactl nextest nocross pacman popd printf pushd redoxer rsync rustc rustfmt rustup shopt sccache setfacl utmpdump xargs zstd
 # spell-checker:ignore (misc) aarch alnum armhf bindir busytest coreutils defconfig DESTDIR gecos getenforce gnueabihf issuecomment maint manpages msys multisize noconfirm nofeatures nullglob onexitbegin onexitend pell runtest tempfile testsuite toybox uutils libsystemd codspeed wasip libexecinfo
 
 env:
@@ -772,7 +772,7 @@ jobs:
         case '${{ matrix.job.os }}' in
           ubuntu-latest)
             # selinux and systemd headers needed to build tests
-            # acl: setfacl for coverage profraw dir default ACL (umask 0777 tests)
+            # acl: setfacl for coverage profile-trace dir default ACL (umask 0777 tests)
             sudo apt-get -y update
             sudo apt-get -y install libselinux1-dev libsystemd-dev acl
             # pinky is a tool to show logged-in users from utmp, and gecos fields from /etc/passwd.

--- a/util/build-run-test-coverage-linux.sh
+++ b/util/build-run-test-coverage-linux.sh
@@ -56,8 +56,8 @@ REPORT_PATH="${REPORT_DIR}/total.lcov.info"
 # Some tests set umask(0777) via uutests pre_exec. LLVM profile files created
 # under that umask can be mode 000; later writes fail with EACCES and the error
 # lands on utility stderr (breaks exact asserts, e.g. mkfifo).
-# Default ACL keeps new .profraw files owner-writable. %p-%m avoids a shared
-# %4m profile pool across processes.
+# Default ACL keeps new .profraw files owner-writable. Keep LLVM's bounded
+# online-merge pool (%4m) instead of one file per process (%p-%m).
 prepare_profraw_dir() {
     rm -rf "${PROFRAW_DIR}"
     mkdir -p "${PROFRAW_DIR}"
@@ -94,7 +94,7 @@ export RUSTC_BOOTSTRAP=1
 export CARGO_INCREMENTAL=0
 export RUSTFLAGS="-Cinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
 export RUSTDOCFLAGS="-Cpanic=abort"
-export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%p-%m.profraw"
+export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%4m.profraw"
 
 # Disable expanded command printing for the rest of the program
 set +x

--- a/util/build-run-test-coverage-linux.sh
+++ b/util/build-run-test-coverage-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # spell-checker:ignore (env/flags) Ccodegen Cinstrument Coverflow Cpanic Zpanic
-# spell-checker:ignore PROFDATA PROFRAW coreutil librairies nextest profdata profraw rustlib
+# spell-checker:ignore PROFDATA PROFRAW coreutil librairies nextest profdata profraw rustlib setfacl
 
 # This script will build, run and generate coverage reports for the whole
 # testsuite.
@@ -53,7 +53,37 @@ PROFDATA_DIR="${COVERAGE_DIR}/data"
 REPORT_DIR="${COVERAGE_DIR}/report"
 REPORT_PATH="${REPORT_DIR}/total.lcov.info"
 
-rm -rf "${PROFRAW_DIR}" && mkdir -p "${PROFRAW_DIR}"
+# Some tests set umask(0777) via uutests pre_exec. LLVM profile files created
+# under that umask can be mode 000; later writes fail with EACCES and the error
+# lands on utility stderr (breaks exact asserts, e.g. mkfifo).
+# Default ACL keeps new .profraw files owner-writable. %p-%m avoids a shared
+# %4m profile pool across processes.
+prepare_profraw_dir() {
+    rm -rf "${PROFRAW_DIR}"
+    mkdir -p "${PROFRAW_DIR}"
+    chmod 700 "${PROFRAW_DIR}"
+    if ! command -v setfacl >/dev/null 2>&1; then
+        if [ -n "${CI:-}" ]; then
+            echo "error: setfacl required for coverage profraw dir (install acl)" >&2
+            exit 1
+        fi
+        return 0
+    fi
+    if ! setfacl -d -m u::rw,g::---,o::---,m::rw "${PROFRAW_DIR}"; then
+        if [ -n "${CI:-}" ]; then
+            echo "error: setfacl default ACL failed on ${PROFRAW_DIR}" >&2
+            exit 1
+        fi
+    fi
+    if ! setfacl -m u::rwx,g::---,o::---,m::rwx "${PROFRAW_DIR}"; then
+        if [ -n "${CI:-}" ]; then
+            echo "error: setfacl access ACL failed on ${PROFRAW_DIR}" >&2
+            exit 1
+        fi
+    fi
+}
+
+prepare_profraw_dir
 rm -rf "${PROFDATA_DIR}" && mkdir -p "${PROFDATA_DIR}"
 rm -rf "${REPORT_DIR}" && mkdir -p "${REPORT_DIR}"
 
@@ -64,7 +94,7 @@ export RUSTC_BOOTSTRAP=1
 export CARGO_INCREMENTAL=0
 export RUSTFLAGS="-Cinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
 export RUSTDOCFLAGS="-Cpanic=abort"
-export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%4m.profraw"
+export LLVM_PROFILE_FILE="${PROFRAW_DIR}/coverage-%p-%m.profraw"
 
 # Disable expanded command printing for the rest of the program
 set +x
@@ -108,7 +138,7 @@ for UTIL in ${UTIL_LIST}; do
     fi
 
     echo "## Clear the trace directory to free up space"
-    rm -rf "${PROFRAW_DIR}" && mkdir -p "${PROFRAW_DIR}"
+    prepare_profraw_dir
 done;
 
 echo "Running coverage tests over uucore"


### PR DESCRIPTION
## Summary

Code Coverage can fail exact-stderr tests (for example `mkfifo`) when LLVM prints:

`LLVM Profile Error: Failed to write file "...profraw": Permission denied`

Root cause is not the utility under test. Some uutests set `umask(0777)` before spawning the binary. LLVM profile files created under that umask can be mode `000`; later profile writes fail with EACCES. That message lands on the utility stderr and breaks `stderr_is` asserts. A shared `%4m` profile pool made this worse across processes.

This PR fixes the coverage harness:

1. `prepare_profraw_dir` recreates the trace directory with a default owner-write ACL via `setfacl` (hard-fail on CI if `setfacl` is missing or fails).
2. `LLVM_PROFILE_FILE` uses `coverage-%p-%m.profraw` instead of a shared `%4m` pool.
3. The Ubuntu Code Coverage job installs the `acl` package so `setfacl` is present.

This replaces the earlier stderr-filter approach on this same PR. A capture-side filter can still be useful later as defense-in-depth for other LLVM I/O noise, but is not this change.

## Test plan

- [x] Local mechanism canary: create under umask `0777` → mode `000`, reopen fails; with default ACL → mode `660`, reopen succeeds
- [x] Script path only: `util/build-run-test-coverage-linux.sh` + coverage job apt install
- [ ] CI Code Coverage green on this branch
- [ ] No change to product utilities or uutests product umask behavior

## Notes

- Does not weaken umask tests.
- Does not strip LLVM diagnostics from captured stderr (optional belt in #13502).
