### PR TITLE
cp: match GNU's backup guard instead of comparing inodes alone

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -28,6 +28,7 @@ use nix::sys::stat::{Mode, SFlag, dev_t, mknod as nix_mknod, mode_t};
 use thiserror::Error;
 
 use platform::copy_on_write;
+use uucore::backup_control::source_is_target_backup;
 use uucore::display::Quotable;
 use uucore::error::{UError, UResult, UUsageError, set_exit_code, strip_errno};
 use uucore::fs::{
@@ -2125,7 +2126,13 @@ fn handle_existing_dest(
     let mut is_dest_removed = false;
     let backup_path = backup_control::get_backup_path(options.backup, dest, &options.backup_suffix);
     if let Some(backup_path) = backup_path {
-        if paths_refer_to_same_file(source, &backup_path, true) {
+        // Only a source that the backup rename could actually land on is a
+        // problem. Comparing inodes alone also refuses a hard link that merely
+        // shares one, which GNU copies happily. Numbered backups never reuse an
+        // existing name, so they cannot destroy anything.
+        if options.backup != BackupMode::Numbered
+            && source_is_target_backup(source, dest, &options.backup_suffix, true)
+        {
             return Err(translate!("cp-error-backing-up-destroy-source", "dest" => dest.quote(), "source" => source.quote())
             .into());
         }

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1356,6 +1356,56 @@ fn test_cp_backup_simple_protect_source() {
 }
 
 #[test]
+fn test_cp_backup_simple_allows_hardlink_under_another_name() {
+    // `other` shares an inode with the backup path but is not named after it,
+    // so the backup rename cannot clobber it. GNU copies this happily.
+    let (at, mut ucmd) = at_and_ucmd!();
+    let backup = format!("{TEST_HELLO_WORLD_SOURCE}~");
+    at.write(&backup, "backup content");
+    at.hard_link(&backup, "other");
+
+    ucmd.arg("--backup=simple")
+        .arg("other")
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .succeeds()
+        .no_stderr();
+
+    assert_eq!(at.read(TEST_HELLO_WORLD_SOURCE), "backup content");
+}
+
+#[test]
+fn test_cp_backup_simple_protect_source_regardless_of_spelling() {
+    // The guard compares files, not the strings naming them.
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = format!("{TEST_HELLO_WORLD_SOURCE}~");
+    at.write(&source, "source content");
+
+    ucmd.arg("--backup=simple")
+        .arg(format!("./{source}"))
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .fails()
+        .stderr_contains("might destroy source");
+
+    assert_eq!(at.read(&source), "source content");
+}
+
+#[test]
+fn test_cp_backup_numbered_allows_source_named_like_backup() {
+    // A numbered backup never reuses an existing name, so nothing is at risk.
+    let (at, mut ucmd) = at_and_ucmd!();
+    let source = format!("{TEST_HELLO_WORLD_SOURCE}~");
+    at.write(&source, "source content");
+
+    ucmd.arg("--backup=numbered")
+        .arg(&source)
+        .arg(TEST_HELLO_WORLD_SOURCE)
+        .succeeds();
+
+    assert_eq!(at.read(&source), "source content");
+    assert_eq!(at.read(TEST_HELLO_WORLD_SOURCE), "source content");
+}
+
+#[test]
 fn test_cp_backup_never() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
The "backing up X might destroy source" check compared the source against the computed backup path by inode only. That refuses `cp --backup=simple other a` when `other` is a hard link to `a~`, even though the backup rename lands on the name `a~` and cannot touch `other`. GNU copies it.

GNU's `source_is_dst_backup` gates on the names first: the source's basename must be the target's basename plus the suffix. Only then does it compare the files. `uucore::backup_control::source_is_target_backup` already implements exactly this for mv, so reuse it here. Numbered backups never reuse an existing name and are excluded, as in GNU.

Verified against GNU master (9.11.130) over simple/existing/numbered/none and the hard-link, symlink, alternate-spelling and absent-backup cases.