### PR TITLE
test: avoid temp path collisions in install strip tests

### DIFF
--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -792,8 +792,12 @@ fn strip_source_file() -> PathBuf {
     BINARY
         .get_or_init(|| {
             let dir = std::env::temp_dir();
-            let source = dir.join("hello.rs");
-            let binary = dir.join("hello_bin");
+            // Include the PID so concurrent test processes (e.g. under `cargo
+            // nextest`, which runs each test in its own process) don't race
+            // on the same source/binary path.
+            let pid = process::id();
+            let source = dir.join(format!("hello-{pid}.rs"));
+            let binary = dir.join(format!("hello_bin-{pid}"));
             let mut file = File::create(&source).unwrap();
             file.write_all(b"fn main() {}").unwrap();
             process::Command::new("rustc")


### PR DESCRIPTION
Function strip_source_file() reused a fixed hello.rs/hello_bin path in std::env::temp_dir(), which races when tests run in separate processes (e.g. under cargo nextest, which runs each test in its own process) and could pick up another process's file mid-write or mid-compile. Suffix both paths with the process PID.