### PR TITLE
sort: do not panic when --check stops at the first disorder

### DIFF
--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -53,7 +53,13 @@ pub fn check(path: &OsStr, settings: &GlobalSettings) -> UResult<()> {
 
     let mut prev_chunk: Option<Chunk> = None;
     let mut line_idx = 0;
-    for chunk in loaded_receiver {
+    let mut result: UResult<()> = Ok(());
+    // Note that we iterate over a reference, so that `loaded_receiver` is still alive
+    // once we stop: `chunks::read` unwraps its `send`, so dropping our end while the
+    // reader thread is still going would panic it. Since we stop at the *first*
+    // disorder, the reader is usually still working at that point, so we shut it down
+    // in an orderly fashion below instead of just dropping our end.
+    'outer: for chunk in &loaded_receiver {
         line_idx += 1;
         if let Some(prev_chunk) = prev_chunk.take() {
             // Check if the first element of the new chunk is greater than the last
@@ -69,13 +75,14 @@ pub fn check(path: &OsStr, settings: &GlobalSettings) -> UResult<()> {
                 chunk.line_data(),
             ) > max_allowed_cmp
             {
-                return Err(SortError::Disorder {
+                result = Err(SortError::Disorder {
                     file: path.to_owned(),
                     line_number: line_idx,
                     line: String::from_utf8_lossy(new_first.line).into_owned(),
                     silent: settings.check_silent,
                 }
                 .into());
+                break 'outer;
             }
             let _ = recycled_sender.send(prev_chunk.recycle());
         }
@@ -83,19 +90,28 @@ pub fn check(path: &OsStr, settings: &GlobalSettings) -> UResult<()> {
         for (a, b) in chunk.lines().iter().tuple_windows() {
             line_idx += 1;
             if compare_by(a, b, settings, chunk.line_data(), chunk.line_data()) > max_allowed_cmp {
-                return Err(SortError::Disorder {
+                result = Err(SortError::Disorder {
                     file: path.to_owned(),
                     line_number: line_idx,
                     line: String::from_utf8_lossy(b.line).into_owned(),
                     silent: settings.check_silent,
                 }
                 .into());
+                break 'outer;
             }
         }
 
         prev_chunk = Some(chunk);
     }
-    Ok(())
+
+    // Stop handing out buffers, so the reader runs out of work, then drain anything it
+    // has already produced. This lets its in-flight `send` complete instead of failing,
+    // and terminates because the reader can only own the (at most two) recycled chunks
+    // that are still outstanding.
+    drop(recycled_sender);
+    while loaded_receiver.recv().is_ok() {}
+
+    result
 }
 
 /// The function running on the reader thread.

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1238,6 +1238,33 @@ fn test_check_silent() {
 }
 
 #[test]
+fn test_check_stops_early_without_panicking() {
+    // `--check` returns as soon as it finds the first disorder. That used to drop the
+    // channel while the reader thread was still sending chunks, so the reader panicked
+    // on a `SendError`. Under `panic = "abort"` (our release profile) that aborts the
+    // whole process instead of exiting 1.
+    //
+    // The disorder sits midway through an input that is large relative to the buffer
+    // size, so the reader is certain to be blocked on a full channel when we stop.
+    // Note this cannot fail spuriously: once the receiver outlives the reader, no
+    // panic is possible.
+    const LINES_BEFORE: usize = 20_000;
+    let mut input = "c\n".repeat(LINES_BEFORE);
+    input.push_str("a\n");
+    input.push_str(&"c\n".repeat(LINES_BEFORE));
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("disorder.txt", &input);
+
+    ucmd.args(&["-c", "--buffer-size=1K", "disorder.txt"])
+        .fails_with_code(1)
+        .stderr_only(format!(
+            "sort: disorder.txt:{}: disorder: a\n",
+            LINES_BEFORE + 1
+        ));
+}
+
+#[test]
 fn test_check_unique() {
     new_ucmd!()
         .args(&["-c", "-u"])


### PR DESCRIPTION
`check` returns as soon as it finds a disorder, which dropped the chunk receiver while the reader thread was still sending. The reader unwraps that send, so it panicked with `SendError`. Under `panic = "abort"` in the release profile that aborts the whole process instead of exiting 1, and since the disorder message is still printed first, it looks like it worked.

Keep the receiver alive until the reader has finished: stop handing out recycled buffers, then drain the loaded channel. The reader can only hold the two outstanding recycled chunks, so this reads at most two extra chunks and is guaranteed to terminate.

Fixes #11201.

---

Disclosure: an alternative solution would be to use a tribool response instead of the drain; this approach was chosen as it is smaller and self-contained.