### PR TITLE
install: refuse a backup that would destroy the source

### DIFF
--- a/src/uu/install/locales/en-US.ftl
+++ b/src/uu/install/locales/en-US.ftl
@@ -61,3 +61,4 @@ install-verbose-creating-directory = creating directory { $path }
 install-verbose-creating-directory-step = install: creating directory { $path }
 install-verbose-removed = removed { $path }
 install-verbose-backup = (backup: { $backup })
+install-error-backing-up-destroy-source = backing up { $dest } might destroy source;  { $source } not copied

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -20,7 +20,7 @@ use std::io::{Write, stdout};
 use std::path::{MAIN_SEPARATOR, Path, PathBuf};
 use std::process;
 use thiserror::Error;
-use uucore::backup_control::{self, BackupMode};
+use uucore::backup_control::{self, BackupMode, source_is_target_backup};
 use uucore::buf_copy::copy_fast;
 use uucore::display::Quotable;
 use uucore::entries::{grp2gid, usr2uid};
@@ -90,6 +90,9 @@ enum InstallError {
 
     #[error("{}", translate!("install-error-backup-failed", "from" => .0.quote(), "error" => strip_errno(.1)))]
     BackupFailed(PathBuf, #[source] std::io::Error),
+
+    #[error("{}", translate!("install-error-backing-up-destroy-source", "dest" => .0.quote(), "source" => .1.quote()))]
+    BackupWouldDestroySource(PathBuf, PathBuf),
 
     #[error("{}", translate!("install-error-install-failed", "from" => .0.quote(), "to" => .1.quote(), "error" => .2.clone()))]
     InstallFailed(PathBuf, PathBuf, String),
@@ -781,7 +784,7 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
                     return Ok(());
                 }
 
-                let backup_path = perform_backup(&target, b)?;
+                let backup_path = perform_backup(source, &target, b)?;
 
                 if let Err(e) = parent_fd.unlink_at(filename.as_os_str(), false)
                     && e.kind() != std::io::ErrorKind::NotFound
@@ -896,6 +899,8 @@ fn chown_optional_user_group(path: &Path, b: &Behavior) -> UResult<()> {
 ///
 /// # Parameters
 ///
+/// * `from` - The source file path, needed to refuse a backup that would
+///   destroy it.
 /// * `to` - The destination file path.
 /// * `b` - The behavior configuration.
 ///
@@ -903,7 +908,18 @@ fn chown_optional_user_group(path: &Path, b: &Behavior) -> UResult<()> {
 ///
 /// Returns an Option containing the backup path, or None if backup is not needed.
 ///
-fn perform_backup(to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
+fn perform_backup(from: &Path, to: &Path, b: &Behavior) -> UResult<Option<PathBuf>> {
+    // Renaming the destination over the source would leave nothing to install
+    // from, so refuse instead. Numbered backups never reuse an existing name,
+    // and with no backup at all there is no rename to worry about.
+    if !matches!(b.backup_mode, BackupMode::None | BackupMode::Numbered)
+        && source_is_target_backup(from, to, &b.suffix, true)
+    {
+        return Err(
+            InstallError::BackupWouldDestroySource(to.to_path_buf(), from.to_path_buf()).into(),
+        );
+    }
+
     if to.exists() {
         if b.verbose {
             writeln!(
@@ -1174,7 +1190,7 @@ fn copy(from: &Path, to: &Path, b: &Behavior) -> UResult<()> {
         return Ok(());
     }
     // Declare the path here as we may need it for the verbose output below.
-    let backup_path = perform_backup(to, b)?;
+    let backup_path = perform_backup(from, to, b)?;
 
     copy_file(from, to)?;
 

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2980,3 +2980,97 @@ fn test_install_backup_nil_same_file() {
         assert_eq!(at.read(file), "content");
     }
 }
+
+#[test]
+fn test_install_backup_refuses_when_source_is_the_backup() {
+    // Installing `a~` over `a` renames `a` to `a~`, which would clobber the
+    // source before it is read. GNU refuses; so must we.
+    for mode in ["simple", "existing"] {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        at.touch("a");
+        at.write("a~", "source content");
+
+        scene
+            .ucmd()
+            .arg(format!("--backup={mode}"))
+            .arg("a~")
+            .arg("a")
+            .fails()
+            .stderr_is("install: backing up 'a' might destroy source;  'a~' not copied\n");
+
+        // The source must be intact.
+        assert_eq!(at.read("a~"), "source content");
+    }
+}
+
+#[test]
+fn test_install_backup_numbered_allows_source_named_like_backup() {
+    // A numbered backup never reuses an existing name, so it cannot destroy
+    // the source and must not be refused.
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.write("a~", "source content");
+
+    scene
+        .ucmd()
+        .arg("--backup=numbered")
+        .arg("a~")
+        .arg("a")
+        .succeeds();
+    assert_eq!(at.read("a~"), "source content");
+    assert_eq!(at.read("a"), "source content");
+}
+
+#[test]
+fn test_install_backup_allows_hardlink_under_another_name() {
+    // `other` shares an inode with `a~` but its name is not `a` + suffix, so
+    // the backup rename cannot clobber it. GNU allows this.
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.write("a~", "source content");
+    at.hard_link("a~", "other");
+
+    scene
+        .ucmd()
+        .arg("--backup=simple")
+        .arg("other")
+        .arg("a")
+        .succeeds();
+    assert_eq!(at.read("a"), "source content");
+}
+
+#[test]
+fn test_install_backup_refuses_regardless_of_spelling() {
+    // The guard compares files, not the strings naming them.
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.write("a~", "source content");
+
+    scene
+        .ucmd()
+        .arg("--backup=simple")
+        .arg("./a~")
+        .arg("a")
+        .fails()
+        .stderr_contains("might destroy source");
+    assert_eq!(at.read("a~"), "source content");
+}
+
+#[test]
+fn test_install_backup_custom_suffix_refuses() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("a");
+    at.write("a.bak", "source content");
+
+    scene
+        .ucmd()
+        .args(&["-b", "--suffix=.bak", "a.bak", "a"])
+        .fails()
+        .stderr_contains("might destroy source");
+    assert_eq!(at.read("a.bak"), "source content");
+}


### PR DESCRIPTION
`install --backup=simple a~ a` renames `a` over `a~` before reading the source, so both files end up empty and the source content is gone. GNU refuses this (`source_is_dst_backup` in copy.c); install had no guard at all, while cp and mv both did.

Reuse `uucore::backup_control::source_is_target_backup`, which already mirrors GNU's two-part test: the source's basename must be the target's basename plus the suffix, and the source must actually be the file the backup rename would land on. Numbered backups never reuse an existing name, and BackupMode::None makes no rename, so neither is gated.

Verified against GNU master (9.11.130) across simple/existing/numbered/ none and a custom --suffix: messages, exit codes and resulting file contents are byte-identical modulo the binary name.