### PR TITLE
shred: report random source open errors

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -264,12 +264,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let random_source = match matches.get_one::<String>(options::RANDOM_SOURCE) {
-        Some(filepath) => Some(RefCell::new(File::open(filepath).map_err(|_| {
-            USimpleError::new(
-                1,
-                translate!("shred-cannot-open-random-source", "source" => filepath.quote()),
-            )
-        })?)),
+        Some(filepath) => Some(RefCell::new(
+            File::open(filepath).map_err_context(|| filepath.clone())?,
+        )),
         None => None,
     };
 

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -293,6 +293,18 @@ fn test_random_source_regular_file() {
 }
 
 #[test]
+fn test_random_source_open_error_includes_cause() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.touch("target");
+
+    ucmd.arg("--random-source=missing")
+        .arg("target")
+        .fails()
+        .stderr_only("shred: missing: No such file or directory\n");
+}
+
+#[test]
 fn test_random_source_dir() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
Fixes #12962.

`shred --random-source` replaced failures from opening the supplied source with a generic error, hiding the underlying cause such as permission denied or a missing file.

Propagate the original I/O error with the source path as context, matching GNU `shred` diagnostics. Add a regression test for a missing random source.
