### PR TITLE
ln: remove unreachable code

### DIFF
--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -316,16 +316,6 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
     for srcpath in files {
         let targetpath = if settings.no_dereference && target_dir.is_symlink() {
             let remove_target = || {
-                // In that case, we don't want to do link resolution
-                // We need to clean the target
-                if target_dir.is_file()
-                    && let Err(e) = fs::remove_file(target_dir)
-                {
-                    show_error!(
-                        "{}",
-                        translate!("ln-error-could-not-update", "target" => target_dir.quote(), "error" => e)
-                    );
-                }
                 #[cfg(windows)]
                 if target_dir.is_dir() {
                     // Not sure why but on Windows, the symlink can be

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -316,17 +316,15 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
     for srcpath in files {
         let targetpath = if settings.no_dereference && target_dir.is_symlink() {
             let remove_target = || {
+                // Not sure why but on Windows, the symlink can be
+                // considered as a dir
+                // See test_ln::test_symlink_no_deref_dir
                 #[cfg(windows)]
-                if target_dir.is_dir() {
-                    // Not sure why but on Windows, the symlink can be
-                    // considered as a dir
-                    // See test_ln::test_symlink_no_deref_dir
-                    if let Err(e) = fs::remove_dir(target_dir) {
-                        show_error!(
-                            "{}",
-                            translate!("ln-error-could-not-update", "target" => target_dir.quote(), "error" => e)
-                        );
-                    }
+                if let Err(e) = fs::remove_dir(target_dir) {
+                    show_error!(
+                        "{}",
+                        translate!("ln-error-could-not-update", "target" => target_dir.quote(), "error" => e)
+                    );
                 }
             };
             match settings.overwrite {


### PR DESCRIPTION
At the beginning of the `link_files_in_dir` function, we do a `if !target_dir.is_dir()` check with an early exit to ensure `target_dir` is a directory (or a symlink pointing to a directory). And so calling `target_dir.is_file()` will always return `false` later in the function, making the related code block unreachable.

Related to this, an additional call of `target_dir.is_dir()` on Windows is unnecessary as it will always return `true`.

This PR removes both the unreachable code and the unnecessary `is_dir` call on Windows.
