### PR TITLE
sort: do not panic when a write fails during a merge

### DIFF
--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -20,7 +20,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
     rc::Rc,
-    sync::mpsc::{Receiver, Sender, SyncSender, channel, sync_channel},
+    sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError, channel, sync_channel},
     thread::{self, JoinHandle},
 };
 
@@ -309,12 +309,48 @@ impl FileMerger<'_> {
     }
 
     fn write_all_to(mut self, settings: &GlobalSettings, out: &mut impl Write) -> UResult<()> {
-        while self
-            .write_next(out, settings)
-            .map_err_context(|| "write failed".into())?
-        {}
-        drop(self.request_sender);
-        self.reader_join_handle.join().unwrap()
+        let mut write_result = Ok(());
+        loop {
+            match self
+                .write_next(out, settings)
+                .map_err_context(|| "write failed".into())
+            {
+                Ok(true) => (),
+                Ok(false) => break,
+                Err(error) => {
+                    // Don't return yet: we still have to shut the reader thread down in an
+                    // orderly fashion below. Returning here would drop our receivers while
+                    // the reader is still sending, and `chunks::read` unwraps that send.
+                    write_result = Err(error);
+                    break;
+                }
+            }
+        }
+
+        let Self {
+            heap,
+            request_sender,
+            reader_join_handle,
+            ..
+        } = self;
+
+        // Stop asking for chunks, so the reader runs out of work and returns.
+        drop(request_sender);
+        // Until it does, keep draining the files it might still be sending to. We have to
+        // poll all of them in turn rather than draining one at a time: the reader can be
+        // blocked on any one channel, and blocking on a different one would deadlock.
+        let mut files = heap.into_vec();
+        while !files.is_empty() {
+            files.retain(|file| {
+                !matches!(file.receiver.try_recv(), Err(TryRecvError::Disconnected))
+            });
+            thread::yield_now();
+        }
+
+        let reader_result = reader_join_handle.join().unwrap();
+        // A write failure is what the user needs to hear about; the reader hitting an error
+        // on the way down is secondary.
+        write_result.and(reader_result)
     }
 
     fn write_next(

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1137,6 +1137,41 @@ fn test_merge_preserves_long_lines() {
     assert_eq!(stdout.as_slice(), input.as_bytes());
 }
 
+// Regression test: a failing write must not take the merge reader thread down with it.
+// The write error used to propagate straight out of `write_all_to`, dropping the chunk
+// receivers while the reader was still sending, and `chunks::read` unwraps that send.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_merge_write_error_does_not_panic() {
+    use std::fs::File;
+
+    // The inputs have to be long enough that the reader is still feeding us chunks when
+    // the write fails, otherwise it has already finished and there is nothing to race.
+    const LINES: usize = 100_000;
+    let mut input = String::with_capacity(LINES * 7);
+    for line in 0..LINES {
+        writeln!(input, "{line:06}").unwrap();
+    }
+
+    let ts = TestScenario::new("sort");
+    ts.fixtures.write("a.txt", &input);
+    ts.fixtures.write("b.txt", &input);
+
+    // Whether the reader is mid-send when the write fails is a race, so repeat: a single
+    // attempt reproduced the panic only about a quarter of the time. With the fix the
+    // reader is always shut down in an orderly fashion, so this cannot fail spuriously.
+    for _ in 0..20 {
+        let dev_full = File::create("/dev/full").expect("Failed to open /dev/full");
+        ts.ucmd()
+            .args(&["-m", "a.txt", "b.txt"])
+            .set_stdout(dev_full)
+            .fails()
+            .code_is(1)
+            .stderr_contains("No space left on device")
+            .stderr_does_not_contain("panicked");
+    }
+}
+
 #[test]
 fn test_merge_unique() {
     new_ucmd!()


### PR DESCRIPTION
`write_all_to` returned the write error immediately, which dropped the chunk receivers
while the reader thread was still sending. The reader unwraps that send, so it panicked
with `SendError`. Under `panic = "abort"` in the release profile that aborts the whole
process instead of reporting the write error and exiting 1. The write error is printed
first, so it looks like it worked and then crashes.

Fixes #13653.

## The change

Hold on to the error and shut the reader down first, the same way the success path
already does: stop requesting chunks, then drain the files it may still be sending to.

The drain polls every channel in turn rather than draining them one at a time. That part
is load-bearing: the reader can be blocked sending on any one file, so blocking on a
different one deadlocks. It costs nothing in practice because by then the reader only has
its outstanding requests left to finish.

## Verification

Release build (`panic = "abort"`), before -> after:

| repro | before | after |
| --- | --- | --- |
| `sort -m a b -o /dev/full` | 20/30 exit 134 | 40/40 exit 1 |
| `sort -S 1M big.txt -o /dev/full` | 6/6 abort | 15/15 exit 1 |
| `-S 100K` / `-S 8M`, same input | 8/8, 8/8 abort | 8/8, 8/8 exit 1 |
| `-m --batch-size=2` (temp-file path) | | 6/6 exit 1 |

Output correctness was checked too, not just the absence of a crash: merged output is
200000 lines and stdout matches the `-o` output, a 3M-line external sort's output passes
`sort -c`, and a batched merge gives 600000 sorted lines.

The new test fails 6/6 runs without the change and passes 6/6 with it. It repeats the
command 20 times because a single attempt only reproduces about a quarter of the time in a
debug build: the reader is request-driven, so it is only blocked in `send` transiently.
With the fix no panic is possible, so it cannot fail spuriously.

## Note for reviewers

The underlying `sender.send(payload?).unwrap()` in `chunks::read` is still there. The
alternative fix is to give it a third state instead of the `bool` and handle it at each
call site, which would cover this and #11201 at once. I went with the local fix because
that return value currently means "end of input" to callers that act on it: `merge.rs`
calls `finished_reading()`, which can delete a temp file, and `ext_sort/threaded.rs`
treats it as "the whole input fit in memory". Getting that mapping wrong turns a loud
crash into silent truncation, so it seemed worth doing separately and deliberately. Happy
to go that way instead if you prefer.

Independent of #13652 (same panic site, different trigger and different fix); the two
branches merge cleanly and their tests pass together.
