### PR TITLE
test(ls): regression test for -aRv recursing into ./.. (#13501)

### DIFF
--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -2721,6 +2721,31 @@ fn test_ls_recursive_1() {
         .stdout_is(out);
 }
 
+#[test]
+fn test_ls_recursive_all_with_version_sort_does_not_walk_up() {
+    // Regression test for https://github.com/uutils/coreutils/issues/13501:
+    // combining `-a` (show `.`/`..`) with `-R` (recursive) and `-v`
+    // (version/natural sort) used to make `ls` recurse into the listed
+    // `.`/`..` entries themselves, walking all the way up to the
+    // filesystem root instead of stopping at the leaf directories.
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.mkdir("a");
+    at.mkdir("a/b");
+    at.mkdir("a/b/c");
+
+    #[cfg(unix)]
+    let out = "a/b:\n.\n..\nc\n\na/b/c:\n.\n..\n";
+    #[cfg(windows)]
+    let out = "a/b:\n.\n..\nc\n\na/b\\c:\n.\n..\n";
+    scene
+        .ucmd()
+        .arg("-aRv")
+        .arg("a/b")
+        .succeeds()
+        .stdout_is(out);
+}
+
 /// The quoting module regroups tests that check the behavior of ls when
 /// quoting and escaping special characters with different quoting styles.
 #[cfg(unix)]


### PR DESCRIPTION
## What this is

Test-only PR, no behavior change. Adds coverage for the bug in #13501 (`ls -aRv` recurses into the listed `.`/`..` entries and walks all the way up to the filesystem root).

## What I found

I went in expecting to write an actual fix, but the bug is already gone on `main` - just never closed out. Details:

- Reproduced it for real against an actual `0.8.0` build (the version the reporter was on): `ls -aRv` on a small `a/b/c` tree walked straight past the fixture dir and started listing my *actual home directory tree*, exactly matching the "recurses up to filesystem root" behavior described in the issue.
- Root cause in `0.8.0`: `.`/`..` get pushed into the entries buffer first, then the whole buffer gets sorted, then recursion does `.skip(trim)` assuming `.`/`..` are still the first `trim` (2) entries after sorting. That assumption only holds for the default name sort (where `.`/`..` happen to sort first anyway) - version sort (`-v`) doesn't keep them there, so the skip lands on the wrong entries and `.`/`..` get treated as regular subdirectories to recurse into.
- Built the same repro against current `main` - doesn't happen anymore. Traced it via `git blame` to #9851 (April 2026, an unrelated refactor of `ls`'s directory traversal into an explicit stack for library-embedding purposes). That refactor replaced the position-based skip with an actual `is_dot_dir` flag checked per-entry at recursion time, which is correct regardless of sort order. Landed 12 days after the `0.8.0` release the issue was filed against, so the reporter's build predates the fix.

So there's nothing to fix in `ls.rs` itself. What was missing is test coverage for this exact case - I checked and no existing test exercises `-a` + `-R` + `-v` together, so this could regress again silently. This PR adds that one test.

## Testing

- Rebuilt `ls` from a real `0.8.0` checkout (via `git worktree`) and reproduced the bug for real (recursed all the way into my Windows home directory).
- Confirmed the new test fails against that old logic and passes against current `main`.
- Ran the full `ls` test module (`cargo test --release --test tests -p coreutils --features ls test_ls::`) before and after: same 28 pre-existing failures both times (all `A required privilege is not held by the client` - my Windows account can't create symlinks without dev mode/admin, unrelated to this change), no new failures, my new test passes.
- `rustfmt --check` on the touched file: no diff introduced by my change (the file has some pre-existing formatting drift elsewhere from a rustfmt version mismatch, not touched here).

Disclosure: I used an AI coding assistant (Claude) to help investigate and write this, but did the actual verification (building 0.8.0 from source, reproducing the crash for real, bisecting to #9851, running the test suite) myself/directly, not just theorizing from reading the code.