### PR TITLE
fmt: measure -w in UTF-8 bytes to match GNU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,7 +3640,6 @@ dependencies = [
  "clap",
  "fluent",
  "thiserror 2.0.19",
- "unicode-width 0.2.2",
  "uucore",
 ]
 

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -20,7 +20,6 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-unicode-width = { workspace = true }
 uucore = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }

--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -8,22 +8,18 @@
 use std::io::BufRead;
 use std::iter::Peekable;
 use std::slice::Iter;
-use unicode_width::UnicodeWidthChar;
 
 use crate::FileOrStdReader;
 use crate::FmtOptions;
 
+/// Column contribution of a decoded character toward GNU `fmt` `-w`/`--width`.
+///
+/// Current GNU `fmt` (through at least 9.11) is not multibyte-aware: it measures
+/// line length in UTF-8 bytes (pointer differences in `fmt.c`), not Unicode
+/// display columns. Match that so wrapping agrees on CJK and other multibyte text.
+/// When GNU switches to display-column width, revisit this.
 fn char_width(c: char) -> usize {
-    if (c as usize) < 0xA0 {
-        // if it is ASCII, call it exactly 1 wide (including control chars)
-        // calling control chars' widths 1 is consistent with OpenBSD fmt
-        1
-    } else {
-        // otherwise, get the unicode width
-        // note that we shouldn't actually get None here because only c < 0xA0
-        // can return None, but for safety and future-proofing we do it this way
-        UnicodeWidthChar::width(c).unwrap_or(1)
-    }
+    c.len_utf8()
 }
 
 /// Return the UTF-8 sequence length implied by a leading byte, or `None` if invalid.
@@ -98,8 +94,9 @@ fn decode_char_info(bytes: &[u8], start: usize) -> DecodedCharInfo {
     }
 }
 
-/// Compute display width for a UTF-8 byte slice, treating invalid bytes as width 1.
-fn byte_display_width(bytes: &[u8]) -> usize {
+/// Compute GNU-compatible width for a UTF-8 byte slice (byte length).
+/// Invalid UTF-8 bytes are treated as width 1 each via `decode_char_info`.
+fn byte_width(bytes: &[u8]) -> usize {
     let mut width = 0;
     let mut idx = 0;
     while idx < bytes.len() {
@@ -157,7 +154,7 @@ pub struct FileLine {
     indent_end: usize,
     /// The end of the PREFIX's indent, that is, the spaces before the prefix
     prefix_indent_end: usize,
-    /// Display length of indent taking into account tabs
+    /// Printed length of indent taking into account tabs (GNU: byte-oriented)
     indent_len: usize,
     /// PREFIX indent length taking into account tabs
     prefix_len: usize,
@@ -561,7 +558,7 @@ impl<'a> ParaWords<'a> {
                     .map(|x| WordInfo {
                         word: x,
                         word_start: 0,
-                        word_nchars: byte_display_width(x),
+                        word_nchars: byte_width(x),
                         before_tab: None,
                         after_tab: 0,
                         sentence_start: false,

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -65,6 +65,25 @@ fn test_fmt_width_max_display_width() {
         .stdout_is("aa\nbb cc\ndd ee\n");
 }
 
+/// Regression for https://github.com/uutils/coreutils/issues/10095
+///
+/// GNU `fmt` measures `-w` in UTF-8 bytes (not Unicode display columns).
+/// These cases match GNU coreutils 9.11.
+#[test]
+fn test_fmt_width_multibyte_gnu_compatible() {
+    new_ucmd!()
+        .args(&["-w", "10"])
+        .pipe_in("漢 字 test 日 本 語")
+        .succeeds()
+        .stdout_is("漢 字\ntest 日\n本 語\n");
+
+    new_ucmd!()
+        .args(&["-w", "15"])
+        .pipe_in("漢字 test 日本語")
+        .succeeds()
+        .stdout_is("漢字 test\n日本語\n");
+}
+
 #[test]
 fn test_fmt_width_invalid() {
     new_ucmd!()


### PR DESCRIPTION
### Summary
GNU `fmt` (verified against 9.11) measures `-w`/`--width` in UTF-8 **bytes**, not Unicode display columns. uutils was using `unicode-width`, so CJK examples from #10095 wrapped differently.

This switches `char_width` / word length accounting in `parasplit.rs` to UTF-8 byte length and adds regression tests for the issue’s multibyte cases.

Intentionally **not** reopening #12623’s `width-1` / newline-budget approach (closed as stale vs GNU 9.10+).

When GNU grows true multibyte/display-column width support, this should be revisited.

### Validation
```
cargo test --features unix --test tests test_fmt_width -- --nocapture
# 7 passed (includes test_fmt_width_multibyte_gnu_compatible)
```

Compared local binary output to GNU 9.11 on the #10095 examples.

Fixes #10095

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.

Made with [Cursor](https://cursor.com)