### PR TITLE
chmod: re-check --preserve-root during the recursive descent

### DIFF
--- a/src/uu/chmod/locales/en-US.ftl
+++ b/src/uu/chmod/locales/en-US.ftl
@@ -9,6 +9,8 @@ chmod-error-dangling-symlink = cannot operate on dangling symlink {$file}
 chmod-error-no-such-file = cannot access {$file}: No such file or directory
 chmod-error-preserve-root = it is dangerous to operate recursively on {$file}
   chmod: use --no-preserve-root to override this failsafe
+chmod-error-preserve-root-same-as = it is dangerous to operate recursively on {$file} (same as '/')
+  chmod: use --no-preserve-root to override this failsafe
 chmod-error-permission-denied = cannot access {$file}: Permission denied
 chmod-error-new-permissions = {$file}: new permissions are {$actual}, not {$expected}
 chmod-error-changing-permissions = changing permissions of {$file}: {$err}

--- a/src/uu/chmod/locales/fr-FR.ftl
+++ b/src/uu/chmod/locales/fr-FR.ftl
@@ -21,6 +21,8 @@ chmod-error-dangling-symlink = impossible d'opérer sur le lien symbolique pendo
 chmod-error-no-such-file = impossible d'accéder à {$file} : Aucun fichier ou répertoire de ce type
 chmod-error-preserve-root = il est dangereux d'opérer récursivement sur {$file}
   chmod: utiliser --no-preserve-root pour outrepasser cette protection
+chmod-error-preserve-root-same-as = il est dangereux d'opérer récursivement sur {$file} (identique à '/')
+  chmod: utiliser --no-preserve-root pour outrepasser cette protection
 chmod-error-permission-denied = impossible d'accéder à {$file} : Permission refusée
 chmod-error-new-permissions = {$file} : les nouvelles permissions sont {$actual}, pas {$expected}
 chmod-error-changing-permissions = changement des permissions de {$file} : {$err}

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -36,6 +36,8 @@ enum ChmodError {
     NoSuchFile(PathBuf),
     #[error("{}", translate!("chmod-error-preserve-root", "file" => _0.quote()))]
     PreserveRoot(PathBuf),
+    #[error("{}", translate!("chmod-error-preserve-root-same-as", "file" => _0.quote()))]
+    PreserveRootSameAs(PathBuf),
     #[error("{}", translate!("chmod-error-permission-denied", "file" => _0.quote()))]
     PermissionDenied(PathBuf),
     #[error("{}", translate!("chmod-error-new-permissions", "file" => _0.maybe_quote(), "actual" => _1.clone(), "expected" => _2.clone()))]
@@ -424,6 +426,17 @@ impl Chmoder {
         matches!(fs::canonicalize(&file), Ok(p) if p == Path::new("/"))
     }
 
+    /// `--preserve-root` guard for the recursive descent.
+    ///
+    /// The operand loop in [`Self::chmod`] only checks the paths named on the
+    /// command line. With `-L`, a symlink met *inside* the tree can resolve to
+    /// `/`, so the failsafe has to be re-checked at every descent or the
+    /// recursion walks straight into the real root. Only symlinks are
+    /// canonicalized, so ordinary trees pay nothing for this.
+    fn descends_into_root(&self, path: &Path) -> bool {
+        self.preserve_root && path.is_symlink() && Self::is_root(path)
+    }
+
     // Non-safe traversal implementation for platforms without safe_traversal support
     #[cfg(any(not(unix), target_os = "redox"))]
     fn walk_dir_with_context(
@@ -432,6 +445,12 @@ impl Chmoder {
         is_command_line_arg: bool,
         ancestors: &mut HashSet<FileInformation>,
     ) -> UResult<()> {
+        // Skip (and diagnose) a symlink that resolves to '/' before touching it.
+        if self.descends_into_root(file_path) {
+            show!(ChmodError::PreserveRootSameAs(file_path.into()));
+            return Ok(());
+        }
+
         let mut r = self.chmod_file(file_path);
 
         // Determine whether to traverse symlinks based on context and traversal mode
@@ -503,6 +522,12 @@ impl Chmoder {
         is_command_line_arg: bool,
         ancestors: &mut HashSet<FileInformation>,
     ) -> UResult<()> {
+        // Skip (and diagnose) a symlink that resolves to '/' before touching it.
+        if self.descends_into_root(file_path) {
+            show!(ChmodError::PreserveRootSameAs(file_path.into()));
+            return Ok(());
+        }
+
         let mut r = self.chmod_file(file_path);
 
         // Determine whether to traverse symlinks based on context and traversal mode

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -551,6 +551,26 @@ fn test_chmod_preserve_root_with_paths_that_resolve_to_root() {
 }
 
 #[test]
+fn test_chmod_preserve_root_symlink_during_recursion() {
+    // The failsafe must be re-checked during the descent, not only for the
+    // operands: with -L, a symlink met inside the tree that resolves to '/'
+    // would otherwise be recursed into.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("tree");
+    at.symlink_dir("/", "tree/link");
+
+    ucmd.arg("-R")
+        .arg("-L")
+        .arg("--preserve-root")
+        .arg("755")
+        .arg("tree")
+        .fails_with_code(1)
+        .stderr_contains(
+            "chmod: it is dangerous to operate recursively on 'tree/link' (same as '/')",
+        );
+}
+
+#[test]
 fn test_chmod_symlink_non_existing_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
--preserve-root was only enforced for the paths named on the command line (the operand loop in Chmoder::chmod). With -R -L, a symlink encountered *inside* the tree that resolves to / was followed, and the recursion walked into the real root, defeating the failsafe.
