### PR TITLE
test(more): add integration test for -n u16::MAX regression

### DIFF
--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -254,3 +254,15 @@ fn test_from_line_option() {
     assert!(!output.contains("line1"));
     quit_more(&mut controller, child);
 }
+
+#[test]
+#[cfg(unix)]
+fn test_lines_option_max_u16_no_overflow() {
+    // Regression test for https://github.com/uutils/coreutils/pull/12970
+    // When -n is u16::MAX (65535), adding 1 for the banner line used to
+    // overflow. Verify that more starts and displays content without crashing.
+    let (child, mut controller, output) =
+        run_more_with_pty(&["-n", "65535"], "test.txt", "line1\nline2\nline3\n");
+    assert!(output.contains("line1"));
+    quit_more(&mut controller, child);
+}


### PR DESCRIPTION
Regression test for #12970.

When `-n` is `u16::MAX` (65535), adding 1 for the banner line used to overflow. This PR adds an integration test via PTY that verifies `more -n 65535` starts correctly and displays content without crashing.