### PR TITLE
test: fix `unreachable_patterns` lint on Windows

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -339,7 +339,6 @@ fn path(path: &OsStr, condition: &PathCondition) -> bool {
         | PathCondition::CharacterSpecial
         | PathCondition::Fifo
         | PathCondition::GroupIdFlag
-        | PathCondition::Readable
         | PathCondition::Socket
         | PathCondition::Sticky
         | PathCondition::SymLink


### PR DESCRIPTION
This PR fixes an error from the `unreachable_patterns` lint on Windows that was introduced with https://github.com/uutils/coreutils/pull/13548