### PR TITLE
date: strip the O strftime modifier in the C locale

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -775,13 +775,13 @@ fn substitute_epoch_seconds(fmt: &str, date: &Zoned) -> String {
 ///
 /// In the C locale `%O` requests alternative numeric symbols that do not
 /// exist, so GNU `date` treats it as a no-op: `%Om` renders exactly like
-/// `%m`. jiff does not know the modifier and would emit it literally.
-/// Remove the `O` strftime modifier from `fmt`.
-///
-/// In the C locale `%O` requests alternative numeric symbols that do not
-/// exist, so GNU `date` treats it as a no-op: `%Om` renders exactly like
 /// `%m` (issue #11656). jiff does not know the modifier and would emit it
 /// literally, so strip it before jiff sees the format string.
+///
+/// The `O` is only dropped when it actually modifies something, that is,
+/// when a specifier letter follows it. A dangling `%O` (at the end of the
+/// string, or followed by a non-letter) stays literal, as does any `O`
+/// that merely follows the `%%` escape.
 fn strip_o_modifier(fmt: &str) -> String {
     if !fmt.contains("%O") {
         return fmt.to_string();
@@ -795,9 +795,12 @@ fn strip_o_modifier(fmt: &str) -> String {
             continue;
         }
         match chars.peek() {
-            // Drop the modifier but keep the specifier: `%Om` -> `%m`.
             Some('O') => {
-                chars.next();
+                let mut lookahead = chars.clone();
+                lookahead.next();
+                if lookahead.peek().is_some_and(char::is_ascii_alphabetic) {
+                    chars.next();
+                }
                 out.push('%');
             }
             // Keep `%%` intact: an `O` after a literal percent is plain text.

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -771,6 +771,46 @@ fn substitute_epoch_seconds(fmt: &str, date: &Zoned) -> String {
     out
 }
 
+/// Remove the `O` strftime modifier from `fmt`.
+///
+/// In the C locale `%O` requests alternative numeric symbols that do not
+/// exist, so GNU `date` treats it as a no-op: `%Om` renders exactly like
+/// `%m`. jiff does not know the modifier and would emit it literally.
+/// Remove the `O` strftime modifier from `fmt`.
+///
+/// In the C locale `%O` requests alternative numeric symbols that do not
+/// exist, so GNU `date` treats it as a no-op: `%Om` renders exactly like
+/// `%m` (issue #11656). jiff does not know the modifier and would emit it
+/// literally, so strip it before jiff sees the format string.
+fn strip_o_modifier(fmt: &str) -> String {
+    if !fmt.contains("%O") {
+        return fmt.to_string();
+    }
+
+    let mut out = String::with_capacity(fmt.len());
+    let mut chars = fmt.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            // Drop the modifier but keep the specifier: `%Om` -> `%m`.
+            Some('O') => {
+                chars.next();
+                out.push('%');
+            }
+            // Keep `%%` intact: an `O` after a literal percent is plain text.
+            Some('%') => {
+                chars.next();
+                out.push_str("%%");
+            }
+            _ => out.push('%'),
+        }
+    }
+    out
+}
+
 fn format_extended_default(
     date: &ExtendedDateTime,
     format_string: &str,
@@ -865,7 +905,7 @@ fn format_date_with_locale_aware_months(
     // negative infinity (e.g. `@-1.5` → `-2`, not `-1`). Every other field jiff
     // produces already agrees with GNU, so only `%s` needs correcting; rewrite it
     // to the floored epoch second before jiff sees the format string.
-    let fmt_owned = substitute_epoch_seconds(fmt, date);
+    let fmt_owned = strip_o_modifier(&substitute_epoch_seconds(fmt, date));
     let fmt = fmt_owned.as_str();
 
     // Check if format string has GNU modifiers (width/flags) and format if present

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2066,7 +2066,6 @@ fn test_date_strftime_flag_on_composite() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11656 — GNU date strips the `O` strftime modifier in C locale (e.g. `%Om` -> `%m`); uutils leaks it as literal `%om`."]
 fn test_date_strftime_o_modifier() {
     // In C locale the `O` modifier is a no-op (alternative numeric symbols).
     // GNU renders `%Om` as `06` for June; uutils renders it as the literal `%Om`.


### PR DESCRIPTION
Fixes #11656

In the C locale the `O` strftime modifier requests alternative numeric
symbols that do not exist, so GNU `date` treats it as a no-op: `%Om`
renders exactly like `%m`. jiff does not know the modifier and emitted it
literally.

Strip the modifier from the format string before jiff sees it, mirroring
the existing `substitute_epoch_seconds` pass. `%%` is preserved so that an
`O` following a literal percent stays plain text.

Before:

```
    $ LC_ALL=C TZ=UTC date -d 2024-06-15 +%Om-%Oy-%Ol
    %Om-%Oy-%Ol
```
After (matches GNU):

```
    $ LC_ALL=C TZ=UTC date -d 2024-06-15 +%Om-%Oy-%Ol
    06-24-12
```

The test for this behaviour already existed in `tests/by-util/test_date.rs`
marked `#[ignore]`; this PR removes the ignore.