### PR TITLE
mv: apply the backup guard to every mode but numbered

### DIFF
--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -366,7 +366,10 @@ fn parse_paths(files: &[OsString], opts: &Options) -> Vec<PathBuf> {
 
 fn handle_two_paths(source: &Path, target: &Path, opts: &Options) -> UResult<()> {
     // `mv` never follows a symlink source, so the guard must not either.
-    if opts.backup == BackupMode::Simple
+    // GNU applies this to every mode but `numbered`, which cannot reuse an
+    // existing name; `existing` falls back to a simple backup when no numbered
+    // backup is present, and so can destroy the source just the same.
+    if !matches!(opts.backup, BackupMode::None | BackupMode::Numbered)
         && source_is_target_backup(source, target, &opts.suffix, false)
     {
         return Err(io::Error::new(

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -3343,3 +3343,51 @@ fn test_mv_cross_device_preserves_ownership_recursive() {
         "nested file gid should be preserved after cross-device move"
     );
 }
+
+#[test]
+fn test_mv_backup_existing_mode_protects_source() {
+    // `--backup=existing` falls back to a simple backup when no numbered
+    // backup is present, so it can destroy the source just as `simple` does.
+    // GNU refuses in every mode but `numbered`.
+    for mode in ["simple", "existing"] {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("a");
+        at.write("a~", "source content");
+
+        ucmd.arg(format!("--backup={mode}"))
+            .arg("a~")
+            .arg("a")
+            .fails()
+            .stderr_contains("might destroy source");
+
+        assert_eq!(at.read("a~"), "source content");
+    }
+}
+
+#[test]
+fn test_mv_backup_existing_mode_protects_source_even_with_numbered_present() {
+    // GNU's check always uses the simple suffix once the mode is not
+    // `numbered`, so an existing `a.~1~` does not make this safe.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("a");
+    at.write("a~", "source content");
+    at.write("a.~1~", "old numbered backup");
+
+    ucmd.arg("--backup=existing")
+        .arg("a~")
+        .arg("a")
+        .fails()
+        .stderr_contains("might destroy source");
+
+    assert_eq!(at.read("a~"), "source content");
+}
+
+#[test]
+fn test_mv_backup_numbered_allows_source_named_like_backup() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.touch("a");
+    at.write("a~", "source content");
+
+    ucmd.arg("--backup=numbered").arg("a~").arg("a").succeeds();
+    assert_eq!(at.read("a"), "source content");
+}


### PR DESCRIPTION
The "backing up X might destroy source" check only ran for `--backup=simple`, but `--backup=existing` falls back to a simple backup when no numbered backup is present and can destroy the source in exactly the same way: `mv --backup=existing a~ a` renamed `a` over `a~` and left both empty. GNU gates on `backup_type != numbered_backups`.

Numbered backups never reuse an existing name, and BackupMode::None makes no rename at all, so both stay excluded.

Verified against GNU master (9.11.130) for simple/existing/numbered/none, including the case where a numbered backup already exists: GNU still refuses there, because its check uses the simple suffix regardless.