### PR TITLE
safe_traversal: don't follow a symlink in open_file_at

### DIFF
--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -438,11 +438,20 @@ impl DirFd {
     }
 
     /// Open a file for writing relative to this directory
-    /// Creates the file if it doesn't exist, truncates if it does
+    ///
+    /// Creates the file if it doesn't exist, truncates it if it does. `name` is
+    /// opened with `O_NOFOLLOW`, so a symlink at that final component is refused
+    /// rather than followed to its target. This keeps the primitive in line with
+    /// the rest of this module (see `open`/`open_subdir`) and stops the fd-based
+    /// copy from writing through a symlink planted at the destination name.
     pub fn open_file_at(&self, name: &OsStr) -> io::Result<fs::File> {
         let name_cstr =
             CString::new(name.as_bytes()).map_err(|_| SafeTraversalError::PathContainsNull)?;
-        let flags = OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_TRUNC | OFlag::O_CLOEXEC;
+        let flags = OFlag::O_CREAT
+            | OFlag::O_WRONLY
+            | OFlag::O_TRUNC
+            | OFlag::O_NOFOLLOW
+            | OFlag::O_CLOEXEC;
         let mode = Mode::from_bits_truncate(0o666); // Default file permissions
 
         let fd: OwnedFd = openat(self.fd.as_fd(), name_cstr.as_c_str(), flags, mode)
@@ -1260,6 +1269,32 @@ mod tests {
 
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "new");
+    }
+
+    /// `open_file_at` must not follow a symlink at the final component. The
+    /// fd-based install copy unlinks the destination and then creates it here,
+    /// so a symlink planted at that name must be refused rather than followed,
+    /// otherwise a file outside the destination directory gets truncated.
+    #[test]
+    fn test_open_file_at_nofollow_refuses_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // A sentinel file that lives outside the destination directory.
+        let sentinel = temp_dir.path().join("sentinel");
+        fs::write(&sentinel, "victim contents").unwrap();
+
+        // Destination directory holding a symlink pointing at the sentinel.
+        let dest = temp_dir.path().join("dest");
+        fs::create_dir(&dest).unwrap();
+        symlink(&sentinel, dest.join("link")).unwrap();
+
+        let dir_fd = DirFd::open(&dest, SymlinkBehavior::Follow).unwrap();
+        let result = dir_fd.open_file_at(OsStr::new("link"));
+
+        // The open is refused (ELOOP) instead of resolving the link.
+        assert!(result.is_err());
+        // The sentinel outside the directory is left untouched.
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "victim contents");
     }
 
     #[test]


### PR DESCRIPTION
The safe-traversal helpers exist so recursive and privileged file operations can anchor on directory descriptors and refuse to cross a symlink, and every openat in the module passes O_NOFOLLOW to enforce that. open_file_at, the one primitive that creates a file, was missing it, so it opened O_CREAT|O_WRONLY|O_TRUNC on the final name and would follow a symlink sitting there. Its only caller is install's fd-based copy, which unlinks the destination name and then creates it through this helper; if a symlink is present at that name it gets followed and its target is truncated and filled with the source file's contents, so a link placed in the destination directory can redirect a privileged install onto a file outside the tree. The path-based copy_file already avoids this by using create_new, which never resolves a symlink, so the fd-based path was the odd one out. I noticed it while reading how the two copy paths line up. Adding O_NOFOLLOW makes open_file_at refuse the link with ELOOP instead of writing through it, matching the rest of the module. The added test plants a symlink to a sentinel outside the directory and checks the sentinel is left untouched.