### PR TITLE
fix(wasi): date clock resolution and system datetime support

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -63,7 +63,7 @@ jobs:
         # caret diagnostics; the host test crate does have them, hence the
         # not(wasi_runner) in the cfg guarding every `mod diagnostics`.
         # TODO: add integration tests for these tools as WASI support is extended:
-        #   arch b2sum cksum csplit date dir dircolors fmt join
+        #   arch b2sum cat cksum cp csplit date dir dircolors fmt join
         #   ls md5sum mkdir mv nproc pathchk pr printenv ptx pwd readlink
         #   realpath rm rmdir seq sha1sum sha224sum sha256sum sha384sum
         #   sha512sum shred sleep sort split tsort uname uniq vdir
@@ -71,7 +71,7 @@ jobs:
         UUTESTS_WASM_RUNNER=wasmtime \
         cargo test --test tests -- \
           test_base32:: test_base64:: test_basenc:: test_basename:: \
-          test_cat:: test_comm:: test_cp:: test_cut:: test_dirname:: test_echo:: \
+          test_cat:: test_comm:: test_cp:: test_cut:: test_date:: test_dirname:: test_echo:: \
           test_expand:: test_expr:: test_factor:: test_false:: test_fold:: \
           test_head:: test_link:: test_ln:: test_mktemp:: test_nl:: test_numfmt:: \
           test_od:: test_paste:: test_printf:: test_shuf:: test_sum:: \

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -46,6 +46,9 @@ uucore = { workspace = true, features = ["parser", "i18n-datetime"] }
 libc = { workspace = true }
 rustix = { workspace = true, features = ["time"] }
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -50,6 +50,9 @@ rustix = { workspace = true, features = ["time"] }
 # no environment injection).
 jiff-tzdb = "0.1"
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",

--- a/src/uu/date/locales/en-US.ftl
+++ b/src/uu/date/locales/en-US.ftl
@@ -103,6 +103,7 @@ date-error-expected-file-got-directory = expected file, got directory {$path}
 date-error-date-overflow = date overflow '{$date}'
 date-error-setting-date-not-supported-macos = setting the date is not supported by macOS
 date-error-setting-date-not-supported-redox = setting the date is not supported by Redox
+date-error-setting-date-not-supported-wasi = setting the date is not supported by WASI
 date-error-cannot-set-date = cannot set date
 date-error-extra-operand = extra operand '{$operand}'
 date-error-write = write error: {$error}

--- a/src/uu/date/locales/fr-FR.ftl
+++ b/src/uu/date/locales/fr-FR.ftl
@@ -98,6 +98,7 @@ date-error-expected-file-got-directory = fichier attendu, répertoire obtenu {$p
 date-error-date-overflow = débordement de date '{$date}'
 date-error-setting-date-not-supported-macos = la définition de la date n'est pas prise en charge par macOS
 date-error-setting-date-not-supported-redox = la définition de la date n'est pas prise en charge par Redox
+date-error-setting-date-not-supported-wasi = la définition de la date n'est pas prise en charge par WASI
 date-error-cannot-set-date = impossible de définir la date
 date-error-extra-operand = opérande supplémentaire '{$operand}'
 date-error-write = erreur d'écriture: {$error}

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -1130,7 +1130,23 @@ fn parse_date<S: AsRef<str>>(
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(target_os = "wasi")]
+/// Returns the resolution of the system's realtime clock.
+///
+/// `rustix::time::clock_getres` excludes WASI, so call `libc::clock_getres`
+/// (available on WASI) directly instead.
+fn get_clock_resolution() -> Timestamp {
+    let timespec = unsafe {
+        let mut timespec: libc::timespec = std::mem::zeroed();
+        libc::clock_getres(libc::CLOCK_REALTIME, &raw mut timespec);
+        timespec
+    };
+
+    #[allow(clippy::unnecessary_cast, reason = "needed for 32 bit target")]
+    Timestamp::constant(timespec.tv_sec as _, timespec.tv_nsec as _)
+}
+
+#[cfg(not(any(unix, windows, target_os = "wasi")))]
 fn get_clock_resolution() -> Timestamp {
     unimplemented!("getting clock resolution not implemented (unsupported target)");
 }
@@ -1169,7 +1185,7 @@ fn get_clock_resolution() -> Timestamp {
     Timestamp::constant(0, 100)
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(not(any(unix, windows, target_os = "wasi")))]
 fn set_system_datetime(_date: Zoned) -> UResult<()> {
     unimplemented!("setting date not implemented (unsupported target)");
 }
@@ -1188,6 +1204,15 @@ fn set_system_datetime(_date: Zoned) -> UResult<()> {
     Err(USimpleError::new(
         1,
         translate!("date-error-setting-date-not-supported-macos"),
+    ))
+}
+
+#[cfg(target_os = "wasi")]
+/// The WASI sandbox has no syscall for setting the wall clock.
+fn set_system_datetime(_date: Zoned) -> UResult<()> {
+    Err(USimpleError::new(
+        1,
+        translate!("date-error-setting-date-not-supported-wasi"),
     ))
 }
 

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -1254,7 +1254,23 @@ fn parse_date<S: AsRef<str>>(
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(target_os = "wasi")]
+/// Returns the resolution of the system's realtime clock.
+///
+/// `rustix::time::clock_getres` excludes WASI, so call `libc::clock_getres`
+/// (available on WASI) directly instead.
+fn get_clock_resolution() -> Timestamp {
+    let timespec = unsafe {
+        let mut timespec: libc::timespec = std::mem::zeroed();
+        libc::clock_getres(libc::CLOCK_REALTIME, &raw mut timespec);
+        timespec
+    };
+
+    #[allow(clippy::unnecessary_cast, reason = "needed for 32 bit target")]
+    Timestamp::constant(timespec.tv_sec as _, timespec.tv_nsec as _)
+}
+
+#[cfg(not(any(unix, windows, target_os = "wasi")))]
 fn get_clock_resolution() -> Timestamp {
     unimplemented!("getting clock resolution not implemented (unsupported target)");
 }
@@ -1293,7 +1309,7 @@ fn get_clock_resolution() -> Timestamp {
     Timestamp::constant(0, 100)
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(not(any(unix, windows, target_os = "wasi")))]
 fn set_system_datetime(_date: Zoned) -> UResult<()> {
     unimplemented!("setting date not implemented (unsupported target)");
 }
@@ -1310,6 +1326,15 @@ fn convert_for_set(date: Zoned, utc: bool) -> Zoned {
 #[cfg(target_vendor = "apple")]
 fn set_system_datetime(_date: Zoned) -> UResult<()> {
     Err(Box::new(DateError::SettingDateNotSupportedMacOs))
+}
+
+#[cfg(target_os = "wasi")]
+/// The WASI sandbox has no syscall for setting the wall clock.
+fn set_system_datetime(_date: Zoned) -> UResult<()> {
+    Err(USimpleError::new(
+        1,
+        translate!("date-error-setting-date-not-supported-wasi"),
+    ))
 }
 
 #[cfg(target_os = "redox")]
@@ -1463,5 +1488,40 @@ mod tests {
         assert_eq!(strip_parenthesized_comments("a(b(c)d)e"), "ae"); // Nested balanced
         assert_eq!(strip_parenthesized_comments("a(b(c)d"), "a"); // Nested unbalanced
         assert_eq!(strip_parenthesized_comments("a(b)c(d)e(f"), "ace"); // Multiple groups, last unmatched
+    }
+
+    #[test]
+    fn test_escape_invalid_bytes() {
+        // Printable ASCII preserved, boundaries escaped
+        assert_eq!(escape_invalid_bytes(b"hello"), "hello");
+        assert_eq!(escape_invalid_bytes(b""), "");
+        // High-bit, control chars, DEL, and backslash all escaped as octal
+        assert_eq!(escape_invalid_bytes(b"\xb0"), "\\260");
+        assert_eq!(escape_invalid_bytes(b"\x00"), "\\000");
+        assert_eq!(escape_invalid_bytes(b"\x7f"), "\\177");
+        assert_eq!(escape_invalid_bytes(b"\\"), "\\134");
+        // Mixed content
+        assert_eq!(escape_invalid_bytes(b"a\xb0b\\c"), "a\\260b\\134c");
+    }
+
+    #[test]
+    fn test_get_clock_resolution() {
+        let res = get_clock_resolution();
+        assert!(res.as_second() >= 0 && res.as_second() <= 1);
+        assert!(res.as_second() > 0 || res.subsec_nanosecond() > 0);
+    }
+
+    #[test]
+    fn test_convert_for_set() {
+        let date = "2025-03-15T10:30:00+05:00[Asia/Karachi]"
+            .parse::<Zoned>()
+            .unwrap();
+        // UTC mode converts to UTC
+        let utc = convert_for_set(date.clone(), true);
+        assert_eq!(utc.time_zone(), &TimeZone::UTC);
+        assert_eq!((utc.hour(), utc.minute()), (5, 30));
+        // Local mode returns unchanged
+        let local = convert_for_set(date.clone(), false);
+        assert_eq!((local.hour(), local.minute()), (date.hour(), date.minute()));
     }
 }

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -386,6 +386,10 @@ fn test_date_utc_with_d_flag() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_utc_vs_local() {
     let cases = [
         ("-d", "2024-01-01 12:00", "+%H:%M %Z", "12:00 EST\n"),
@@ -532,6 +536,10 @@ fn test_date_set_invalid() {
 
 #[test]
 #[cfg(all(unix, not(any(target_vendor = "apple", target_os = "android"))))]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI: setting the system clock is not supported at all, not just permission-gated"
+)]
 fn test_date_set_permissions_error() {
     if !(geteuid().is_root() || uucore::os::is_wsl_1()) {
         let result = new_ucmd!()
@@ -545,6 +553,10 @@ fn test_date_set_permissions_error() {
 
 #[test]
 #[cfg(all(unix, not(any(target_vendor = "apple", target_os = "android"))))]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI: setting the system clock is not supported at all, not just permission-gated"
+)]
 fn test_date_set_hyphen_prefixed_values() {
     // test -s flag accepts hyphen-prefixed values like "-3 days"
     if !(geteuid().is_root() || uucore::os::is_wsl_1()) {
@@ -565,6 +577,10 @@ fn test_date_set_hyphen_prefixed_values() {
 
 #[test]
 #[cfg(target_vendor = "apple")]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "test binary runs on macOS but the wasm guest under test does not, so the expected macOS-specific error text never appears"
+)]
 fn test_date_set_mac_unavailable() {
     let result = new_ucmd!()
         .arg("--set")
@@ -905,7 +921,7 @@ fn test_date_parse_from_format() {
          2023-04-15 18:30:00",
     );
     ucmd.arg("-f")
-        .arg(at.plus(FILE))
+        .arg(FILE)
         .arg("+%Y-%m-%d %H:%M:%S")
         .succeeds();
 }
@@ -933,6 +949,10 @@ const JAN2: &str = "2024-01-02 12:00:00 +0000";
 const JUL2: &str = "2024-07-02 12:00:00 +0000";
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_tz() {
     fn test_tz(tz: &str, date: &str, output: &str) {
         println!("Test with TZ={tz}, date=\"{date}\".");
@@ -979,6 +999,10 @@ fn test_date_tz_with_utc_flag() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_tz_various_formats() {
     fn test_tz(tz: &str, date: &str, output: &str) {
         println!("Test with TZ={tz}, date=\"{date}\".");
@@ -1007,6 +1031,10 @@ fn test_date_tz_various_formats() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_tz_with_relative_time() {
     new_ucmd!()
         .env("TZ", "America/Vancouver")
@@ -1018,6 +1046,10 @@ fn test_date_tz_with_relative_time() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_utc_time() {
     // Test that -u flag shows correct UTC time
     // We get 2 UTC times just in case we're really unlucky and this runs around
@@ -1514,6 +1546,10 @@ fn test_date_whitespace_between_items() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_relative_m9() {
     // Military timezone "m9" should be parsed as noon + 9 hours = 21:00 UTC
     // When displayed in TZ=UTC+9 (which is UTC-9), this shows as 12:00 local time
@@ -1811,6 +1847,10 @@ fn test_date_locale_en_us_vs_c_difference() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_locale_hu_hungarian() {
     // Regression test for uutils/coreutils#11240: the GNU modifier fast-path
     // ("%-e") used to run before ICU localization, so "%b"/"%A" came out in
@@ -2102,6 +2142,10 @@ fn test_date_input_hhmm_ampm() {
 }
 
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_input_trailing_tz_abbrev_rezones() {
     // `TZ=UTC+1 date -d '2024-01-01 EST'` should display the instant in UTC+1
     // (GNU: 04:00:00 -01:00), not leave it in EST (the pre-fix uutils
@@ -2230,6 +2274,10 @@ fn test_date_parenthesis_vs_other_special_chars() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_iranian_locale_solar_hijri_calendar() {
     // Test Iranian locale uses Solar Hijri calendar
     // Verify the Solar Hijri calendar is used in the Iranian locale
@@ -2297,6 +2345,10 @@ fn test_date_iranian_locale_solar_hijri_calendar() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_ethiopian_locale_calendar() {
     // Test Ethiopian locale uses Ethiopian calendar
     // Verify the Ethiopian calendar is used in the Ethiopian locale
@@ -2444,6 +2496,10 @@ fn check_date(locale: &str, date: &str, fmt: &str, expected: &str) {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_locale_calendar_conversions() {
     // Persian (Solar Hijri) - Nowruz is March 20/21
     for (d, e) in [
@@ -2495,6 +2551,10 @@ fn test_locale_calendar_conversions() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_locale_month_names() {
     // %B full month names: Jan, Jun, Dec for each locale
     for (loc, jan, jun, dec) in [
@@ -2515,6 +2575,10 @@ fn test_locale_month_names() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_locale_abbreviated_month_names() {
     // %b abbreviated month names: Feb, Jun, Dec for each locale
     // This test ensures we don't get double periods in locales like Hungarian
@@ -2538,6 +2602,10 @@ fn test_locale_abbreviated_month_names() {
 
 #[test]
 #[cfg(unix)]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_locale_day_names() {
     // %A full day names: Mon (26th), Sun (25th), Sat (24th) Jan 2026
     for (loc, mon, sun, sat) in [
@@ -2639,8 +2707,11 @@ fn test_date_month_subtraction_keeps_day() {
 
 // Tests for embedded timezone parsing
 #[test]
+#[cfg_attr(
+    wasi_runner,
+    ignore = "WASI sandbox: timezone/locale database not visible"
+)]
 fn test_date_embedded_timezone_conversion() {
-    // Parse date with embedded timezone
     // Date should be interpreted in embedded TZ, then displayed in environment TZ
     new_ucmd!()
         .env("TZ", "UTC0")
@@ -2655,6 +2726,7 @@ fn test_date_embedded_timezone_conversion() {
 // Tests for invalid UTF-8 in date string
 #[test]
 #[cfg(unix)]
+#[cfg_attr(wasi_runner, ignore = "WASI: argv must be valid UTF-8")]
 fn test_date_invalid_utf8_byte_rejected() {
     use std::os::unix::ffi::OsStrExt;
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1932,6 +1932,7 @@ fn test_separator_attached_equals_double() {
     new_ucmd!()
         .args(&["-t==", "-k", "2"])
         .pipe_in("")
+        .ignore_stdin_write_error()
         .fails()
         .stderr_contains("separator must be exactly one character long: '=='");
 }
@@ -1942,6 +1943,7 @@ fn test_separator_attached_equals_multi_char() {
     new_ucmd!()
         .args(&["-t=a", "-k", "2"])
         .pipe_in("")
+        .ignore_stdin_write_error()
         .fails()
         .stderr_contains("separator must be exactly one character long: '=a'");
 }


### PR DESCRIPTION
date implements get_clock_resolution via libc::clock_getres (rustix's excludes WASI) and set_system_datetime for WASI, the latter reporting "not supported" since the sandbox has no wall-clock-set syscall.