### PR TITLE
pr: report missing file as "pr: <file>: <message>"

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 use thiserror::Error;
 
 use uucore::display::Quotable;
-use uucore::error::UResult;
+use uucore::error::{UResult, strip_errno};
 use uucore::format_usage;
 use uucore::time::{FormatSystemTimeFallback, format, format_system_time};
 use uucore::translate;
@@ -190,6 +190,9 @@ impl From<Utf8Error> for PrError {
 enum PrError {
     #[error("pr: {msg}")]
     EncounteredErrors { msg: String },
+
+    #[error("pr: {path}: {msg}")]
+    ReadError { path: String, msg: String },
 }
 
 pub fn uu_app() -> Command {
@@ -989,14 +992,19 @@ fn build_options(
 /// Read the entire contents of the given path into memory.
 ///
 /// If `path` is `"-"`, then read from stdin.
-fn read_to_end(path: &str) -> Result<Vec<u8>, std::io::Error> {
+fn read_to_end(path: &str) -> Result<Vec<u8>, PrError> {
     if path == "-" {
         let mut f = stdin();
         let mut buf = vec![];
         f.read_to_end(&mut buf)?;
         Ok(buf)
     } else {
-        std::fs::read(path)
+        // Include the file name and strip the raw "(os error N)" suffix so the
+        // message matches GNU pr, e.g. "pr: qwe: No such file or directory".
+        std::fs::read(path).map_err(|err| PrError::ReadError {
+            path: path.to_string(),
+            msg: strip_errno(&err),
+        })
     }
 }
 

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1071,3 +1071,15 @@ fn test_merge_empty_input() {
         .succeeds()
         .no_output();
 }
+
+#[test]
+fn test_missing_file_error_message() {
+    // A nonexistent operand must be reported as "pr: <file>: <message>", like
+    // GNU pr, with the raw "(os error N)" suffix stripped. The exact message
+    // text is platform dependent, so only assert the portable parts.
+    new_ucmd!()
+        .arg("nonexistent_file")
+        .fails_with_code(1)
+        .stderr_contains("pr: nonexistent_file: ")
+        .stderr_does_not_contain("(os error");
+}


### PR DESCRIPTION
Fixes #13013

## What

When `pr` is given a path it can't open, it currently prints:

```
$ pr qwe
pr: No such file or directory (os error 2)
```

The file name is missing and Rust's raw `(os error N)` suffix leaks. GNU `pr` prints the file name and no errno:

```
$ pr qwe
pr: qwe: No such file or directory
```

## Change

`read_to_end` mapped `std::fs::read` errors into `PrError` through the generic `From<io::Error>` impl, which only calls `to_string()` — so the path (still in scope at the call) was lost and the errno suffix kept.

This adds a dedicated `PrError::ReadError { path, msg }` variant and builds the message in `read_to_end`, reusing the existing `uucore::error::strip_errno()` helper (the same pattern already used in `head` and `sort`).

Only the read path is changed, so write errors (e.g. `pr file >/dev/full`) keep their current behavior and are **not** prefixed with the file name, matching the discussion on the issue.

After:

```
$ pr qwe
pr: qwe: No such file or directory
```

## Test

Adds `test_missing_file_error_message`. The exact OS message differs by platform (for example, "The system cannot find the file specified." on Windows), so the test asserts the portable behavior — the file name is present and the `(os error N)` suffix is stripped — rather than a hardcoded string.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` all pass locally.

---

Note for triage: #13231 also targets this issue but has been stalled; its regression test hardcodes the Unix error string and fails on Windows CI. This PR is a minimal alternative that keeps a platform-independent test.
