### PR TITLE
fix(who): add missing rustix feature

### DIFF
--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -27,7 +27,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["termios"] }
 uucore = { workspace = true, features = ["utmpx"] }
 fluent = { workspace = true }
 


### PR DESCRIPTION
Rustix feature `termios` was missing in `Cargo.toml`:

```log
error[E043]: cannot find `termios` in `rustix`
   --> src/uu/who/src/platform/unix.rs:189:13
    |
189 |     rustix::termios::ttyname(std::io::stdin(), Vec::with_capacity(16))
    |             ^^^^^^^ could not find `termios` in `rustix`
    |
note: found an item that was configured out
   --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-1.1.4/src/lib.rs:301:9
    |
299 | #[cfg(feature = "termios")]
    |       ------------------- the item is gated behind the `termios` feature
300 | #[cfg_attr(docsrs, doc(cfg(feature = "termios")))]
301 | pub mod termios;
    |         ^^^^^^^

For more information about this error, try `rustc --explain E0433`.
```