### PR TITLE
tests(tail): fix race in untailable-symlink test

### DIFF
--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1631,9 +1631,28 @@ fn test_follow_name_replaced_by_symlink_is_untailable() {
         .run_no_wait();
     p.make_assertion_with_delay(500).is_alive();
 
+    // Wait until tail's *initial* read of "watched" has actually completed
+    // (i.e. the pre-existing content has been printed) before swapping it
+    // for a symlink. Otherwise, under scheduler contention, tail's initial
+    // open (which legitimately follows symlinks, like any other file open)
+    // could race with the swap and open the symlink's target on its very
+    // first read -- before the untailable-symlink guard (which only applies
+    // to the follow loop) is even active. That would be a test timing bug,
+    // not the vulnerability this test is meant to catch.
+    for _ in 0..50 {
+        if p.stdout_all().contains("visible") {
+            break;
+        }
+        p.delay(20);
+    }
+
     // Swap the watched file for a symlink pointing at a secret file.
-    at.remove("watched");
-    at.symlink_file("secret", "watched");
+    // Create the symlink under a temporary name and rename it into place
+    // atomically, so the poller never observes an intermediate state where
+    // "watched" is missing (which would race with the poll interval and be
+    // reported as "has become inaccessible" instead).
+    at.symlink_file("secret", "watched.tmp");
+    at.rename("watched.tmp", "watched");
     p.delay(1000);
 
     p.kill()


### PR DESCRIPTION
Fixes intermittent CI failures in test_tail::test_follow_name_replaced_by_symlink_is_untailable, e.g. this run (https://github.com/uutils/coreutils/actions/runs/30700365364/job/91373194296?pr=13688), which failed with:

> tail: 'watched' has become inaccessible: No such file or directory instead of the expected has been replaced with an untailable symbolic link.

### Root cause

The test swapped the watched file for a symlink via remove() followed by symlink_file() — two separate syscalls.
Under polling (--use-polling, 0.1s interval), the poller could observe the transient "file missing" state in between,
reporting "has become inaccessible" instead of the intended "untailable symlink" message. The test also only checked the process was alive 500ms after spawn, without confirming tail's initial read had completed — under scheduler contention the symlink swap could happen before tail's first read of the file, which legitimately follows symlinks (no different from any other file open) since the untailable-symlink guard only applies to the follow loop, not the initial read.

### Fix

- Wait for tail's initial content to actually appear in stdout before performing the swap.
- Perform the swap as an atomic rename() over a freshly created symlink, so the intermediate missing-file state is never observable to the poller.