### PR TITLE
install: don't reject existing non-regular targets as "invalid target"

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -777,7 +777,12 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
             return Err(InstallError::SameFile(source.clone(), target.clone()).into());
         }
 
-        if target.is_file() || is_new_file_path(&target) {
+        // An existing target that isn't a directory (regular file, device
+        // node, FIFO, socket, ...) should still go through the normal
+        // copy/overwrite path so the real removal failure is reported,
+        // instead of falling through to InvalidTarget's hardcoded
+        // "No such file or directory" (issue #9934).
+        if target.is_file() || is_new_file_path(&target) || (target.exists() && !target.is_dir()) {
             #[cfg(unix)]
             if let (Some(ref parent_fd), Some(ref filename)) = (target_parent_fd, target_filename) {
                 if b.compare && !need_copy(source, &target, b) {


### PR DESCRIPTION
`standard()`'s final branch only takes the copy path for `target.is_file() || is_new_file_path(&target)`. Both are false for a target that already exists but isn't a regular file — a device node, FIFO, or socket — so it falls to `InstallError::InvalidTarget`, whose string is hardcoded as "No such file or directory". That's just wrong when the file is right there; `install /dev/null /dev/full` prints "invalid target '/dev/full': No such file or directory" instead of attempting the overwrite and reporting why it actually failed.

By the time we reach this check, `is_potential_directory_path` has already routed actual directories into `copy_files_into_dir`, so `target.is_dir()` is guaranteed false here — broadening the condition to `target.exists() && !target.is_dir()` just lets any existing non-directory target reach the same remove-then-copy path a regular file already takes, matching GNU's behavior of attempting the overwrite and surfacing the real errno.

Fixes #9934. Note: the removal-failure path this now falls into (`InstallError::NotPermitted`) is worded "Operation not permitted" rather than GNU's "Permission denied" for this specific EACCES case — that's a preexisting, separate string issue in that error arm and I left it alone rather than bundle an unrelated fix in here.

Didn't add a `/dev/full`-based test since that depends on `/dev` permissions that vary by environment. A more portable regression test would create a FIFO in a temp dir via the test harness and assert `install` overwrites it into a regular file instead of erroring — happy to add if wanted.