### PR TITLE
Revert "fuzzing.yml: Bump GNU coreutils to 9.11"

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,6 +1,6 @@
 name: Fuzzing
 
-# spell-checker:ignore (people) bamf taiki-e
+# spell-checker:ignore (people) taiki-e
 # spell-checker:ignore (misc) fuzzer PIPESTATUS
 
 env:
@@ -23,17 +23,11 @@ concurrency:
 jobs:
   uufuzz-examples:
     name: Build and test uufuzz examples
-    runs-on: ubuntu-26.04 # needs newer glibc
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    - name: Update GNU coreutils
-      run: |
-        # curl fails
-        wget https://launchpad.net/~bamf0/+archive/ubuntu/coreutils-reference/+files/gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
-        sudo dpkg -i gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
-        /bin/true --version
     - name: Build uufuzz library
       run: |
         cd fuzz/uufuzz
@@ -58,16 +52,11 @@ jobs:
 
   fuzz-build:
     name: Build the fuzzers
-    runs-on: ubuntu-26.04 # needs newer glibc
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    - name: Update GNU coreutils
-      run: |
-        # curl fails
-        wget https://launchpad.net/~bamf0/+archive/ubuntu/coreutils-reference/+files/gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
-        sudo dpkg -i gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
     - name: Install `cargo-fuzz`
       uses: taiki-e/install-action@v2
       with:
@@ -83,7 +72,7 @@ jobs:
   fuzz-run:
     needs: fuzz-build
     name: Fuzz (${{ matrix.group.name }})
-    runs-on: ubuntu-26.04 # needs newer glibc
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       RUN_FOR: 60
@@ -122,11 +111,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    - name: Update GNU coreutils
-      run: |
-        # curl fails
-        wget https://launchpad.net/~bamf0/+archive/ubuntu/coreutils-reference/+files/gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
-        sudo dpkg -i gnu-coreutils_9.11-0ubuntu1~ppa3_amd64.deb
     - name: Install `cargo-fuzz`
       uses: taiki-e/install-action@v2
       with:
@@ -218,7 +202,7 @@ jobs:
   fuzz-summary:
     needs: fuzz-run
     name: Fuzzing Summary
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
     if: always()
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -370,7 +370,6 @@ setpipe
 
 # * other
 auxv
-dpkg
 getlimits
 weblate
 algs


### PR DESCRIPTION
Reverts uutils/coreutils#13201

Fails with

```
failed: Network is unreachable.
Connecting to launchpad.net (launchpad.net)|2620:2d:4000:1009::f3|:443... failed: Network is unreachable.
 
```