### PR TITLE
numfmt: prevent panic for --format precision > 65535 on remaining paths

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -479,6 +479,12 @@ pub fn div_round(n: f64, d: f64, method: RoundMethod) -> f64 {
 fn round_with_precision(n: f64, method: RoundMethod, precision: usize) -> f64 {
     let p = 10.0_f64.powf(precision as f64);
 
+    // rounding is a no-op once the scale factor overflows f64;
+    // dividing by it would turn the value into NaN
+    if !p.is_finite() {
+        return n;
+    }
+
     method.round(p * n) / p
 }
 
@@ -628,7 +634,7 @@ fn transform_to(
         }
     };
     Ok(match s {
-        None if opts.to == Unit::None => localize(format!(
+        None if opts.to == Unit::None && precision <= u16::MAX.into() => localize(format!(
             "{:.precision$}",
             round_with_precision(i2, round_method, precision),
         )),
@@ -637,7 +643,7 @@ fn transform_to(
             localize(format!("{i2:.precision$}"))
         }
         None => localize(format!("{i2:.0}")),
-        Some(s) if precision > 0 => localize(format!(
+        Some(s) if precision > 0 && precision <= u16::MAX.into() => localize(format!(
             "{i2:.precision$}{unit_separator}{}",
             DisplayableSuffix(s, opts.to),
         )),

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1659,6 +1659,22 @@ fn test_float_precision_greater_than_16bits() {
 }
 
 #[test]
+fn test_float_precision_greater_than_16bits_without_scaling() {
+    new_ucmd!()
+        .args(&["--format=%.65536f", "1.5"])
+        .succeeds()
+        .stdout_is("2\n");
+}
+
+#[test]
+fn test_float_precision_greater_than_16bits_with_suffix() {
+    new_ucmd!()
+        .args(&["--to=si", "--format=%.65536f", "1000000"])
+        .succeeds()
+        .stdout_is("1M\n");
+}
+
+#[test]
 fn test_format_precision_too_large_on_zero() {
     new_ucmd!()
         .args(&["--format=%.40f", "0"])


### PR DESCRIPTION
#12600 guarded only the middle branch of the render match in `transform_to`, so `numfmt --format=%.70000f 1.5` and `numfmt --to=si --format %.70000f 1000000` still abort with `Formatting argument out of range` (#13483). This adds the same `precision <= u16::MAX` guard to the two remaining `format!("{:.precision$}")` branches.

While testing the suffix path I found `round_with_precision` also turns the value into NaN for precision >= 309, because `10f64.powf(precision)` overflows to infinity and `inf / inf` is NaN. Rounding is a no-op at that scale anyway, so it now returns the value unchanged when the scale factor is not finite.

Closes #13483
