### PR TITLE
chgrp: make `test_reference` less strict on Linux

### DIFF
--- a/tests/by-util/test_chgrp.rs
+++ b/tests/by-util/test_chgrp.rs
@@ -207,7 +207,8 @@ fn test_reference() {
             .arg("--reference=/etc/passwd")
             .arg("/etc")
             .fails()
-            .stderr_is("chgrp: changing group of '/etc': Operation not permitted\nfailed to change group of '/etc' from root to root\n");
+            // group name can differ, so just check the first part of the message
+            .stderr_contains("chgrp: changing group of '/etc': Operation not permitted\nfailed to change group of '/etc' from ");
     }
 }
 


### PR DESCRIPTION
The `test_reference` test recently started to fail in the CI on Linux with:
```
thread 'test_chgrp::test_reference' (14446) panicked at tests/by-util/test_chgrp.rs:210:14:
    assertion failed: `(left == right)`

    Diff < left / right > :
     chgrp: changing group of '/etc': Operation not permitted
    <failed to change group of '/etc' from runner to root
    >failed to change group of '/etc' from root to root
```
This PR makes the test less strict by no longer testing for specific groups.