### PR TITLE
pr: strip std::io:error os error code

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -165,7 +165,7 @@ impl Default for NumberingMode {
 impl From<std::io::Error> for PrError {
     fn from(err: std::io::Error) -> Self {
         Self::EncounteredErrors {
-            msg: err.to_string(),
+            msg: strip_errno(&err),
         }
     }
 }


### PR DESCRIPTION
code path can be reached with 
```
cargo run pr /etc/hostname > /dev/full
```