### PR TITLE
pr: do not page-fill when headers and trailers are omitted

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1254,7 +1254,13 @@ fn print_page(
             out.write_all(line_separator)?;
         }
     }
-    out.write_all(page_separator)?;
+    // The page separator belongs to paginated output; with headers and
+    // trailers omitted the input is reproduced as-is. Under -F/-f the
+    // separator is the form feed that carries an input page break through to
+    // the output, so it is still written.
+    if options.display_header_and_trailer || options.form_feed_used {
+        out.write_all(page_separator)?;
+    }
     out.flush()?;
     Ok(())
 }
@@ -1418,7 +1424,10 @@ fn write_columns(
                     .as_bytes(),
             )?;
         }
-        if not_found_break && feed_line_present {
+        // A form feed already terminates the page, and without headers and
+        // trailers there is no page to fill either: stop at the last content
+        // line instead of padding out to the page length.
+        if not_found_break && (feed_line_present || !options.display_header_and_trailer) {
             break;
         }
         out.write_all(line_separator)?;

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1254,10 +1254,7 @@ fn print_page(
             out.write_all(line_separator)?;
         }
     }
-    // The page separator belongs to paginated output; with headers and
-    // trailers omitted the input is reproduced as-is. Under -F/-f the
-    // separator is the form feed that carries an input page break through to
-    // the output, so it is still written.
+    // Only paginated output gets a page separator; under -F/-f it is the form feed.
     if options.display_header_and_trailer || options.form_feed_used {
         out.write_all(page_separator)?;
     }
@@ -1424,9 +1421,7 @@ fn write_columns(
                     .as_bytes(),
             )?;
         }
-        // A form feed already terminates the page, and without headers and
-        // trailers there is no page to fill either: stop at the last content
-        // line instead of padding out to the page length.
+        // Stop at the last content line: a form feed ended the page, or there is none.
         if not_found_break && (feed_line_present || !options.display_header_and_trailer) {
             break;
         }

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -250,6 +250,65 @@ fn test_with_page_range() {
 }
 
 #[test]
+fn test_omit_header_no_page_fill() {
+    // https://github.com/uutils/coreutils/issues/13029
+    // With headers and trailers omitted there is no page to fill: `-t` writes
+    // the input back out and stops, instead of padding to the page length.
+    new_ucmd!()
+        .arg("-t")
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\nc\n");
+
+    // Also across a page boundary: 57 lines is one full content page plus one,
+    // so a second page starts. Without headers there is no page separator
+    // either, and the output still matches the input exactly.
+    let input = (1..=57)
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    new_ucmd!()
+        .arg("-t")
+        .pipe_in(input.clone())
+        .succeeds()
+        .stdout_only(&input);
+}
+
+#[test]
+fn test_short_page_length_no_page_fill() {
+    // A page length below the header plus trailer size omits them, and then the
+    // output is likewise not padded up to that page length.
+    new_ucmd!()
+        .args(&["-l", "5"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\nc\n");
+}
+
+#[test]
+fn test_omit_header_short_page_no_page_fill() {
+    // The two conditions together: `-t` with a short page still reproduces the
+    // input rather than padding it out.
+    new_ucmd!()
+        .args(&["-t", "-l", "5"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\nc\n");
+}
+
+#[test]
+fn test_default_mode_fills_page() {
+    // Control for the tests above: with headers and trailers the page *is*
+    // filled, so three lines of input still produce one full 66-line page.
+    let output = new_ucmd!()
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_move_str();
+    assert_eq!(output.lines().count(), 66);
+}
+
+#[test]
 fn test_with_no_header_trailer_option() {
     let test_file_path = "test_one_page.log";
     let expected_test_file_path = "test_one_page_no_ht.log.expected";
@@ -666,13 +725,20 @@ fn test_separator_options_default_values() {
 
 #[test]
 fn test_omit_pagination_option() {
-    // -T/--omit-pagination omits headers/trailers and eliminates form feeds
-    // TODO: verify output matches GNU pr behavior (form feed elimination)
-    new_ucmd!().args(&["-T"]).pipe_in("a\nb\n").succeeds();
+    // -T/--omit-pagination omits headers/trailers, so like -t it does not pad
+    // the output up to the page length.
+    // TODO: -t should preserve a form feed present in the input; it is
+    // currently dropped, while -T correctly eliminates it.
+    new_ucmd!()
+        .args(&["-T"])
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_only("a\nb\n");
     new_ucmd!()
         .args(&["--omit-pagination"])
         .pipe_in("a\nb\n")
-        .succeeds();
+        .succeeds()
+        .stdout_only("a\nb\n");
 }
 
 #[test]

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -251,18 +251,14 @@ fn test_with_page_range() {
 
 #[test]
 fn test_omit_header_no_page_fill() {
-    // https://github.com/uutils/coreutils/issues/13029
-    // With headers and trailers omitted there is no page to fill: `-t` writes
-    // the input back out and stops, instead of padding to the page length.
+    // https://github.com/uutils/coreutils/issues/13029: -t must not pad the page.
     new_ucmd!()
         .arg("-t")
         .pipe_in("a\nb\nc\n")
         .succeeds()
         .stdout_only("a\nb\nc\n");
 
-    // Also across a page boundary: 57 lines is one full content page plus one,
-    // so a second page starts. Without headers there is no page separator
-    // either, and the output still matches the input exactly.
+    // Also across a page boundary: 57 lines starts a second page.
     let input = (1..=57)
         .map(|i| i.to_string())
         .collect::<Vec<_>>()
@@ -277,8 +273,7 @@ fn test_omit_header_no_page_fill() {
 
 #[test]
 fn test_short_page_length_no_page_fill() {
-    // A page length below the header plus trailer size omits them, and then the
-    // output is likewise not padded up to that page length.
+    // A page length below the header plus trailer size omits them, so no padding.
     new_ucmd!()
         .args(&["-l", "5"])
         .pipe_in("a\nb\nc\n")
@@ -288,8 +283,7 @@ fn test_short_page_length_no_page_fill() {
 
 #[test]
 fn test_omit_header_short_page_no_page_fill() {
-    // The two conditions together: `-t` with a short page still reproduces the
-    // input rather than padding it out.
+    // Both conditions together: -t with a short page.
     new_ucmd!()
         .args(&["-t", "-l", "5"])
         .pipe_in("a\nb\nc\n")
@@ -299,8 +293,7 @@ fn test_omit_header_short_page_no_page_fill() {
 
 #[test]
 fn test_default_mode_fills_page() {
-    // Control for the tests above: with headers and trailers the page *is*
-    // filled, so three lines of input still produce one full 66-line page.
+    // Control: with headers and trailers the page is still filled to 66 lines.
     let output = new_ucmd!()
         .pipe_in("a\nb\nc\n")
         .succeeds()
@@ -725,10 +718,8 @@ fn test_separator_options_default_values() {
 
 #[test]
 fn test_omit_pagination_option() {
-    // -T/--omit-pagination omits headers/trailers, so like -t it does not pad
-    // the output up to the page length.
-    // TODO: -t should preserve a form feed present in the input; it is
-    // currently dropped, while -T correctly eliminates it.
+    // -T omits headers/trailers, so like -t it does not pad to the page length.
+    // TODO: -t drops an input form feed; -T correctly eliminates it.
     new_ucmd!()
         .args(&["-T"])
         .pipe_in("a\nb\n")

--- a/tests/fixtures/pr/test_one_page_no_ht.log.expected
+++ b/tests/fixtures/pr/test_one_page_no_ht.log.expected
@@ -54,4 +54,3 @@ Mon Dec 10 11:42:59.155 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
 Mon Dec 10 11:42:59.157 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
 Mon Dec 10 11:42:59.159 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
 Mon Dec 10 11:42:59.352 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
-

--- a/tests/fixtures/pr/test_page_length1.log.expected
+++ b/tests/fixtures/pr/test_page_length1.log.expected
@@ -3,10 +3,8 @@
     8	Mon Dec 10 11:42:56.856 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
     9	Mon Dec 10 11:42:57.002 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
    10	Mon Dec 10 11:42:57.003 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
-
    11	Mon Dec 10 11:42:57.003 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
    12	Mon Dec 10 11:42:57.152 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
    13	Mon Dec 10 11:42:57.154 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
    14	Mon Dec 10 11:42:57.154 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
    15	Mon Dec 10 11:42:57.302 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
-


### PR DESCRIPTION
Fixes #13029

## What

`pr -t` pads the rest of the page with blank lines after the last line of
content, and then writes a page separator:

```
$ printf 'a\nb\nc\n' | pr -t | wc -l
57
```

GNU prints the 3 input lines and stops. Page fill belongs to paginated output;
with headers and trailers omitted there is no page to fill.

## Change

Two sites, both gated on the existing `display_header_and_trailer`:
`write_columns()` kept walking empty rows after the content ran out, and
`print_page()` wrote a page separator unconditionally. Under `-F`/`-f` the
separator is the form feed carrying an input page break, so it is still written
there.

Because that predicate is shared, `-T` and short pages stop padding too.

Not addressed, all pre-existing on `main`: input form feeds under plain `-t`,
the `-t -l 10` content loss, the multi-column remainder row, and `-m` padding.

## Test

Four new cases plus a control that default output still fills a 66-line page.
`test_omit_pagination_option` was upgraded from a bare `.succeeds()` to an
exact-stdout assertion.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` pass
locally. Checked against `pr` from GNU coreutils 9.4 as a black-box oracle
over 402 flag/input combinations at `6e35744` (base `de1477d2`): 104 cases
newly match GNU, none that already matched stop matching, and the 80
`-F`/`-f` cases stay byte-identical to `main`. Happy to share the harness
script and the full result matrix if that would help.

---

Note for triage: #12331 also touches `write_columns()` and fixes other `-T`
behavior (combined flags, `-s` alignment, page boundaries). It does not fix
`-t` — building its head and running the repro still prints 57 lines. Happy to
rebase on it, or fold this in, if you would rather land that first.

AI-assisted, reviewed by me. No GNU source consulted.

