### PR TITLE
ruff: fix lint errors in Python files

### DIFF
--- a/util/analyze-gnu-results.py
+++ b/util/analyze-gnu-results.py
@@ -100,8 +100,8 @@ def analyze_test_results(json_data):
     error_count = 0  # Not in JSON data but included for compatibility
 
     # Analyze each utility's tests
-    for utility, tests in json_data.items():
-        for test_name, result in tests.items():
+    for tests in json_data.values():
+        for result in tests.values():
             total_tests += 1
 
             match result:

--- a/util/compare_gnu_result.py
+++ b/util/compare_gnu_result.py
@@ -13,8 +13,10 @@ from os import environ
 REPO_DEFAULT_BRANCH = environ.get("REPO_DEFAULT_BRANCH", "main")
 ONLY_INTERMITTENT = environ.get("ONLY_INTERMITTENT", "false")
 
-NEW = json.load(open("gnu-result.json"))
-OLD = json.load(open("main-gnu-result.json"))
+with open("gnu-result.json", "r") as file:
+    NEW = json.load(file)
+with open("main-gnu-result.json", "r") as file:
+    OLD = json.load(file)
 
 # Extract the specific results from the dicts
 last = OLD[list(OLD.keys())[0]]

--- a/util/compare_gnu_result.py
+++ b/util/compare_gnu_result.py
@@ -19,8 +19,8 @@ with open("main-gnu-result.json", "r") as file:
     OLD = json.load(file)
 
 # Extract the specific results from the dicts
-last = OLD[list(OLD.keys())[0]]
-current = NEW[list(NEW.keys())[0]]
+last = OLD[next(iter(OLD.keys()))]
+current = NEW[next(iter(NEW.keys()))]
 
 
 pass_d = int(current["pass"]) - int(last["pass"])

--- a/util/compare_size_results.py
+++ b/util/compare_size_results.py
@@ -51,7 +51,7 @@ def load_sizes(path):
         data = json.load(f)
 
     if not isinstance(data, dict):
-        raise ValueError(f"Unexpected JSON structure in {path}")
+        raise TypeError(f"Unexpected JSON structure in {path}")
 
     # date-keyed wrapper used in tracking JSON
     if data and all(isinstance(v, dict) and "sizes" in v for v in data.values()):

--- a/util/compare_test_results.py
+++ b/util/compare_test_results.py
@@ -239,8 +239,7 @@ def main():
 
     if args.output and output_lines:
         with open(args.output, "w") as f:
-            for line in output_lines:
-                f.write(f"{line}\n")
+            f.writelines(f"{line}\n" for line in output_lines)
 
     # Return exit code based on whether we found regressions
     return 1 if real_regressions else 0

--- a/util/compare_test_results.py
+++ b/util/compare_test_results.py
@@ -55,18 +55,22 @@ def identify_test_changes(current_flat, reference_flat):
     # Find regressions (tests that were passing but now failing)
     regressions = []
     for test_path, status in current_flat.items():
-        if status in ("FAIL", "ERROR"):
-            if test_path in reference_flat:
-                if reference_flat[test_path] == "PASS":
-                    regressions.append(test_path)
+        if (
+            status in ("FAIL", "ERROR")
+            and test_path in reference_flat
+            and reference_flat[test_path] == "PASS"
+        ):
+            regressions.append(test_path)
 
     # Find fixes (tests that were failing but now passing)
     fixes = []
     for test_path, status in reference_flat.items():
-        if status in ("FAIL", "ERROR"):
-            if test_path in current_flat:
-                if current_flat[test_path] == "PASS":
-                    fixes.append(test_path)
+        if (
+            status in ("FAIL", "ERROR")
+            and test_path in current_flat
+            and current_flat[test_path] == "PASS"
+        ):
+            fixes.append(test_path)
 
     # Find newly skipped tests (were passing, now skipped)
     newly_skipped = []

--- a/util/gnu-json-result.py
+++ b/util/gnu-json-result.py
@@ -34,7 +34,7 @@ for filepath in test_dir.glob("**/*.log"):
             )
             if result:
                 current[path.name] = result.group(1)
-    except Exception as e:
+    except Exception as e:  # ruff: ignore[BLE001]
         print(f"Error processing file {path}: {e}", file=sys.stderr)
 
 print(json.dumps(out, indent=2, sort_keys=True))

--- a/util/remaining-gnu-error.py
+++ b/util/remaining-gnu-error.py
@@ -47,7 +47,7 @@ def show_list(list_test):
             print("%s: %s / require_root" % (f, os.stat(f).st_size))
         else:
             print("%s: %s" % (f, os.stat(f).st_size))
-    print("")
+    print()
     print("%s tests remaining" % len(tests))
 
 
@@ -93,11 +93,11 @@ for d in data:
 print("===============")
 print("SKIP tests:")
 show_list(skip_tests)
-print("")
+print()
 print("===============")
 print("ERROR tests:")
 show_list(error_tests)
-print("")
+print()
 print("===============")
 print("FAIL tests:")
 show_list(list_of_files)

--- a/util/remaining-gnu-error.py
+++ b/util/remaining-gnu-error.py
@@ -44,11 +44,11 @@ def show_list(list_test):
 
     for f in reversed(tests):
         if contains_require_root(f):
-            print("%s: %s / require_root" % (f, os.stat(f).st_size))
+            print(f"{f}: {os.stat(f).st_size} / require_root")
         else:
-            print("%s: %s" % (f, os.stat(f).st_size))
+            print(f"{f}: {os.stat(f).st_size}")
     print()
-    print("%s tests remaining" % len(tests))
+    print(f"{len(tests)} tests remaining")
 
 
 def contains_require_root(file_path):
@@ -77,7 +77,7 @@ for d in data:
             try:
                 list_of_files.remove(a)
             except ValueError:
-                print("Could not find test '%s'. Maybe update the GNU repo?" % a)
+                print(f"Could not find test '{a}'. Maybe update the GNU repo?")
                 sys.exit(1)
 
         # if it is SKIP, show it

--- a/util/remaining-gnu-error.py
+++ b/util/remaining-gnu-error.py
@@ -2,13 +2,12 @@
 # This script lists the GNU failing tests by size
 # Just like with util/run-gnu-test.sh, we expect the gnu sources
 # to be in ../
-import urllib.request
-
-import urllib
-import os
 import glob
 import json
+import os
 import sys
+import urllib
+import urllib.request
 
 base = "../gnu/tests/"
 

--- a/util/remaining-gnu-error.py
+++ b/util/remaining-gnu-error.py
@@ -55,7 +55,7 @@ def contains_require_root(file_path):
     try:
         with open(file_path, "r") as file:
             return "require_root_" in file.read()
-    except IOError:
+    except OSError:
         return False
 
 

--- a/util/remaining-gnu-error.py
+++ b/util/remaining-gnu-error.py
@@ -18,7 +18,7 @@ try:
         "https://raw.githubusercontent.com/uutils/coreutils-tracking/main/aggregated-result.json",
         result_json,
     )
-except Exception as e:
+except Exception as e:  # ruff: ignore[BLE001]
     print(f"Failed to download the file: {e}")
     if not os.path.exists(result_json):
         print(f"Local file '{result_json}' not found. Exiting.")

--- a/util/size-experiment.py
+++ b/util/size-experiment.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # spell-checker:ignore debuginfo
-import subprocess
-from itertools import product
-import shutil
 import os
+import shutil
+import subprocess
 from collections import defaultdict
+from itertools import product
 from pprint import pprint
 
 # Set to false if you've only changed the analysis and do not want to recompile

--- a/util/test_compare_test_results.py
+++ b/util/test_compare_test_results.py
@@ -3,16 +3,17 @@
 Unit tests for the GNU test results comparison script.
 """
 
-import unittest
 import json
-import tempfile
 import os
-from unittest.mock import patch
+import tempfile
+import unittest
 from io import StringIO
+from unittest.mock import patch
+
 from util.compare_test_results import (
     flatten_test_results,
-    load_ignore_list,
     identify_test_changes,
+    load_ignore_list,
     main,
 )
 


### PR DESCRIPTION
This PR fixes a bunch of lint errors that are shown with the newly released `ruff 0.16.0`. It also disables the [blind-except](https://docs.astral.sh/ruff/rules/blind-except/) lint in two places.

It should make the `Code Quality / Style/Python` job in the CI pass again.