### PR TITLE
tail(test): Attempt to fix flaky tail pipe test by increasing byte count

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -5019,10 +5019,10 @@ fn test_when_piped_input_then_no_broken_pipe() {
 
 #[test]
 #[cfg(unix)]
-fn test_when_output_closed_then_no_broken_pie() {
+fn test_when_output_closed_then_no_broken_pipe() {
     let mut cmd = new_ucmd!();
     let mut child = cmd
-        .args(&["-c", "100000", "/dev/zero"])
+        .args(&["-c", "10000000", "/dev/zero"])
         .set_stdout(Stdio::piped())
         .run_no_wait();
     // Dropping the stdout should not lead to an error.


### PR DESCRIPTION
The test `test_when_output_closed_then_no_broken_pie` sometimes passes and sometimes fails because the pipe buffer size can hold the entire output before the parent closes stdout. That leads to a deferred flush error instead of an immediate write error, and `fails_silently()` sees output on stderr.

By increasing the argument from `100000` to `10000000` (10 MB), the pipe buffer will always fill up, forcing the error to occur during an active `write()` call where it can be silently suppressed.

- Fixes #13569
- Failure log: https://github.com/uutils/coreutils/actions/runs/30171537944/job/89713408493?pr=13568