### PR TITLE
ln: include destination in symbolic link failure message

### DIFF
--- a/src/uu/ln/locales/en-US.ftl
+++ b/src/uu/ln/locales/en-US.ftl
@@ -34,5 +34,6 @@ ln-prompt-replace = replace {$file}?
 ln-cannot-backup = cannot backup {$file}
 ln-failed-to-access = failed to access {$file}
 ln-failed-to-create-hard-link = failed to create hard link {$source} => {$dest}
+ln-failed-to-create-symbolic-link = failed to create symbolic link {$dest}
 ln-failed-to-create-hard-link-dir = {$source}: hard link not allowed for directory
 ln-backup = backup: {$backup}

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -452,7 +452,15 @@ fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     }
 
     let res = if settings.symbolic {
-        symlink(&source, dst).map_err(Into::into)
+        symlink(&source, dst).map_err(|e| {
+            LnError::IoContext(
+                UIoError::from(e),
+                translate!(
+                    "ln-failed-to-create-symbolic-link",
+                    "dest" => dst.quote()
+                ),
+            )
+        })
     } else {
         let p = if settings.logical && source.is_symlink() {
             fs::canonicalize(&source).map_err(|e| {

--- a/tests/by-util/test_ln.rs
+++ b/tests/by-util/test_ln.rs
@@ -583,6 +583,19 @@ fn test_symlink_missing_destination() {
 }
 
 #[test]
+fn test_symlink_error_includes_destination() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_symlink_error_includes_destination";
+    let link = "no_such_dir/test_symlink_error_includes_destination";
+
+    at.touch(file);
+
+    ucmd.args(&["-s", file, link]).fails().stderr_is(format!(
+        "ln: failed to create symbolic link '{link}': No such file or directory\n"
+    ));
+}
+
+#[test]
 fn test_symlink_relative() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_symlink_relative_a";


### PR DESCRIPTION
`ln -s` failures (permission denied, missing directory, etc.) printed only the raw error, e.g. `ln: Permission denied`, leaving no indication of which path failed.

Root cause: the symlink call was mapped with `Into::into`, producing a bare `LnError::Io` with no context, unlike the hard-link path which already attaches source and destination via `IoContext`.

Fix: map the symlink error to `IoContext` with a new `ln-failed-to-create-symbolic-link` message key, matching GNU's `failed to create symbolic link '<dest>': <error>` format.

Only `src/uu/ln/src/ln.rs`, `src/uu/ln/locales/en-US.ftl`, and `tests/by-util/test_ln.rs` are changed.

Closes #13667

Verification

- `ln -s a /dev/qwe` -> `ln: failed to create symbolic link '/dev/qwe': Permission denied` (matches GNU)
- `ln -s a /tmp/nonexistent_dir/x` -> `ln: failed to create symbolic link '/tmp/nonexistent_dir/x': No such file or directory`
- Successful symlink creation unchanged
- New regression test `test_symlink_error_includes_destination`
- `cargo test --test tests test_ln`: 55 passed