### PR TITLE
mkdir, mkfifo: label at creation instead of relabelling after

### DIFF
--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -307,6 +307,18 @@ fn create_single_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<(
     #[cfg(not(unix))]
     let (mkdir_mode, shaped_umask) = (config.mode.unwrap_or(DEFAULT_PERM), 0u32);
 
+    // Label the directory at creation, as GNU does; relabelling after leaves a window.
+    #[cfg(all(feature = "selinux", any(target_os = "android", target_os = "linux")))]
+    let _selinux_guard = if config.set_security_context && uucore::selinux::is_selinux_enabled() {
+        let mode = uucore::libc::S_IFDIR | mkdir_mode as uucore::libc::mode_t;
+        match uucore::selinux::FsCreateContext::new(path, Some(mode), config.context) {
+            Ok(guard) => Some(guard),
+            Err(e) => return Err(USimpleError::new(1, e.to_string())),
+        }
+    } else {
+        None
+    };
+
     match create_dir_with_mode(path, mkdir_mode, shaped_umask) {
         Ok(()) => {
             if config.verbose {
@@ -315,16 +327,6 @@ fn create_single_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<(
                     "{}",
                     translate!("mkdir-verbose-created-directory", "util_name" => "mkdir", "path" => path.quote())
                 )?;
-            }
-
-            // Apply SELinux context if requested
-            #[cfg(all(feature = "selinux", any(target_os = "android", target_os = "linux")))]
-            if config.set_security_context
-                && uucore::selinux::is_selinux_enabled()
-                && let Err(e) = uucore::selinux::set_selinux_security_context(path, config.context)
-            {
-                let _ = std::fs::remove_dir(path);
-                return Err(USimpleError::new(1, e.to_string()));
             }
 
             // Apply SMACK context if requested

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -43,6 +43,26 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .collect();
 
     for f in fifos {
+        // Label the FIFO at creation, as GNU does; relabelling after leaves a window.
+        #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
+        let _selinux_guard = {
+            let set_security_context = matches.get_flag(options::SECURITY_CONTEXT);
+            let context = matches.get_one::<String>(options::CONTEXT);
+            if set_security_context || context.is_some() {
+                let mode = uucore::libc::S_IFIFO | mode as uucore::libc::mode_t;
+                match uucore::selinux::FsCreateContext::new(
+                    std::path::Path::new(&f),
+                    Some(mode),
+                    context,
+                ) {
+                    Ok(guard) => Some(guard),
+                    Err(e) => return Err(USimpleError::new(1, e.to_string())),
+                }
+            } else {
+                None
+            }
+        };
+
         // Clear umask around mkfifo so the kernel applies the exact
         // requested mode atomically. Skipping the path-based chmod
         // that used to follow this call closes the TOCTOU window an
@@ -62,23 +82,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 ),
             ));
         } else {
-            // Apply SELinux context if requested
-            #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
-            {
-                let set_security_context = matches.get_flag(options::SECURITY_CONTEXT);
-                let context = matches.get_one::<String>(options::CONTEXT);
-
-                if set_security_context || context.is_some() {
-                    use std::path::Path;
-                    if let Err(e) =
-                        uucore::selinux::set_selinux_security_context(Path::new(&f), context)
-                    {
-                        let _ = std::fs::remove_file(f);
-                        return Err(USimpleError::new(1, e.to_string()));
-                    }
-                }
-            }
-
             // Apply SMACK context if requested
             #[cfg(all(feature = "smack", target_os = "linux"))]
             {


### PR DESCRIPTION
Same treatment as mknod: install the creation context first so the kernel applies the label as part of mkdir/mknod