### PR TITLE
tr: use POSIX_FADV_SEQUENTIAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ dependencies = [
  "fluent",
  "nom 8.0.0",
  "rustix",
+ "tempfile",
  "uucore",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "clap",
  "fluent",
  "nom",
+ "rustix",
  "uucore",
 ]
 

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -23,9 +23,12 @@ uucore = { workspace = true, features = ["fs", "signals"] }
 fluent = { workspace = true }
 bytecount = { workspace = true, features = ["runtime-dispatch-simd"] }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["stdio", "fs"] }
+
 [dev-dependencies]
 divan = { workspace = true }
-rustix = { workspace = true, features = ["stdio", "fs"] }
+tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
 
 [features]

--- a/src/uu/tr/src/tr.rs
+++ b/src/uu/tr/src/tr.rs
@@ -101,6 +101,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     let stdin = stdin();
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    let _ = rustix::fs::fadvise(&stdin, 0, None, rustix::fs::Advice::Sequential);
     let mut locked_stdin = stdin.lock();
     let mut locked_stdout = stdout().lock();
 

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -5,9 +5,14 @@
 // spell-checker:ignore lowre punct aabbaa aabbcc aabc abbb abbbcddd abcc abcdefabcdef abcdefghijk abcdefghijklmn abcdefghijklmnop ABCDEFGHIJKLMNOPQRS abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFZZ abcxyz ABCXYZ abcxyzabcxyz ABCXYZABCXYZ acbdef alnum amzamz AMZXAMZ bbbd cclass cefgm cntrl compl dabcdef dncase fooclass Gzabcdefg PQRST upcase wxyzz xdigit XXXYYY xycde xyyye xyyz xyzzzzxyzzzz ZABCDEF Zamz Cdefghijkl Cdefghijklmn asdfqqwweerr qwerr asdfqwer qwer aassddffqwer asdfqwer
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
+#[cfg(target_os = "linux")]
+use uutests::util::get_tests_binary;
 
 #[cfg(unix)]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+#[cfg(target_os = "linux")]
+use std::process::Command;
 
 #[test]
 fn test_invalid_arg() {
@@ -1560,6 +1565,31 @@ fn test_octal_escape_ambiguous_followed_by_non_utf8() {
         .pipe_in([b'(', b'1', 0xff, b')'])
         .succeeds()
         .stderr_contains("warning: invalid utf8 sequence");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_sequential_fadvise() {
+    let (at, _ucmd) = at_and_ucmd!();
+    at.write("input", "abc");
+
+    let trace_file = at.plus_as_string("strace.out");
+    let result = Command::new("strace")
+        .args(["-o", &trace_file, "-e", "fadvise64,fadvise64_64"])
+        .arg(get_tests_binary())
+        .args(["tr", "a", "b"])
+        .stdin(std::fs::File::open(at.plus("input")).unwrap())
+        .output();
+
+    if result.is_err() {
+        return; // strace not available
+    }
+
+    let trace = at.read("strace.out");
+    assert!(
+        trace.contains("POSIX_FADV_SEQUENTIAL"), // spell-checker:disable-line
+        "Expected sequential fadvise: {trace}"
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1569,6 +1569,7 @@ fn test_octal_escape_ambiguous_followed_by_non_utf8() {
 
 #[test]
 #[cfg(target_os = "linux")]
+#[cfg_attr(wasi_runner, ignore = "WASI: strace cannot trace WebAssembly")]
 fn test_sequential_fadvise() {
     let (at, _ucmd) = at_and_ucmd!();
     at.write("input", "abc");

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1587,9 +1587,13 @@ fn test_sequential_fadvise() {
     }
 
     let trace = at.read("strace.out");
+    let advised_stdin = trace.lines().any(|line| {
+        (line.starts_with("fadvise64(0,") || line.starts_with("fadvise64_64(0,"))
+            && line.contains("POSIX_FADV_SEQUENTIAL") // spell-checker:disable-line
+    });
     assert!(
-        trace.contains("POSIX_FADV_SEQUENTIAL"), // spell-checker:disable-line
-        "Expected sequential fadvise: {trace}"
+        advised_stdin,
+        "Expected sequential fadvise on stdin: {trace}"
     );
 }
 


### PR DESCRIPTION
Fixes #13121.

`tr` reads standard input sequentially but did not provide the kernel with a corresponding access-pattern hint.

Call `fadvise` with `POSIX_FADV_SEQUENTIAL` on standard input on supported platforms, treating it as a best-effort optimization so failures do not change command behavior. Add a Linux `strace` regression test that verifies the advice is issued.
