### PR TITLE
mv: compare file identity in the --backup=simple safety guard

### DIFF
--- a/0001-uniq-add-benchmarks-for-w-check-chars.patch
+++ b/0001-uniq-add-benchmarks-for-w-check-chars.patch
@@ -19,7 +19,7 @@ index ab5e57038..780ecff15 100644
 @@ -108,6 +108,29 @@ fn uniq_case_insensitive(bencher: Bencher, num_lines: usize) {
      });
  }
- 
+
 +/// Benchmark 4: `-w N` over duplicate-heavy input, for both a narrow N (1)
 +/// and a wide N (512, as reported in #13199).
 +/// Regression coverage for #13199: `uniq -w N` was ~5x slower than GNU uniq
@@ -46,6 +46,5 @@ index ab5e57038..780ecff15 100644
  fn main() {
      divan::main();
  }
--- 
+--
 2.53.0
-

--- a/0001-uniq-add-benchmarks-for-w-check-chars.patch
+++ b/0001-uniq-add-benchmarks-for-w-check-chars.patch
@@ -1,0 +1,51 @@
+From 9f5f6a008258741ae359a43920d25c3e959f9867 Mon Sep 17 00:00:00 2001
+From: Sylvestre Ledru <sylvestre@debian.org>
+Date: Wed, 1 Jul 2026 21:33:03 +0200
+Subject: [PATCH] uniq: add benchmarks for -w/--check-chars
+
+There was no benchmark exercising --check-chars, the option that
+triggered the per-line locale env-var lookups fixed for #13199. Add
+two cases (narrow and wide N) reusing the existing duplicate-heavy
+data generator so key-bounds computation still runs on every line
+without flooding the benchmark output.
+---
+ src/uu/uniq/benches/uniq_bench.rs | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/src/uu/uniq/benches/uniq_bench.rs b/src/uu/uniq/benches/uniq_bench.rs
+index ab5e57038..780ecff15 100644
+--- a/src/uu/uniq/benches/uniq_bench.rs
++++ b/src/uu/uniq/benches/uniq_bench.rs
+@@ -108,6 +108,29 @@ fn uniq_case_insensitive(bencher: Bencher, num_lines: usize) {
+     });
+ }
+ 
++/// Benchmark 4: `-w N` over duplicate-heavy input, for both a narrow N (1)
++/// and a wide N (512, as reported in #13199).
++/// Regression coverage for #13199: `uniq -w N` was ~5x slower than GNU uniq
++/// because the locale check inside key bounds computation was re-evaluated
++/// via environment variable lookups on every single line (duplicate or not),
++/// regardless of N. Reuses the duplicate-heavy generator so the vast
++/// majority of lines collapse and the benchmark isn't dominated by output.
++#[divan::bench(args = [(10_000, "1"), (10_000, "512")])]
++fn uniq_check_chars(bencher: Bencher, (num_lines, check_chars): (usize, &str)) {
++    let num_groups = 1000;
++    let duplicates_per_group = num_lines / num_groups;
++    let data = generate_duplicate_heavy_data(num_groups, duplicates_per_group);
++    let file_path = setup_test_file(&data);
++    let file_path_str = file_path.to_str().unwrap();
++
++    bencher.bench(|| {
++        black_box(run_util_function(
++            uumain,
++            &["-w", check_chars, file_path_str],
++        ));
++    });
++}
++
+ fn main() {
+     divan::main();
+ }
+-- 
+2.53.0
+

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -365,7 +365,10 @@ fn parse_paths(files: &[OsString], opts: &Options) -> Vec<PathBuf> {
 }
 
 fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()> {
-    if opts.backup == BackupMode::Simple && source_is_target_backup(source, target, &opts.suffix) {
+    // `mv` never follows a symlink source, so the guard must not either.
+    if opts.backup == BackupMode::Simple
+        && source_is_target_backup(source, target, &opts.suffix, false)
+    {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
             translate!("mv-error-backup-might-destroy-source", "target" => target.quote(), "source" => source.quote()),

--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -470,37 +470,59 @@ fn existing_backup_path<S: AsRef<OsStr>>(path: &Path, suffix: S) -> PathBuf {
 /// * `source` - A Path reference that holds the source (backup) file path.
 /// * `target` - A Path reference that holds the target file path.
 /// * `suffix` - Str that holds the backup suffix.
+/// * `dereference` - Whether the source is resolved through symlinks, matching
+///   how the calling utility opens it (`false` for `mv`, `true` for `cp`/`install`).
 ///
 /// # Examples
 ///
 /// ```
+/// use std::fs;
 /// use std::path::Path;
 /// use uucore::backup_control::source_is_target_backup;
-/// let source = Path::new("data.txt~");
-/// let target = Path::new("data.txt");
-/// let suffix = String::from("~");
 ///
-/// assert_eq!(source_is_target_backup(&source, &target, &suffix), true);
+/// let dir = tempfile::tempdir().unwrap();
+/// let target = dir.path().join("data.txt");
+/// let source = dir.path().join("data.txt~");
+/// fs::write(&target, "").unwrap();
+/// fs::write(&source, "").unwrap();
+///
+/// // `./data.txt~` and `data.txt~` name the same file, so both are caught.
+/// assert!(source_is_target_backup(&source, &target, "~", false));
 /// ```
 ///
-pub fn source_is_target_backup(source: &Path, target: &Path, suffix: &str) -> bool {
+pub fn source_is_target_backup(
+    source: &Path,
+    target: &Path,
+    suffix: &str,
+    dereference: bool,
+) -> bool {
+    // GNU gates on the file names first: only a source whose final component is
+    // the target's final component plus the suffix can be clobbered by the
+    // backup rename. This keeps unrelated files that merely happen to share an
+    // inode (a hard link, say) from being refused.
+    let (Some(source_base), Some(target_base)) = (source.file_name(), target.file_name()) else {
+        return false;
+    };
+    let mut expected_base = target_base.to_owned();
+    expected_base.push(suffix);
+    if source_base != expected_base {
+        return false;
+    }
+
+    // Then compare the files themselves rather than how they were spelled, so
+    // `a~`, `./a~` and an absolute path are all recognised. If the backup does
+    // not exist yet there is nothing to destroy.
     let mut target_backup_filename = target.as_os_str().to_owned();
     target_backup_filename.push(suffix);
     let target_backup = PathBuf::from(target_backup_filename);
 
-    // Compare the files themselves, not how they were spelled: `a~`, `./a~` and
-    // an absolute path all name the same file, and comparing the strings lets
-    // the guard fail open and silently destroy the source.
-    if let (Ok(source_info), Ok(backup_info)) = (
-        FileInformation::from_path(source, false),
-        FileInformation::from_path(&target_backup, false),
+    match (
+        FileInformation::from_path(source, dereference),
+        FileInformation::from_path(&target_backup, true),
     ) {
-        return source_info == backup_info;
+        (Ok(source_info), Ok(backup_info)) => source_info == backup_info,
+        _ => false,
     }
-
-    // The backup does not exist yet (so nothing can be destroyed), or one of the
-    // paths could not be stat'd; fall back to comparing the spellings.
-    source.as_os_str() == target_backup.as_os_str()
 }
 
 //
@@ -689,28 +711,79 @@ mod tests {
 
     #[test]
     fn test_source_is_target_backup() {
-        let source = Path::new("data.txt.bak");
-        let target = Path::new("data.txt");
-        let suffix = String::from(".bak");
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("data.txt");
+        let source = dir.path().join("data.txt.bak");
+        fs::write(&target, "").unwrap();
+        fs::write(&source, "").unwrap();
 
-        assert!(source_is_target_backup(source, target, &suffix));
+        assert!(source_is_target_backup(&source, &target, ".bak", false));
     }
 
     #[test]
     fn test_source_is_not_target_backup() {
-        let source = Path::new("data.txt");
-        let target = Path::new("backup.txt");
-        let suffix = String::from(".bak");
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("backup.txt");
+        let source = dir.path().join("data.txt");
+        fs::write(&target, "").unwrap();
+        fs::write(&source, "").unwrap();
 
-        assert!(!source_is_target_backup(source, target, &suffix));
+        assert!(!source_is_target_backup(&source, &target, ".bak", false));
     }
 
     #[test]
     fn test_source_is_target_backup_with_tilde_suffix() {
-        let source = Path::new("example~");
-        let target = Path::new("example");
-        let suffix = String::from("~");
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("example");
+        let source = dir.path().join("example~");
+        fs::write(&target, "").unwrap();
+        fs::write(&source, "").unwrap();
 
-        assert!(source_is_target_backup(source, target, &suffix));
+        assert!(source_is_target_backup(&source, &target, "~", false));
+    }
+
+    /// The guard must see through how the operands were spelled.
+    #[test]
+    fn test_source_is_target_backup_ignores_spelling() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a"), "").unwrap();
+        fs::write(dir.path().join("a~"), "").unwrap();
+
+        for target in ["a", "./a"] {
+            let source = dir.path().join("a~");
+            let target = dir.path().join(target);
+            assert!(
+                source_is_target_backup(&source, &target, "~", false),
+                "guard failed open for target spelled {}",
+                target.display()
+            );
+        }
+    }
+
+    /// A backup that does not exist yet cannot destroy anything.
+    #[test]
+    fn test_source_is_target_backup_absent_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("a");
+        let source = dir.path().join("a~");
+        fs::write(&target, "").unwrap();
+
+        assert!(!source_is_target_backup(&source, &target, "~", false));
+    }
+
+    /// Sharing the backup's inode under a different name is safe: the rename
+    /// only drops one link, so the data survives.
+    #[cfg(unix)]
+    #[test]
+    fn test_source_is_target_backup_hard_link_under_other_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("a");
+        let backup = dir.path().join("a~");
+        let source = dir.path().join("b");
+        fs::write(&target, "").unwrap();
+        fs::write(&backup, "").unwrap();
+        fs::hard_link(&backup, &source).unwrap();
+
+        assert!(!source_is_target_backup(&source, &target, "~", false));
     }
 }

--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -84,6 +84,7 @@
 use crate::{
     display::Quotable,
     error::{UError, UResult},
+    fs::FileInformation,
 };
 use clap::ArgMatches;
 use std::{
@@ -483,10 +484,23 @@ fn existing_backup_path<S: AsRef<OsStr>>(path: &Path, suffix: S) -> PathBuf {
 /// ```
 ///
 pub fn source_is_target_backup(source: &Path, target: &Path, suffix: &str) -> bool {
-    let source_filename = source.as_os_str();
     let mut target_backup_filename = target.as_os_str().to_owned();
     target_backup_filename.push(suffix);
-    source_filename == target_backup_filename
+    let target_backup = PathBuf::from(target_backup_filename);
+
+    // Compare the files themselves, not how they were spelled: `a~`, `./a~` and
+    // an absolute path all name the same file, and comparing the strings lets
+    // the guard fail open and silently destroy the source.
+    if let (Ok(source_info), Ok(backup_info)) = (
+        FileInformation::from_path(source, false),
+        FileInformation::from_path(&target_backup, false),
+    ) {
+        return source_info == backup_info;
+    }
+
+    // The backup does not exist yet (so nothing can be destroyed), or one of the
+    // paths could not be stat'd; fall back to comparing the spellings.
+    source.as_os_str() == target_backup.as_os_str()
 }
 
 //

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -703,6 +703,49 @@ fn test_mv_same_hardlink_backup_simple_destroy() {
         .stderr_contains("backing up 'test_mv_same_file_a' might destroy source");
 }
 
+/// The guard must compare the files, not how the operands were spelled.
+/// Comparing strings let `'a~'` versus `'./a'` slip through, and mv then
+/// destroyed the source and exited 0 with no diagnostic.
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_backup_simple_guard_ignores_spelling() {
+    for target in ["./test_mv_spell_a", "test_mv_spell_a"] {
+        let (at, mut ucmd) = at_and_ucmd!();
+        let source = "test_mv_spell_a~";
+        at.write(source, "SRCDATA");
+        at.write("test_mv_spell_a", "DSTDATA");
+
+        ucmd.arg(source)
+            .arg(target)
+            .arg("--backup=simple")
+            .fails()
+            .stderr_contains("might destroy source");
+
+        assert_eq!(
+            at.read(source),
+            "SRCDATA",
+            "mv destroyed the source when the target was spelled {target}"
+        );
+    }
+}
+
+/// ...but it must not fire for unrelated operands that merely look similar.
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_backup_simple_guard_allows_unrelated_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("test_mv_spell_src", "SRCDATA");
+    at.write("test_mv_spell_dst", "DSTDATA");
+
+    ucmd.arg("test_mv_spell_src")
+        .arg("test_mv_spell_dst")
+        .arg("--backup=simple")
+        .succeeds();
+
+    assert_eq!(at.read("test_mv_spell_dst"), "SRCDATA");
+    assert_eq!(at.read("test_mv_spell_dst~"), "DSTDATA");
+}
+
 #[test]
 fn test_mv_same_file_not_dot_dir() {
     let (at, mut ucmd) = at_and_ucmd!();

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -746,6 +746,41 @@ fn test_mv_backup_simple_guard_allows_unrelated_source() {
     assert_eq!(at.read("test_mv_spell_dst~"), "DSTDATA");
 }
 
+/// A symlink source is a distinct file from the backup it points at, so the
+/// backup rename cannot destroy it. GNU allows this.
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_backup_simple_guard_allows_symlink_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("test_mv_sym_a", "DSTDATA");
+    at.write("test_mv_sym_real", "REALDATA");
+    at.symlink_file("test_mv_sym_real", "test_mv_sym_a~");
+
+    ucmd.arg("test_mv_sym_a~")
+        .arg("test_mv_sym_a")
+        .arg("--backup=simple")
+        .succeeds();
+}
+
+/// A hard link under another name shares the backup's inode but keeps the data
+/// alive after the rename, so the guard must not fire. GNU allows this.
+#[test]
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_mv_backup_simple_guard_allows_hardlink_source() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("test_mv_hl_a", "DSTDATA");
+    at.write("test_mv_hl_a~", "SRCDATA");
+    at.hard_link("test_mv_hl_a~", "test_mv_hl_b");
+
+    ucmd.arg("test_mv_hl_b")
+        .arg("test_mv_hl_a")
+        .arg("--backup=simple")
+        .succeeds();
+
+    assert_eq!(at.read("test_mv_hl_a"), "SRCDATA");
+    assert_eq!(at.read("test_mv_hl_a~"), "DSTDATA");
+}
+
 #[test]
 fn test_mv_same_file_not_dot_dir() {
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
source_is_target_backup appended the suffix to the destination and compared the result to the source as raw strings, so the guard only fired when both operands happened to be spelled the same way. "a~" != "./a" + "~"