### PR TITLE
shred: report the real error for an inaccessible file

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -624,17 +624,26 @@ fn wipe_file(
         }
     }
 
-    if !path.exists() {
-        return Err(USimpleError::new(
-            1,
-            translate!("shred-no-such-file-or-directory", "file" => path.maybe_quote()),
-        ));
-    }
-    if !path.is_file() {
-        return Err(USimpleError::new(
-            1,
-            translate!("shred-not-a-file", "file" => path.maybe_quote()),
-        ));
+    // `Path::exists()` and `Path::is_file()` both collapse any metadata error
+    // (including a permission error) into `false`, which made shred report a
+    // file whose parent directory lacks search permission as "No such file or
+    // directory". Inspect the metadata directly so a genuine `ENOENT` stays a
+    // "no such file" error while a permission error falls through to the
+    // open-for-writing below, which surfaces the real reason.
+    match fs::metadata(path) {
+        Ok(md) if !md.is_file() => {
+            return Err(USimpleError::new(
+                1,
+                translate!("shred-not-a-file", "file" => path.maybe_quote()),
+            ));
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Err(USimpleError::new(
+                1,
+                translate!("shred-no-such-file-or-directory", "file" => path.maybe_quote()),
+            ));
+        }
+        _ => {}
     }
 
     let metadata =

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -470,3 +470,31 @@ fn test_shred_trailing_slash_on_dir() {
         .fails()
         .stderr_contains("Is a directory");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_shred_inaccessible_file_reports_real_error() {
+    // A file whose parent directory lacks search permission must not be
+    // misreported as "No such file or directory": `Path::exists()` and
+    // `Path::is_file()` collapse the permission error into `false`.
+    use std::fs::{Permissions, set_permissions};
+    use std::os::unix::fs::PermissionsExt;
+
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+
+    at.mkdir("locked");
+    at.touch("locked/file");
+    set_permissions(at.plus_as_string("locked"), Permissions::from_mode(0o000)).unwrap();
+
+    let result = scene.ucmd().arg("locked/file").fails();
+    result.stderr_contains("Permission denied");
+    assert!(
+        !result.stderr_str().contains("No such file"),
+        "shred misreported an inaccessible file as missing: {}",
+        result.stderr_str()
+    );
+
+    // Restore search permission so the fixture directory can be cleaned up.
+    set_permissions(at.plus_as_string("locked"), Permissions::from_mode(0o755)).unwrap();
+}


### PR DESCRIPTION
Fixes #13639.

`shred`'s pre-checks used `Path::exists()` and `Path::is_file()`, both of which return `false` for *any* metadata access error, including a permission error. As a result, a file whose parent directory lacks search permission was reported as:

```
shred: locked/file: No such file or directory
```

even though it exists.

This replaces the two checks with a single `fs::metadata()` match:

- a genuine `ENOENT` still yields "No such file or directory";
- an existing non-file still yields "Not a file";
- a metadata error such as a permission error now falls through to the open-for-writing path, which surfaces the real reason instead of masquerading as a missing file.

All the normal cases (missing file, dangling symlink, directory, regular file) keep their existing behaviour. Added a `#[cfg(unix)]` regression test that shreds a file inside a `0o000` directory and asserts the error mentions "Permission denied" and not "No such file"; it fails on the old `Path::exists()` code and passes with the fix. This mirrors the fix in #9789 (chmod).
