### PR TITLE
date: treat -d - as midnight

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -427,8 +427,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 && time_digits.len() <= 4
                 && time_digits.chars().all(|c| c.is_ascii_digit());
 
-            let date = if is_empty_or_whitespace || is_military_j {
-                // Treat empty string or 'J' as midnight today (00:00:00) in local time
+            let date = if is_empty_or_whitespace || input == "-" || is_military_j {
+                // Treat empty string, single hyphen, or 'J' as midnight today in local time
                 let date_part =
                     strtime::format("%F", &now).unwrap_or_else(|_| String::from("1970-01-01"));
                 let offset = if settings.utc {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -84,6 +84,14 @@ fn test_single_dash_as_date() {
 }
 
 #[test]
+fn test_single_dash_as_date_string() {
+    new_ucmd!()
+        .args(&["-u", "-d", "-", "+%T"])
+        .succeeds()
+        .stdout_is("00:00:00\n");
+}
+
+#[test]
 fn test_date_email() {
     for param in ["--rfc-email", "--rfc-e", "-R", "--rfc-2822", "--rfc-822"] {
         new_ucmd!().arg(param).succeeds();


### PR DESCRIPTION
Fixes #12919.

`date -d -` currently leaves the time unchanged because the date parser interprets `-` as an empty relative adjustment. GNU `date` treats this date string as midnight today.

Handle a single hyphen in the existing midnight special case and add a regression test. Positional `date -` remains invalid.
