### PR TITLE
Cargo.toml: drop unnecessary comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -729,10 +729,6 @@ rstest_reuse.workspace = true
 rustix.workspace = true
 selinux = { workspace = true, optional = true }
 
-# this breaks clippy linting with: "tests/by-util/test_factor_benches.rs: No such file or directory (os error 2)"
-# factor_benches = { optional = true, version = "0.0.0", package = "uu_factor_benches", path = "tests/benches/factor" }
-
-#
 # * pinned transitive dependencies
 # Not needed for now. Keep as examples:
 #pin_cc = { version="1.0.61, < 1.0.62", package="cc" } ## cc v1.0.62 has compiler errors for MinRustV v1.32.0, requires 1.34 (for `std::str::split_ascii_whitespace()`)


### PR DESCRIPTION
`tests/benches/factor` is missing already.