### PR TITLE
chmod: report the real error when a target's metadata is inaccessible

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -370,40 +370,60 @@ impl Chmoder {
 
         for filename in files {
             let file = Path::new(filename);
-            if !file.exists() {
-                if file.is_symlink() {
-                    if !self.dereference && !self.recursive {
-                        // The file is a symlink and we should not follow it
-                        // Don't try to change the mode of the symlink itself
-                        continue;
-                    }
-                    if self.recursive && self.traverse_symlinks == TraverseSymlinks::None {
-                        continue;
-                    }
+            // `Path::exists()` returns `false` when the path's metadata cannot be
+            // read at all (for example a parent directory without search
+            // permission), which made chmod misreport an existing but
+            // inaccessible file as "No such file or directory". Use
+            // `try_exists()` so a permission error is surfaced as such, matching
+            // GNU (issue #9789).
+            match file.try_exists() {
+                Ok(false) => {
+                    if file.is_symlink() {
+                        if !self.dereference && !self.recursive {
+                            // The file is a symlink and we should not follow it
+                            // Don't try to change the mode of the symlink itself
+                            continue;
+                        }
+                        if self.recursive && self.traverse_symlinks == TraverseSymlinks::None {
+                            continue;
+                        }
 
-                    if !self.quiet {
-                        show!(ChmodError::DanglingSymlink(filename.into()));
-                        set_exit_code(1);
-                    }
+                        if !self.quiet {
+                            show!(ChmodError::DanglingSymlink(filename.into()));
+                            set_exit_code(1);
+                        }
 
-                    if self.verbose {
-                        println!(
-                            "{}",
-                            translate!("chmod-verbose-failed-dangling", "file" => filename.quote())
-                        );
+                        if self.verbose {
+                            println!(
+                                "{}",
+                                translate!("chmod-verbose-failed-dangling", "file" => filename.quote())
+                            );
+                        }
+                    } else if !self.quiet {
+                        show!(ChmodError::NoSuchFile(filename.into()));
                     }
-                } else if !self.quiet {
-                    show!(ChmodError::NoSuchFile(filename.into()));
+                    // GNU exits with exit code 1 even if -q or --quiet are passed
+                    // So we set the exit code, because it hasn't been set yet if `self.quiet` is true.
+                    set_exit_code(1);
+                    continue;
                 }
-                // GNU exits with exit code 1 even if -q or --quiet are passed
-                // So we set the exit code, because it hasn't been set yet if `self.quiet` is true.
-                set_exit_code(1);
-                continue;
-            } else if !self.dereference && file.is_symlink() {
-                // The file is a symlink and we should not follow it
-                // chmod 755 --no-dereference a/link
-                // should not change the permissions in this case
-                continue;
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                    if !self.quiet {
+                        show!(ChmodError::PermissionDenied(filename.into()));
+                    }
+                    set_exit_code(1);
+                    continue;
+                }
+                // Present, or an unexpected error that the chmod attempt below
+                // will surface with a precise message.
+                Ok(true) | Err(_) => {
+                    if !self.dereference && file.is_symlink() {
+                        // The file is a symlink and we should not follow it
+                        // chmod 755 --no-dereference a/link
+                        // should not change the permissions in this case
+                        continue;
+                    }
+                }
             }
             if self.recursive && self.preserve_root && Self::is_root(file) {
                 return Err(ChmodError::PreserveRoot("/".into()).into());

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -415,7 +415,7 @@ fn test_chmod_inaccessible_file_reports_permission_denied() {
     let at = &scene.fixtures;
 
     at.mkdir("locked");
-    make_file(&at.plus_as_string("locked/file"), 0o100644);
+    make_file(&at.plus_as_string("locked/file"), 0o100_644);
     set_permissions(at.plus_as_string("locked"), Permissions::from_mode(0o000)).unwrap();
 
     scene

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -406,6 +406,30 @@ fn test_permission_denied() {
 }
 
 #[test]
+fn test_chmod_inaccessible_file_reports_permission_denied() {
+    // Non-recursive chmod of a file whose metadata cannot be read because its
+    // parent directory lacks search permission must report "Permission denied",
+    // not "No such file or directory" (issue #9789). `Path::exists()` collapses
+    // the permission error into `false`, so the fix relies on `try_exists()`.
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("locked");
+    make_file(&at.plus_as_string("locked/file"), 0o100644);
+    set_permissions(at.plus_as_string("locked"), Permissions::from_mode(0o000)).unwrap();
+
+    scene
+        .ucmd()
+        .arg("644")
+        .arg("locked/file")
+        .fails()
+        .stderr_is("chmod: cannot access 'locked/file': Permission denied\n");
+
+    // Restore search permission so the fixture directory can be cleaned up.
+    set_permissions(at.plus_as_string("locked"), Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
 #[allow(clippy::unreadable_literal)]
 fn test_chmod_recursive_correct_exit_code() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Fixes #9789.

`chmod` used `Path::exists()` to decide whether a target exists. `Path::exists()` returns `false` for *any* metadata access error, including permission errors, so a file whose parent directory lacks search permission was reported as:

```
chmod: cannot access 'locked/file': No such file or directory
```

instead of GNU's:

```
chmod: cannot access 'locked/file': Permission denied
```

This switches the non-recursive path to `Path::try_exists()`, which returns `Ok(false)` only for a genuine `ENOENT` and `Err(..)` for a permission error. A permission error is now reported via the existing `ChmodError::PermissionDenied` variant, whose message already matches GNU. Any other unexpected metadata error falls through to the normal chmod attempt so it can surface a precise message.

Added a regression test (`test_chmod_inaccessible_file_reports_permission_denied`) for the non-recursive case; it fails on the old `Path::exists()` code (prints "No such file or directory") and passes with the fix. The existing permission-denied tests only covered the recursive (`-R`) path.
