### PR TITLE
refactor: use core::ffi types

### DIFF
--- a/src/uu/chcon/src/chcon.rs
+++ b/src/uu/chcon/src/chcon.rs
@@ -17,10 +17,10 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use rustix::fs::{Mode, OFlags, openat};
 use selinux::{OpaqueSecurityContext, SecurityContext};
 
+use core::ffi::{CStr, c_int};
 use std::borrow::Cow;
-use std::ffi::{CStr, CString, OsStr, OsString};
+use std::ffi::{CString, OsStr, OsString};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
-use std::os::raw::c_int;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 

--- a/src/uu/chcon/src/fts.rs
+++ b/src/uu/chcon/src/fts.rs
@@ -7,10 +7,10 @@
 
 #![cfg(any(target_os = "linux", target_os = "android"))]
 
-use std::ffi::{CStr, CString, OsStr};
+use core::ffi::{CStr, c_int, c_long, c_short};
+use std::ffi::{CString, OsStr};
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
-use std::os::raw::{c_int, c_long, c_short};
 use std::path::Path;
 use std::{io, iter, ptr, slice};
 

--- a/src/uu/chroot/src/chroot.rs
+++ b/src/uu/chroot/src/chroot.rs
@@ -302,7 +302,7 @@ fn set_supplemental_gids(gids: &[libc::gid_t]) -> std::io::Result<()> {
         target_os = "cygwin",
         target_os = "netbsd"
     ))]
-    let n = gids.len() as libc::c_int;
+    let n = gids.len() as core::ffi::c_int;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     let n = gids.len() as libc::size_t;
     let err = unsafe { setgroups(n, gids.as_ptr()) };

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -60,10 +60,10 @@ pub(crate) fn copy_on_write(
         // blessed uses of `transmute()`.
         unsafe {
             let pfn: extern "C" fn(
-                src: *const libc::c_char,
-                dst: *const libc::c_char,
+                src: *const core::ffi::c_char,
+                dst: *const core::ffi::c_char,
                 flags: u32,
-            ) -> libc::c_int = std::mem::transmute(raw_pfn);
+            ) -> core::ffi::c_int = std::mem::transmute(raw_pfn);
             error = pfn(src.as_ptr(), dst.as_ptr(), 0);
             if std::io::Error::last_os_error().kind() == std::io::ErrorKind::AlreadyExists
                 // Only remove the `dest` if the `source` and `dest` are not the same

--- a/src/uu/date/src/locale.rs
+++ b/src/uu/date/src/locale.rs
@@ -19,7 +19,7 @@ macro_rules! cfg_langinfo {
 }
 
 cfg_langinfo! {
-    use std::ffi::CStr;
+    use core::ffi::CStr;
     use std::sync::OnceLock;
 
     #[cfg(test)]

--- a/src/uu/dd/src/conversion_tables.rs
+++ b/src/uu/dd/src/conversion_tables.rs
@@ -25,7 +25,7 @@ pub fn build_lcase_table() -> ConversionTable {
     let mut table = [0u8; 256];
     for (i, item) in table.iter_mut().enumerate() {
         // SAFETY: tolower is called with a valid byte value and returns a valid byte
-        *item = unsafe { libc::tolower(i as libc::c_int) } as u8;
+        *item = unsafe { libc::tolower(i as core::ffi::c_int) } as u8;
     }
     table
 }
@@ -45,7 +45,7 @@ pub fn build_ucase_table() -> ConversionTable {
     let mut table = [0u8; 256];
     for (i, item) in table.iter_mut().enumerate() {
         // SAFETY: toupper is called with a valid byte value and returns a valid byte
-        *item = unsafe { libc::toupper(i as libc::c_int) } as u8;
+        *item = unsafe { libc::toupper(i as core::ffi::c_int) } as u8;
     }
     table
 }

--- a/src/uu/dd/src/dd.rs
+++ b/src/uu/dd/src/dd.rs
@@ -430,7 +430,7 @@ impl<'a> Input<'a> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn make_linux_iflags(iflags: &IFlags) -> Option<libc::c_int> {
+fn make_linux_iflags(iflags: &IFlags) -> Option<core::ffi::c_int> {
     let mut flag = 0;
 
     if iflags.direct {
@@ -1334,7 +1334,7 @@ fn finalize<T>(
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[allow(clippy::cognitive_complexity)]
-fn make_linux_oflags(oflags: &OFlags) -> Option<libc::c_int> {
+fn make_linux_oflags(oflags: &OFlags) -> Option<core::ffi::c_int> {
     let mut flag = 0;
 
     // oflag=FLAG

--- a/src/uu/dd/src/progress.rs
+++ b/src/uu/dd/src/progress.rs
@@ -454,7 +454,7 @@ pub(crate) fn check_and_reset_sigusr1() -> bool {
 }
 
 #[cfg(target_os = "linux")]
-extern "C" fn sigusr1_handler(_: std::os::raw::c_int) {
+extern "C" fn sigusr1_handler(_: core::ffi::c_int) {
     SIGUSR1_RECEIVED.store(true, Ordering::Relaxed);
 }
 

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -1160,7 +1160,7 @@ fn ignore_signal(sig: usize) -> UResult<()> {
     // nix::sys::signal::Signal does not cover real-time signals, so we need to call
     // libc::signal directly.
     let result = unsafe {
-        let res = libc::signal(sig as libc::c_int, libc::SIG_IGN);
+        let res = libc::signal(sig as core::ffi::c_int, libc::SIG_IGN);
         nix::errno::Errno::result(res)
     };
     if let Err(err) = result {
@@ -1177,7 +1177,7 @@ fn reset_signal(sig: usize) -> UResult<()> {
     // nix::sys::signal::Signal does not cover real-time signals, so we need to call
     // libc::signal directly.
     let result = unsafe {
-        let res = libc::signal(sig as libc::c_int, libc::SIG_DFL);
+        let res = libc::signal(sig as core::ffi::c_int, libc::SIG_DFL);
         nix::errno::Errno::result(res)
     };
     if let Err(err) = result {
@@ -1206,9 +1206,9 @@ fn sigset_from_signal_value(sig: usize) -> UResult<SigSet> {
         ));
     }
 
-    if let Err(err) =
-        unsafe { nix::errno::Errno::result(libc::sigaddset(&raw mut sigset, sig as libc::c_int)) }
-    {
+    if let Err(err) = unsafe {
+        nix::errno::Errno::result(libc::sigaddset(&raw mut sigset, sig as core::ffi::c_int))
+    } {
         return Err(USimpleError::new(
             125,
             translate!(

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -6,7 +6,8 @@
 // spell-checker:ignore (ToDO) gethostid
 
 use clap::Command;
-use libc::{c_long, gethostid};
+use core::ffi::c_long;
+use libc::gethostid;
 use std::io::{Write, stdout};
 use uucore::{error::UResult, format_usage};
 

--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -34,7 +34,7 @@
 #![allow(dead_code)]
 
 use clap::{Arg, ArgAction, Command};
-use std::ffi::CStr;
+use core::ffi::CStr;
 use std::io::{self, Write};
 use uucore::display::Quotable;
 use uucore::entries::{self, Group, Locate, Passwd};

--- a/src/uu/logname/src/logname.rs
+++ b/src/uu/logname/src/logname.rs
@@ -6,7 +6,7 @@
 // spell-checker:ignore (ToDO) getlogin userlogin
 
 use clap::Command;
-use std::ffi::CStr;
+use core::ffi::CStr;
 use std::io::{Write, stdout};
 use uucore::translate;
 use uucore::{error::UResult, show_error};

--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -178,5 +178,5 @@ fn try_open_nohup_file(path: &str) -> std::io::Result<File> {
 
 #[cfg(target_vendor = "apple")]
 unsafe extern "C" {
-    fn _vprocmgr_detach_from_console(flags: u32) -> *const libc::c_int;
+    fn _vprocmgr_detach_from_console(flags: u32) -> *const core::ffi::c_int;
 }

--- a/src/uu/runcon/src/runcon.rs
+++ b/src/uu/runcon/src/runcon.rs
@@ -15,8 +15,9 @@ use clap::{Arg, ArgAction, Command};
 use selinux::{OpaqueSecurityContext, SecurityClass, SecurityContext};
 use uucore::format_usage;
 
+use core::ffi::CStr;
 use std::borrow::Cow;
-use std::ffi::{CStr, CString, OsStr, OsString};
+use std::ffi::{CString, OsStr, OsString};
 use std::io;
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1421,7 +1421,7 @@ pub(crate) fn current_open_fd_count() -> Option<usize> {
 
     let mut count = 0usize;
     for fd in 0..limit {
-        let fd = fd as libc::c_int;
+        let fd = fd as core::ffi::c_int;
         // Probe with libc::fcntl because the fd may be invalid.
         if unsafe { libc::fcntl(fd, libc::F_GETFD) } != -1 {
             count = count.saturating_add(1);

--- a/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
+++ b/src/uu/stdbuf/src/libstdbuf/src/libstdbuf.rs
@@ -4,8 +4,9 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (ToDO) getreent reent IOFBF IOLBF IONBF setvbuf stderrp stdinp stdoutp fdopen
 
+use core::ffi::{c_char, c_int};
 use ctor::ctor;
-use libc::{_IOFBF, _IOLBF, _IONBF, FILE, c_char, c_int, fileno, size_t};
+use libc::{_IOFBF, _IOLBF, _IONBF, FILE, fileno, size_t};
 use std::io::{Write, stderr};
 use std::{env, ptr};
 

--- a/src/uu/timeout/src/timeout.rs
+++ b/src/uu/timeout/src/timeout.rs
@@ -181,7 +181,7 @@ pub fn uu_app() -> Command {
 
 /// Install SIGCHLD handler to ensure waiting for child works even if parent ignored SIGCHLD.
 fn install_sigchld() {
-    extern "C" fn chld(_: libc::c_int) {}
+    extern "C" fn chld(_: core::ffi::c_int) {}
     let _ = install_signal_handler(Signal::as_raw(Signal::CHILD), chld);
 }
 
@@ -296,7 +296,7 @@ fn wait_or_kill_process(
 }
 
 #[cfg(unix)]
-fn preserve_signal_info(signal: libc::c_int) -> libc::c_int {
+fn preserve_signal_info(signal: core::ffi::c_int) -> core::ffi::c_int {
     // This is needed because timeout is expected to preserve the exit
     // status of its child. It is not the case that utilities have a
     // single simple exit code, that's an illusion some shells
@@ -317,7 +317,7 @@ fn preserve_signal_info(signal: libc::c_int) -> libc::c_int {
 }
 
 #[cfg(not(unix))]
-fn preserve_signal_info(signal: libc::c_int) -> libc::c_int {
+fn preserve_signal_info(signal: core::ffi::c_int) -> core::ffi::c_int {
     // Do nothing
     signal
 }

--- a/src/uucore/src/lib/features/entries.rs
+++ b/src/uucore/src/lib/features/entries.rs
@@ -32,13 +32,14 @@
 //! assert!(entries::Group::locate(root_group).is_ok());
 //! ```
 
+use core::ffi::{CStr, c_char, c_int};
 #[cfg(any(target_os = "freebsd", target_vendor = "apple"))]
 use libc::time_t;
-use libc::{c_char, c_int, gid_t, uid_t};
 use libc::{getgrgid, getgrnam};
 use libc::{getpwnam, getpwuid, group, passwd};
+use libc::{gid_t, uid_t};
 
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::io::Result as IOResult;

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -1005,17 +1005,17 @@ pub fn get_filename(file: &Path) -> Option<&str> {
 // Redox's libc appears not to include the following utilities
 
 #[cfg(target_os = "redox")]
-pub fn major(dev: libc::dev_t) -> libc::c_uint {
+pub fn major(dev: libc::dev_t) -> core::ffi::c_uint {
     (((dev >> 8) & 0xFFF) | ((dev >> 32) & 0xFFFFF000)) as _
 }
 
 #[cfg(target_os = "redox")]
-pub fn minor(dev: libc::dev_t) -> libc::c_uint {
+pub fn minor(dev: libc::dev_t) -> core::ffi::c_uint {
     ((dev & 0xFF) | ((dev >> 12) & 0xFFFFF00)) as _
 }
 
 #[cfg(target_os = "redox")]
-pub fn makedev(maj: libc::c_uint, min: libc::c_uint) -> libc::dev_t {
+pub fn makedev(maj: core::ffi::c_uint, min: core::ffi::c_uint) -> libc::dev_t {
     let [maj, min] = [maj as libc::dev_t, min as libc::dev_t];
     (min & 0xff) | ((maj & 0xfff) << 8) | ((min & !0xff) << 12) | ((maj & !0xfff) << 32)
 }

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -60,11 +60,13 @@ fn to_nul_terminated_wide_string(s: impl AsRef<OsStr>) -> Vec<u16> {
 }
 
 #[cfg(unix)]
+use core::ffi::CStr;
+#[cfg(unix)]
 use libc::{
     S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK, mode_t, strerror,
 };
 #[cfg(unix)]
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 #[cfg(not(target_os = "wasi"))]
 use std::io::Error as IOError;
 #[cfg(unix)]

--- a/src/uucore/src/lib/features/i18n/datetime.rs
+++ b/src/uucore/src/lib/features/i18n/datetime.rs
@@ -176,8 +176,8 @@ pub fn get_locale_months() -> Option<&'static [Vec<u8>; 12]> {
     not(target_os = "redox")
 ))]
 fn get_locale_months_inner() -> Option<[Vec<u8>; 12]> {
+    use core::ffi::CStr;
     use nix::libc;
-    use std::ffi::CStr;
 
     let abmon_items: [libc::nl_item; 12] = [
         libc::ABMON_1,

--- a/src/uucore/src/lib/features/process.rs
+++ b/src/uucore/src/lib/features/process.rs
@@ -276,23 +276,23 @@ mod timer {
         #[cfg(not(target_os = "redox"))]
         pub(super) use libc::{SIGEV_SIGNAL, sigevent};
 
-        pub(super) type timer_t = *mut libc::c_void;
+        pub(super) type timer_t = *mut core::ffi::c_void;
 
         unsafe extern "C" {
             pub(super) fn timer_settime(
                 timerid: timer_t,
-                flags: libc::c_int,
+                flags: core::ffi::c_int,
                 new_value: *const itimerspec,
                 old_value: *mut itimerspec,
-            ) -> libc::c_int;
+            ) -> core::ffi::c_int;
 
             pub(super) fn timer_create(
                 clockid: libc::clockid_t,
                 sevp: *mut sigevent,
                 timerid: *mut timer_t,
-            ) -> libc::c_int;
+            ) -> core::ffi::c_int;
 
-            pub(super) fn timer_delete(timerid: timer_t) -> libc::c_int;
+            pub(super) fn timer_delete(timerid: timer_t) -> core::ffi::c_int;
         }
 
         #[repr(C)]
@@ -303,20 +303,20 @@ mod timer {
         }
 
         #[cfg(target_os = "redox")]
-        pub(super) const SIGEV_SIGNAL: libc::c_int = 0;
+        pub(super) const SIGEV_SIGNAL: core::ffi::c_int = 0;
 
         #[repr(C)]
         #[derive(Clone, Copy, Debug)]
         #[cfg(target_os = "redox")]
         pub(super) struct sigevent {
             pub(super) sigev_value: libc::sigval,
-            pub(super) sigev_signo: libc::c_int,
-            pub(super) sigev_notify: libc::c_int,
-            pub(super) sigev_notify_thread_id: libc::c_int,
+            pub(super) sigev_signo: core::ffi::c_int,
+            pub(super) sigev_notify: core::ffi::c_int,
+            pub(super) sigev_notify_thread_id: core::ffi::c_int,
             #[cfg(target_pointer_width = "64")]
-            __unused1: std::mem::MaybeUninit<[libc::c_int; 11]>,
+            __unused1: std::mem::MaybeUninit<[core::ffi::c_int; 11]>,
             #[cfg(target_pointer_width = "32")]
-            __unused1: std::mem::MaybeUninit<[libc::c_int; 12]>,
+            __unused1: std::mem::MaybeUninit<[core::ffi::c_int; 12]>,
         }
     }
 }

--- a/src/uucore/src/lib/features/safe_traversal.rs
+++ b/src/uucore/src/lib/features/safe_traversal.rs
@@ -324,7 +324,7 @@ impl DirFd {
 
             if !FCHMODAT2_UNAVAILABLE.load(Ordering::Relaxed) {
                 // Syscall number for fchmodat2 on asm-generic architectures.
-                const SYS_FCHMODAT2: libc::c_long = 452;
+                const SYS_FCHMODAT2: core::ffi::c_long = 452;
                 // SAFETY: syscall(2) is an FFI call. We pass valid arguments:
                 // - fd: valid open file descriptor
                 // - name: valid C string pointer (name_cstr lives for the duration)
@@ -393,7 +393,7 @@ impl DirFd {
     /// race because the fd pins the inode.
     ///
     #[cfg(target_os = "linux")]
-    fn chmod_at_via_opath(&self, name: &std::ffi::CStr, mode: u32) -> io::Result<()> {
+    fn chmod_at_via_opath(&self, name: &core::ffi::CStr, mode: u32) -> io::Result<()> {
         use rustix::fs::{Mode, OFlags, chmod, openat};
 
         let fd = openat(
@@ -405,7 +405,7 @@ impl DirFd {
         .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))?;
 
         let proc_path = format!("/proc/self/fd/{}\0", fd.as_raw_fd());
-        let proc_cstr = std::ffi::CStr::from_bytes_with_nul(proc_path.as_bytes())
+        let proc_cstr = core::ffi::CStr::from_bytes_with_nul(proc_path.as_bytes())
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid proc path"))?;
 
         chmod(proc_cstr, Mode::from_bits_truncate(mode))

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -566,7 +566,7 @@ pub fn ignore_interrupts() -> Result<(), Errno> {
 #[cfg(unix)]
 pub fn install_signal_handler(
     sig: i32,
-    handler: extern "C" fn(std::os::raw::c_int),
+    handler: extern "C" fn(core::ffi::c_int),
 ) -> Result<(), Errno> {
     let signal = Signal::try_from(sig).map_err(|_| Errno::EINVAL)?;
     let action = SigAction::new(

--- a/src/uucore/src/lib/features/systemd_logind.rs
+++ b/src/uucore/src/lib/features/systemd_logind.rs
@@ -12,7 +12,7 @@
 //! When the systemd-logind feature is enabled and systemd is available,
 //! this will be used instead of traditional utmp files.
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 use std::mem::MaybeUninit;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -20,8 +20,7 @@ use crate::error::{UResult, USimpleError};
 
 /// FFI bindings for libsystemd login and D-Bus functions
 mod ffi {
-    use std::ffi::c_char;
-    use std::os::raw::{c_int, c_uint};
+    use core::ffi::{c_char, c_int, c_uint};
 
     #[link(name = "systemd")]
     unsafe extern "C" {
@@ -44,13 +43,14 @@ mod ffi {
 /// Safe wrapper functions for libsystemd FFI calls
 mod login {
     use super::ffi;
-    use std::ffi::{CStr, CString};
+    use core::ffi::CStr;
+    use std::ffi::CString;
     use std::ptr;
     use std::time::SystemTime;
 
     /// Get all active sessions
     pub fn get_sessions() -> Result<Vec<String>, Box<dyn std::error::Error>> {
-        let mut sessions_ptr: *mut *mut libc::c_char = ptr::null_mut();
+        let mut sessions_ptr: *mut *mut core::ffi::c_char = ptr::null_mut();
 
         let result = unsafe { ffi::sd_get_sessions(&raw mut sessions_ptr) };
 
@@ -83,7 +83,7 @@ mod login {
     /// Get UID for a session
     pub fn get_session_uid(session_id: &str) -> Result<u32, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut uid: std::os::raw::c_uint = 0;
+        let mut uid: core::ffi::c_uint = 0;
 
         let result = unsafe { ffi::sd_session_get_uid(session_cstring.as_ptr(), &raw mut uid) };
 
@@ -117,7 +117,7 @@ mod login {
     /// Get TTY for a session
     pub fn get_session_tty(session_id: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut tty_ptr: *mut libc::c_char = ptr::null_mut();
+        let mut tty_ptr: *mut core::ffi::c_char = ptr::null_mut();
 
         let result = unsafe { ffi::sd_session_get_tty(session_cstring.as_ptr(), &raw mut tty_ptr) };
 
@@ -144,7 +144,7 @@ mod login {
         session_id: &str,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut host_ptr: *mut libc::c_char = ptr::null_mut();
+        let mut host_ptr: *mut core::ffi::c_char = ptr::null_mut();
 
         let result =
             unsafe { ffi::sd_session_get_remote_host(session_cstring.as_ptr(), &raw mut host_ptr) };
@@ -173,7 +173,7 @@ mod login {
         session_id: &str,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut display_ptr: *mut libc::c_char = ptr::null_mut();
+        let mut display_ptr: *mut core::ffi::c_char = ptr::null_mut();
 
         let result =
             unsafe { ffi::sd_session_get_display(session_cstring.as_ptr(), &raw mut display_ptr) };
@@ -202,7 +202,7 @@ mod login {
         session_id: &str,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut type_ptr: *mut libc::c_char = ptr::null_mut();
+        let mut type_ptr: *mut core::ffi::c_char = ptr::null_mut();
 
         let result =
             unsafe { ffi::sd_session_get_type(session_cstring.as_ptr(), &raw mut type_ptr) };
@@ -230,7 +230,7 @@ mod login {
         session_id: &str,
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let session_cstring = CString::new(session_id)?;
-        let mut seat_ptr: *mut libc::c_char = ptr::null_mut();
+        let mut seat_ptr: *mut core::ffi::c_char = ptr::null_mut();
 
         let result =
             unsafe { ffi::sd_session_get_seat(session_cstring.as_ptr(), &raw mut seat_ptr) };

--- a/src/uucore/src/lib/features/uptime.rs
+++ b/src/uucore/src/lib/features/uptime.rs
@@ -379,7 +379,7 @@ pub fn get_nusers() -> usize {
                 continue;
             }
 
-            let cstr = std::ffi::CStr::from_ptr(buffer.cast());
+            let cstr = core::ffi::CStr::from_ptr(buffer.cast());
             if !cstr.is_empty() {
                 num_user += 1;
             }
@@ -428,7 +428,7 @@ pub fn get_formatted_nusers() -> String {
 /// The load average is a tuple of three floating point numbers representing the 1-minute, 5-minute, and 15-minute load averages.
 #[cfg(unix)]
 pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
-    use crate::libc::c_double;
+    use core::ffi::c_double;
     use libc::getloadavg;
 
     let mut avg: [c_double; 3] = [0.0; 3];

--- a/src/uucore/src/lib/features/utmpx.rs
+++ b/src/uucore/src/lib/features/utmpx.rs
@@ -68,7 +68,7 @@ pub use libc::utmpxname;
 /// # Safety
 /// Just fixed the clippy warning. Please add description here.
 #[cfg(target_os = "freebsd")]
-pub unsafe extern "C" fn utmpxname(_file: *const libc::c_char) -> libc::c_int {
+pub unsafe extern "C" fn utmpxname(_file: *const core::ffi::c_char) -> core::ffi::c_int {
     0
 }
 


### PR DESCRIPTION
`std::ffi::c_char`, `libc::c_char`, `std::os::raw::c_char` etc are deprecated in favour of `core::ffi::c_char`.