### PR TITLE
rm: do not panic when verbose output write fails

### DIFF
--- a/src/uu/rm/locales/en-US.ftl
+++ b/src/uu/rm/locales/en-US.ftl
@@ -49,6 +49,7 @@ rm-error-skipping-different-device = skipping {$file}, since it's on a different
 rm-error-and-preserve-root-all-in-effect = and --preserve-root=all is in effect
 rm-error-cannot-remove = cannot remove {$file}
 rm-error-may-not-abbreviate-no-preserve-root = you may not abbreviate the --no-preserve-root option
+rm-error-standard-output = standard output: {$error}
 
 # Verbose messages
 rm-verbose-removed = removed {$file}

--- a/src/uu/rm/locales/fr-FR.ftl
+++ b/src/uu/rm/locales/fr-FR.ftl
@@ -47,6 +47,7 @@ rm-error-use-no-preserve-root = utilisez --no-preserve-root pour outrepasser cet
 rm-error-refusing-to-remove-directory = refus de supprimer le répertoire '.' ou '..' : ignorer {$path}
 rm-error-cannot-remove = impossible de supprimer {$file}
 rm-error-may-not-abbreviate-no-preserve-root = Vous ne pouvez pas abréger l'option --no-preserve-root
+rm-error-standard-output = sortie standard : {$error}
 
 # Messages verbeux
 rm-verbose-removed = {$file} supprimé

--- a/src/uu/rm/src/platform/unix.rs
+++ b/src/uu/rm/src/platform/unix.rs
@@ -22,8 +22,8 @@ use uucore::translate;
 
 use super::super::{
     InteractiveMode, Options, is_dir_empty, is_readable_metadata, prompt_descend, remove_file,
-    show_permission_denied_error, show_removal_error, verbose_removed_directory,
-    verbose_removed_file,
+    show_permission_denied_error, show_removal_error, show_verbose_write_error,
+    verbose_removed_directory, verbose_removed_file,
 };
 
 #[inline]
@@ -128,8 +128,9 @@ pub fn safe_remove_file(
             if let Some(pb) = progress_bar {
                 pb.inc(1);
             }
-            verbose_removed_file(path, options);
-            Some(false)
+            Some(show_verbose_write_error(verbose_removed_file(
+                path, options,
+            )))
         }
         Err(e) => {
             if e.kind() == std::io::ErrorKind::PermissionDenied {
@@ -159,8 +160,9 @@ pub fn safe_remove_empty_dir(
             if let Some(pb) = progress_bar {
                 pb.inc(1);
             }
-            verbose_removed_directory(path, options);
-            Some(false)
+            Some(show_verbose_write_error(verbose_removed_directory(
+                path, options,
+            )))
         }
         Err(e) => {
             let e =
@@ -206,8 +208,7 @@ fn handle_permission_denied(
         return true;
     }
     // Successfully removed empty directory
-    verbose_removed_directory(entry_path, options);
-    false
+    show_verbose_write_error(verbose_removed_directory(entry_path, options))
 }
 
 /// Helper to handle unlink operation with error reporting
@@ -224,12 +225,12 @@ fn handle_unlink(
         show_error!("{e}");
         true
     } else {
-        if is_dir {
-            verbose_removed_directory(entry_path, options);
+        let result = if is_dir {
+            verbose_removed_directory(entry_path, options)
         } else {
-            verbose_removed_file(entry_path, options);
-        }
-        false
+            verbose_removed_file(entry_path, options)
+        };
+        show_verbose_write_error(result)
     }
 }
 
@@ -257,10 +258,7 @@ pub fn remove_dir_with_special_cases(path: &Path, options: &Options, error_occur
             // of the recursion.
             error_occurred
         }
-        Ok(_) => {
-            verbose_removed_directory(path, options);
-            false
-        }
+        Ok(_) => show_verbose_write_error(verbose_removed_directory(path, options)),
     }
 }
 
@@ -323,8 +321,7 @@ pub fn safe_remove_dir_recursive(
             if e.kind() == std::io::ErrorKind::PermissionDenied {
                 // Try to remove the directory directly if it's empty
                 if fs::remove_dir(path).is_ok() {
-                    verbose_removed_directory(path, options);
-                    return false;
+                    return show_verbose_write_error(verbose_removed_directory(path, options));
                 }
                 // If we can't read the directory AND can't remove it,
                 // show permission denied error for GNU compatibility

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -20,7 +20,7 @@ use std::path::MAIN_SEPARATOR;
 use std::path::Path;
 use thiserror::Error;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UError, UResult};
+use uucore::error::{FromIo, UError, UResult, USimpleError, strip_errno};
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::quoting_style::{QuotingStyle, locale_aware_escape_name};
 use uucore::translate;
@@ -52,24 +52,48 @@ enum RmError {
 
 impl UError for RmError {}
 
+/// Write one verbose line to standard output, turning a write failure
+/// (e.g. a full device or a closed pipe) into an error instead of
+/// panicking like `println!` would.
+fn write_verbose_line(message: &str) -> UResult<()> {
+    writeln!(io::stdout().lock(), "{message}").map_err(|err| {
+        USimpleError::new(
+            1,
+            translate!("rm-error-standard-output", "error" => strip_errno(&err)),
+        )
+    })?;
+    Ok(())
+}
+
 /// Helper function to print verbose message for removed file
-fn verbose_removed_file(path: &Path, options: &Options) {
+fn verbose_removed_file(path: &Path, options: &Options) -> UResult<()> {
     if options.verbose {
-        println!(
-            "{}",
-            translate!("rm-verbose-removed", "file" => uucore::fs::normalize_path(path).quote())
-        );
+        write_verbose_line(&translate!(
+            "rm-verbose-removed",
+            "file" => uucore::fs::normalize_path(path).quote()
+        ))?;
     }
+    Ok(())
 }
 
 /// Helper function to print verbose message for removed directory
-fn verbose_removed_directory(path: &Path, options: &Options) {
+fn verbose_removed_directory(path: &Path, options: &Options) -> UResult<()> {
     if options.verbose {
-        println!(
-            "{}",
-            translate!("rm-verbose-removed-directory", "file" => uucore::fs::normalize_path(path).quote())
-        );
+        write_verbose_line(&translate!(
+            "rm-verbose-removed-directory",
+            "file" => uucore::fs::normalize_path(path).quote()
+        ))?;
     }
+    Ok(())
+}
+
+/// Helper function to report a verbose output write error and return error status
+fn show_verbose_write_error(result: UResult<()>) -> bool {
+    if let Err(e) = result {
+        show_error!("{e}");
+        return true;
+    }
+    false
 }
 
 /// Helper function to show error with context and return error status
@@ -93,10 +117,7 @@ fn show_permission_denied_error(path: &Path) -> bool {
 /// Helper function to remove a directory and handle results
 fn remove_dir_with_feedback(path: &Path, options: &Options) -> bool {
     match fs::remove_dir(path) {
-        Ok(_) => {
-            verbose_removed_directory(path, options);
-            false
-        }
+        Ok(_) => show_verbose_write_error(verbose_removed_directory(path, options)),
         Err(e) => show_removal_error(e, path),
     }
 }
@@ -720,7 +741,9 @@ fn remove_dir_recursive(
                 // show another error message as we return from each level
                 // of the recursion.
             }
-            Ok(_) => verbose_removed_directory(path, options),
+            Ok(_) => {
+                error = error || show_verbose_write_error(verbose_removed_directory(path, options));
+            }
         }
 
         error
@@ -845,7 +868,7 @@ fn remove_file(path: &Path, options: &Options, progress_bar: Option<&ProgressBar
         // Fallback method for non-Unix, Redox, or when safe traversal is unavailable
         match fs::remove_file(path) {
             Ok(_) => {
-                verbose_removed_file(path, options);
+                return show_verbose_write_error(verbose_removed_file(path, options));
             }
             Err(e) => {
                 if e.kind() == io::ErrorKind::PermissionDenied {

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -89,11 +89,10 @@ fn verbose_removed_directory(path: &Path, options: &Options) -> UResult<()> {
 
 /// Helper function to report a verbose output write error and return error status
 fn show_verbose_write_error(result: UResult<()>) -> bool {
-    if let Err(e) = result {
+    if let Err(e) = &result {
         show_error!("{e}");
-        return true;
     }
-    false
+    result.is_err()
 }
 
 /// Helper function to show error with context and return error status

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -334,6 +334,58 @@ fn test_verbose() {
         .stdout_only(format!("removed '{file_a}'\nremoved '{file_b}'\n"));
 }
 
+// Regression test for issue #10551: `rm -v` must report a verbose output
+// write failure on stderr and exit 1 instead of panicking.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_verbose_write_error_does_not_panic() {
+    use std::fs::OpenOptions;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_rm_verbose_write_error_file";
+
+    at.touch(file);
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+
+    ucmd.arg("-v")
+        .arg(file)
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1)
+        .stderr_contains("No space left on device")
+        .stderr_does_not_contain("panicked");
+
+    assert!(!at.file_exists(file));
+}
+
+// Directory variant of the #10551 regression test.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_verbose_write_error_does_not_panic_dir() {
+    use std::fs::OpenOptions;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    let dir = "test_rm_verbose_write_error_dir";
+    let file = "test_rm_verbose_write_error_dir/a";
+
+    at.mkdir(dir);
+    at.touch(file);
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+
+    ucmd.arg("-r")
+        .arg("-v")
+        .arg(dir)
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1)
+        .stderr_contains("No space left on device")
+        .stderr_does_not_contain("panicked");
+
+    assert!(!at.file_exists(file));
+}
+
 #[test]
 #[cfg(not(windows))]
 // on unix symlink_dir is a file


### PR DESCRIPTION
`rm -v` printed the "removed ..." lines with `println!`, which panics when the stdout write fails (e.g. `rm -v a > /dev/full`): the entry is already removed, then the process dies on `failed printing to stdout` instead of reporting the error.

The verbose helpers now write through a small `write_verbose_line()` that turns an io error into a diagnostic (`rm: standard output: No space left on device`) plus exit status 1, matching how other write failures are reported (same idiom as `yes`).

Regression tests cover the file and `-r` directory cases with stdout redirected to /dev/full: exit 1, OS error on stderr, no panic, entry removed.

Fixes #10551.
