### PR TITLE
od: report actual file open errors

### DIFF
--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore abcdefghijklmnopqrstuvwxyz Anone fdbb littl bfloat
+// spell-checker:ignore abcdefghijklmnopqrstuvwxyz Anone fdbb littl bfloat mksocket
 
 #[cfg(unix)]
 use std::io::Read;
@@ -91,6 +91,21 @@ fn test_two_files() {
 #[test]
 fn test_non_existing_file() {
     new_ucmd!().arg("non_existing_file").fails();
+}
+
+#[test]
+#[cfg(unix)]
+#[cfg_attr(wasi_runner, ignore = "WASI: Unix sockets are not supported")]
+fn test_socket_error() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let socket = "socket";
+    at.mksocket(socket);
+    let error = std::fs::File::open(at.plus(socket)).unwrap_err();
+
+    ucmd.arg(socket).fails().stderr_only(format!(
+        "od: {socket}: {}\n",
+        uucore::error::strip_errno(&error)
+    ));
 }
 
 // Test that od reads from stdin instead of a file


### PR DESCRIPTION
Fixes #12980.

`od` reduced file-open failures to three hard-coded messages, so errors such as opening a Unix socket were reported as `I/O error` instead of the platform's actual diagnostic.

Format file-open failures with `uucore::error::strip_errno`, preserving GNU-compatible errors without including raw OS error numbers. Add a Unix regression test that creates a socket and verifies the propagated diagnostic.
