### PR TITLE
ls: support numeric-uid-gid on non-unix platforms

### DIFF
--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -781,13 +781,11 @@ impl Config {
             let group = !options.get_flag(options::NO_GROUP)
                 && !options.get_flag(options::format::LONG_NO_GROUP);
             let owner = !options.get_flag(options::format::LONG_NO_OWNER);
-            #[cfg(unix)]
             let numeric_uid_gid = options.get_flag(options::format::LONG_NUMERIC_UID_GID);
             LongFormat {
                 author,
                 group,
                 owner,
-                #[cfg(unix)]
                 numeric_uid_gid,
             }
         };

--- a/src/uu/ls/src/display.rs
+++ b/src/uu/ls/src/display.rs
@@ -64,7 +64,6 @@ pub(crate) struct LongFormat {
     pub(crate) author: bool,
     pub(crate) group: bool,
     pub(crate) owner: bool,
-    #[cfg(unix)]
     pub(crate) numeric_uid_gid: bool,
 }
 
@@ -667,12 +666,21 @@ fn display_group<'a>(
 }
 
 #[cfg(not(unix))]
-fn display_uname(_metadata: &Metadata, _config: &Config, _uid_cache: &mut ()) -> &'static str {
-    "somebody"
+fn display_uname(_metadata: &Metadata, config: &Config, _uid_cache: &mut ()) -> &'static str {
+    // No uid to report on this platform; with `-n` fall back to "0" so the
+    // output still looks numeric, matching the intent of --numeric-uid-gid.
+    if config.long.numeric_uid_gid {
+        "0"
+    } else {
+        "somebody"
+    }
 }
 
 #[cfg(not(unix))]
-fn display_group(_metadata: &Metadata, _config: &Config, _gid_cache: &mut ()) -> &'static str {
+fn display_group(_metadata: &Metadata, config: &Config, _gid_cache: &mut ()) -> &'static str {
+    if config.long.numeric_uid_gid {
+        return "0";
+    }
     "somegroup"
 }
 


### PR DESCRIPTION
Parameter numeric_uid_gid was gated behind #[cfg(unix)], but display_uname and display_group have non-unix fallbacks that print placeholder owner/ group names ("somebody"/"somegroup"); those fallbacks now check the flag too and print "0" instead, matching --numeric-uid-gid's intent on platforms without real uid/gid values (including WASI, which was otherwise left in an inconsistent cfg state where the field existed without being usable everywhere it was read).