### PR TITLE
fix(timeout): handle SIGTTIN and other signals in the waiting loop to avoid stalling

### DIFF
--- a/src/uucore/src/lib/features/process/unix.rs
+++ b/src/uucore/src/lib/features/process/unix.rs
@@ -8,6 +8,7 @@
 // spell-checker:ignore pgrep pwait snice getpgrp
 // spell-checker:ignore sigwait KTIME timeval itimerval setitimer itimer timerid
 // spell-checker:ignore sigevent sigev sigval itimerspec signo clockid sevp
+// spell-checker:ignore SIGXCPU SIGXFSZ SIGVTALRM SIGPROF
 
 use libc::{gid_t, pid_t, uid_t};
 #[cfg(not(target_os = "redox"))]

--- a/src/uucore/src/lib/features/process/unix.rs
+++ b/src/uucore/src/lib/features/process/unix.rs
@@ -137,6 +137,7 @@ impl ChildExt for Child {
                     } // otherwise waits again
                 }
                 Ok(Some(Signal::SIGTERM)) if ignore_term => {} // waits again
+                Ok(Some(Signal::SIGTTIN | Signal::SIGTTOU)) => {} // waits again
                 Ok(Some(signal)) => break Ok(TimeoutRet::Interrupted(signal as usize)),
                 Err(e) => break Err(e),
             }
@@ -158,6 +159,8 @@ pub fn timeout_signal_set() -> SigSet {
     set.add(Signal::SIGUSR1);
     set.add(Signal::SIGUSR2);
     set.add(Signal::SIGCHLD);
+    set.add(Signal::SIGTTIN);
+    set.add(Signal::SIGTTOU);
     set
 }
 

--- a/src/uucore/src/lib/features/process/unix.rs
+++ b/src/uucore/src/lib/features/process/unix.rs
@@ -161,6 +161,10 @@ pub fn timeout_signal_set() -> SigSet {
     set.add(Signal::SIGCHLD);
     set.add(Signal::SIGTTIN);
     set.add(Signal::SIGTTOU);
+    set.add(Signal::SIGXCPU);
+    set.add(Signal::SIGXFSZ);
+    set.add(Signal::SIGVTALRM);
+    set.add(Signal::SIGPROF);
     set
 }
 

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore dont SIGBREAK
+// spell-checker:ignore dont SIGBREAK SIGTTIN ttin
 
 use rstest::rstest;
 use std::time::Duration;
@@ -446,7 +446,7 @@ fn test_windows_command_cannot_invoke() {
 
 #[test]
 #[cfg(unix)]
-fn test_nohang_ttin() {
+fn test_continue_terminal_job_ctrl_sigs() {
     let (ts, bin) = scenario_with_bin();
     ts.cmd("/bin/sh")
         .arg("-c")

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -443,3 +443,13 @@ fn test_windows_command_cannot_invoke() {
         .args(&["1", ".\\not_executable.txt"])
         .fails_with_code(126);
 }
+
+#[test]
+#[cfg(unix)]
+fn test_nohang_ttin() {
+    let (ts, bin) = scenario_with_bin();
+    ts.cmd("/bin/sh")
+        .arg("-c")
+        .arg(format!("trap 'echo' SIGTTIN; {bin:?} 2 /bin/cat"))
+        .timeout(Duration::from_secs(4));
+}

--- a/tests/by-util/test_timeout.rs
+++ b/tests/by-util/test_timeout.rs
@@ -447,9 +447,10 @@ fn test_windows_command_cannot_invoke() {
 #[test]
 #[cfg(unix)]
 fn test_continue_terminal_job_ctrl_sigs() {
+    let name = util_name!();
     let (ts, bin) = scenario_with_bin();
     ts.cmd("/bin/sh")
         .arg("-c")
-        .arg(format!("trap 'echo' SIGTTIN; {bin:?} 2 /bin/cat"))
+        .arg(format!("trap 'echo' SIGTTIN; {bin:?} {name} 2 /bin/cat"))
         .timeout(Duration::from_secs(4));
 }


### PR DESCRIPTION
Previously, the waiting loop would not handle `SIGTTIN`, `SIGTTOU`, and other signals; this was observed on commands that intercepted them on `timeout` if the child process required them for termination (or other behaviors). For example, it would hang on `strace` when the child was `cat` or `tee`, same as when trapping them on a subshell.

Note that this old behavior matched our implementation before the backend changes of my previous PR. Now that we have fine-grained control on signal handling, we can trivially match GNU and resolve the linked issue.

The new behavior matches GNU by continuing to wait on terminal job-control signals and forwarding the others on demand.

Fixes: #12979