### PR TITLE
tail: warn when --pid=0 is ignored

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -134,8 +134,7 @@ pub struct Settings {
     pub follow: Option<FollowMode>,
     pub max_unchanged_stats: u32,
     pub mode: FilterMode,
-    pub pid: platform::Pid,
-    pid_specified: bool,
+    pub pid: Option<platform::Pid>,
     pub retry: bool,
     pub sleep_sec: Duration,
     pub use_polling: bool,
@@ -153,8 +152,7 @@ impl Default for Settings {
             sleep_sec: Duration::from_secs_f32(1.0),
             follow: Option::default(),
             mode: FilterMode::default(),
-            pid: Default::default(),
-            pid_specified: false,
+            pid: Option::default(),
             retry: Default::default(),
             use_polling: Default::default(),
             verbose: Default::default(),
@@ -266,8 +264,7 @@ impl Settings {
                         ));
                     }
 
-                    settings.pid = pid;
-                    settings.pid_specified = true;
+                    settings.pid = Some(pid);
                 }
                 Err(e) => {
                     return Err(USimpleError::new(
@@ -312,7 +309,7 @@ impl Settings {
             }
         }
 
-        if self.pid_specified {
+        if let Some(pid) = self.pid {
             if self.follow.is_none() {
                 writeln!(
                     std::io::stderr().lock(),
@@ -320,7 +317,7 @@ impl Settings {
                     uucore::util_name(),
                     translate!("tail-warning-pid-ignored")
                 )?;
-            } else if self.pid != 0 && !platform::supports_pid_checks(self.pid) {
+            } else if pid != 0 && !platform::supports_pid_checks(pid) {
                 show_warning!("{}", translate!("tail-warning-pid-not-supported"));
             }
         }
@@ -330,7 +327,7 @@ impl Settings {
         // as `tty` (but no otherwise blocking stdin), then we print a warning that `--follow`
         // cannot be applied under these circumstances and is therefore ineffective.
         if self.follow.is_some() && self.has_stdin() {
-            let blocking_stdin = self.pid == 0
+            let blocking_stdin = self.pid.unwrap_or_default() == 0
                 && self.follow == Some(FollowMode::Descriptor)
                 && self.num_inputs() == 1
                 && Handle::stdin().is_ok_and(|handle| {

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -10,7 +10,7 @@ use crate::{Quotable, parse, platform};
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
 use same_file::Handle;
 use std::ffi::OsString;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::parser::parse_signed_num::{SignPrefix, parse_signed_num_max};
@@ -135,6 +135,7 @@ pub struct Settings {
     pub max_unchanged_stats: u32,
     pub mode: FilterMode,
     pub pid: platform::Pid,
+    pid_specified: bool,
     pub retry: bool,
     pub sleep_sec: Duration,
     pub use_polling: bool,
@@ -153,6 +154,7 @@ impl Default for Settings {
             follow: Option::default(),
             mode: FilterMode::default(),
             pid: Default::default(),
+            pid_specified: false,
             retry: Default::default(),
             use_polling: Default::default(),
             verbose: Default::default(),
@@ -265,6 +267,7 @@ impl Settings {
                     }
 
                     settings.pid = pid;
+                    settings.pid_specified = true;
                 }
                 Err(e) => {
                     return Err(USimpleError::new(
@@ -300,7 +303,7 @@ impl Settings {
 
     /// Check [`Settings`] for problematic configurations of tail originating from user provided
     /// command line arguments and print appropriate warnings.
-    pub fn check_warnings(&self) {
+    pub fn check_warnings(&self) -> std::io::Result<()> {
         if self.retry {
             if self.follow.is_none() {
                 show_warning!("{}", translate!("tail-warning-retry-ignored"));
@@ -309,10 +312,15 @@ impl Settings {
             }
         }
 
-        if self.pid != 0 {
+        if self.pid_specified {
             if self.follow.is_none() {
-                show_warning!("{}", translate!("tail-warning-pid-ignored"));
-            } else if !platform::supports_pid_checks(self.pid) {
+                writeln!(
+                    std::io::stderr().lock(),
+                    "{}: warning: {}",
+                    uucore::util_name(),
+                    translate!("tail-warning-pid-ignored")
+                )?;
+            } else if self.pid != 0 && !platform::supports_pid_checks(self.pid) {
                 show_warning!("{}", translate!("tail-warning-pid-not-supported"));
             }
         }
@@ -336,6 +344,8 @@ impl Settings {
                 show_warning!("{}", translate!("tail-warning-following-stdin-ineffective"));
             }
         }
+
+        Ok(())
     }
 
     /// Verify [`Settings`] and try to find unsolvable misconfigurations of tail originating from

--- a/src/uu/tail/src/follow/watch.rs
+++ b/src/uu/tail/src/follow/watch.rs
@@ -133,7 +133,7 @@ impl Observer {
             settings.follow,
             settings.use_polling,
             FileHandling::from(settings),
-            settings.pid,
+            settings.pid.unwrap_or_default(),
         )
     }
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -102,7 +102,7 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
         the input file is not a FIFO, pipe, or regular file, it is unspecified whether or
         not the -f option shall be ignored.
         */
-        if !settings.has_only_stdin() || settings.pid != 0 {
+        if !settings.has_only_stdin() || settings.pid.is_some_and(|pid| pid != 0) {
             follow::follow(observer, settings)?;
         }
     }
@@ -162,7 +162,7 @@ fn tail_file(
         observer.add_bad_path(path, input.display_name.as_str(), false)?;
     } else {
         #[cfg(unix)]
-        let open_result = open_file(path, settings.pid != 0);
+        let open_result = open_file(path, settings.pid.is_some_and(|pid| pid != 0));
         #[cfg(not(unix))]
         let open_result = File::open(path);
 

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -41,7 +41,7 @@ use uucore::{show, show_error};
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let settings = parse_args(args)?;
 
-    settings.check_warnings();
+    settings.check_warnings()?;
 
     match settings.verify() {
         args::VerificationResult::CannotFollowStdinByName => {

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -4099,7 +4099,7 @@ fn test_args_when_settings_check_warnings_then_shows_warnings() {
     );
     scene
         .ucmd()
-        .args(&["--pid=1000", "data"])
+        .args(&["--pid=0", "data"])
         .stderr_to_stdout()
         .succeeds()
         .stdout_only(expected_stdout);
@@ -5098,6 +5098,15 @@ fn test_failed_write_is_reported() {
         .set_stdout(File::create("/dev/full").unwrap())
         .fails()
         .stderr_is("tail: No space left on device\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_failed_warning_write_is_reported() {
+    new_ucmd!()
+        .args(&["--pid=0", "/dev/null"])
+        .set_stderr(File::create("/dev/full").unwrap())
+        .fails_with_code(1);
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Fixes #13108.

`tail` used PID 0 both as the default value and for an explicit `--pid=0`, so it could not emit GNU's ignored-PID warning when the option was supplied without following. Errors while writing that warning were also discarded.

Track whether `--pid` was explicitly supplied so PID 0 produces the warning without changing `-f --pid=0` behavior. Propagate write failures for that warning and add regression coverage, including `/dev/full` on Linux.
