### PR TITLE
pr: report starting pages beyond page count

### DIFF
--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -101,5 +101,6 @@ pr-error-no-such-file = pr: cannot open {$file}, No such file or directory
 pr-error-column-merge-conflict = cannot specify number of columns when printing in parallel
 pr-error-across-merge-conflict = cannot specify both printing across and printing in parallel
 pr-error-invalid-pages-range = invalid --pages argument '{$start}:{$end}'
+pr-error-starting-page-exceeds-page-count = starting page number {$start} exceeds page count {$count}
 pr-error-invalid-expand-tab-argument ='-e' extra characters or invalid number in the argument: ‘{$arg}’
 pr-error-invalid-number-argument ='-n' extra characters or invalid number in the argument: ‘{$arg}’

--- a/src/uu/pr/locales/fr-FR.ftl
+++ b/src/uu/pr/locales/fr-FR.ftl
@@ -100,5 +100,6 @@ pr-error-no-such-file = pr : impossible d'ouvrir {$file}, Aucun fichier ou répe
 pr-error-column-merge-conflict = impossible de spécifier le nombre de colonnes lors de l'impression en parallèle
 pr-error-across-merge-conflict = impossible de spécifier à la fois l'impression transversale et l'impression en parallèle
 pr-error-invalid-pages-range = argument --pages invalide '{$start}:{$end}'
+pr-error-starting-page-exceeds-page-count = le numéro de page de début {$start} dépasse le nombre de pages {$count}
 pr-error-invalid-expand-tab-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-e': '{$arg}'
 pr-error-invalid-number-argument = Caractères supplémentaires ou nombre invalide dans l'argument de '-n': '{$arg}'

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -23,7 +23,7 @@ use uucore::display::Quotable;
 use uucore::error::{UResult, strip_errno};
 use uucore::format_usage;
 use uucore::time::{FormatSystemTimeFallback, format, format_system_time};
-use uucore::translate;
+use uucore::{show_error, translate};
 
 const TAB: char = '\t';
 const LINES_PER_PAGE: usize = 66;
@@ -1022,7 +1022,18 @@ fn pr(name: &str, options: &OutputOptions) -> Result<i32, PrError> {
     let buf = read_to_end(name)?;
 
     let mut writer = stdout().lock();
-    let pages = get_pages(options, 0, &buf);
+    let (pages, page_count) = get_pages(options, 0, &buf);
+    if options.start_page > page_count {
+        show_error!(
+            "{}",
+            translate!(
+                "pr-error-starting-page-exceeds-page-count",
+                "start" => options.start_page,
+                "count" => page_count
+            )
+        );
+        return Ok(0);
+    }
 
     // Split the text into pages, and then print each line in each page.
     for page_with_page_number in pages {
@@ -1036,9 +1047,13 @@ fn pr(name: &str, options: &OutputOptions) -> Result<i32, PrError> {
 
 /// Group lines of a file into pages.
 ///
-/// Returns a list of the form `(page_num, lines)`.
+/// Returns a list of the form `(page_num, lines)` and the total page count.
 ///
-fn get_pages(options: &OutputOptions, file_id: usize, buf: &[u8]) -> Vec<(usize, Vec<FileLine>)> {
+fn get_pages(
+    options: &OutputOptions,
+    file_id: usize,
+    buf: &[u8],
+) -> (Vec<(usize, Vec<FileLine>)>, usize) {
     let start_page = options.start_page;
     let end_page = options.end_page;
     let lines_needed_per_page = lines_to_read_for_page(options);
@@ -1131,7 +1146,7 @@ fn get_pages(options: &OutputOptions, file_id: usize, buf: &[u8]) -> Vec<(usize,
         pages.push((page_num, page.clone()));
     }
 
-    pages
+    (pages, page_num + 1)
 }
 
 /// Key used to group lines together according to their file and page number.
@@ -1188,7 +1203,8 @@ fn get_file_line_groups(
 
         // Split the text into pages and collect each line for
         // subsequent grouping.
-        for (_, mut page) in get_pages(options, file_id, &buf) {
+        let (pages, _) = get_pages(options, file_id, &buf);
+        for (_, mut page) in pages {
             all_lines.append(&mut page);
         }
     }

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -221,6 +221,15 @@ fn test_with_valid_page_ranges() {
 }
 
 #[test]
+fn test_start_page_exceeds_page_count() {
+    new_ucmd!()
+        .args(&["--pages=2", "hosts.log"])
+        .succeeds()
+        .stderr_is("pr: starting page number 2 exceeds page count 1\n")
+        .stdout_is("");
+}
+
+#[test]
 fn test_with_page_range() {
     let test_file_path = "test.log";
     let expected_test_file_path = "test_page_range_1.log.expected";


### PR DESCRIPTION
Fixes #13557.

`pr` silently produced no output when the requested starting page was beyond the input's page count, while GNU reports the requested page and the available count.

Track the total page count while paginating and emit the matching localized diagnostic when the starting page is out of range. Add English and French messages plus a regression test for the GNU-compatible output and exit status.
