### PR TITLE
test: widen several linux-only tests to run on all unix platforms

### DIFF
--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
@@ -171,7 +171,7 @@ fn test_encode_large_input_is_buffered() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_base32_file_with_trailing_slash() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("a", "b");

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -5,7 +5,7 @@
 
 // spell-checker:ignore unpadded, QUJD
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
@@ -287,7 +287,7 @@ fn test_read_error() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_base64_file_with_trailing_slash() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("a", "b");

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -769,7 +769,7 @@ fn test_cat_non_utf8_paths() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_appending_same_input_output() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -2232,7 +2232,7 @@ fn test_du_safe_traversal_with_symlinks() {
     assert!(!result.stdout_str().is_empty());
 }
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_du_inaccessible_directory() {
     // tested by tests/du/no-x
     let ts = TestScenario::new(util_name!());
@@ -2427,7 +2427,7 @@ fn test_du_hard_links_multiple_links_in_args() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_du_symlinks_multiple_links_in_args() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -209,7 +209,7 @@ fn test_number_separator() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[cfg_attr(wasi_runner, ignore = "WASI: argv/filenames must be valid UTF-8")]
 fn test_number_separator_non_utf8() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};
@@ -644,7 +644,7 @@ fn test_section_delimiter() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[cfg_attr(wasi_runner, ignore = "WASI: argv/filenames must be valid UTF-8")]
 fn test_section_delimiter_non_utf8() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};
@@ -711,7 +711,7 @@ fn test_one_char_section_delimiter() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[cfg_attr(wasi_runner, ignore = "WASI: argv/filenames must be valid UTF-8")]
 fn test_one_byte_section_delimiter() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};

--- a/tests/by-util/test_seq.rs
+++ b/tests/by-util/test_seq.rs
@@ -295,7 +295,7 @@ fn test_separator_and_terminator() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_separator_non_utf8() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
@@ -318,7 +318,7 @@ fn test_separator_non_utf8() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_terminator_non_utf8() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1818,7 +1818,7 @@ fn test_files0_read_error() {
         .stderr_only("sort: cannot read: .: Is a directory\n");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[test]
 // Test for GNU tests/sort/sort-files0-from.pl "empty-non-regular"
 fn test_files0_from_empty_non_regular() {

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -133,7 +133,7 @@ fn test_invalid_arg() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(target_os = "android")))]
 fn test_split_to_non_seekable() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.symlink_file("/dev/stdout", "xaa");
@@ -2093,7 +2093,7 @@ fn test_split_non_utf8_additional_suffix_is_byte_preserving() {
 }
 
 #[test]
-#[cfg(target_os = "linux")] // To re-enable on Windows once I work out what goes wrong with it.
+#[cfg(unix)] // To re-enable on Windows once I work out what goes wrong with it.
 fn test_split_directory_already_exists() {
     let (at, mut ucmd) = at_and_ucmd!();
 

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -395,7 +395,7 @@ fn test_failed_write_is_reported() {
         .stderr_is("tac: failed to write to stdout: No space left on device\n");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[test]
 fn test_stdin_bad_tmpdir_fallback() {
     // When TMPDIR is invalid, tac falls back to reading stdin directly into memory

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -5074,7 +5074,7 @@ fn test_failed_write_is_reported_on_seekable_input() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_dev_zero() {
     new_ucmd!()
         .args(&["-c", "1", "/dev/zero"])

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -645,7 +645,7 @@ fn test_touch_set_date_without_leading_zeroes() {
 /// expected by the old nix-based implementation. After switching to rustix
 /// (which uses i64 `tv_sec` natively), this should succeed on all targets.
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn test_touch_set_date_year_zero() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_year_zero";

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -385,6 +385,7 @@ fn test_truncate_with_set1_shorter_than_set2() {
 fn test_truncate_applies_before_complement_with_class() {
     new_ucmd!()
         .args(&["-ct", "[:digit:]", "X"])
+        .ignore_stdin_write_error()
         .pipe_in("A")
         .fails()
         .stderr_contains("when translating with complemented character classes,\nstring2 must map all characters in the domain to one");


### PR DESCRIPTION
Several tests were gated behind #[cfg(target_os = "linux")] even though they only exercise generic POSIX/Unix behavior (trailing-slash handling, non-UTF-8 argv, hard/soft link traversal, /dev/zero reads, directory-exists errors, TMPDIR fallback, and pre-1970 timestamps via rustix). Widen the gate to #[cfg(unix)] so they also run on macOS and BSD; verified passing locally on macOS.