### PR TITLE
head/tail: parse zero byte counts with size suffix as 0 bytes

### DIFF
--- a/src/uucore/src/lib/features/parser/parse_signed_num.rs
+++ b/src/uucore/src/lib/features/parser/parse_signed_num.rs
@@ -84,14 +84,17 @@ pub fn parse_signed_num_max(src: &str) -> Result<SignedNum, ParseSizeError> {
 
     // Remove leading zeros so size is interpreted as decimal, not octal
     let trimmed = size_string.trim_start_matches('0');
+    let had_leading_zeros = trimmed.len() != size_string.len();
     let value = if trimmed.is_empty() {
         // All zeros (e.g., "000" or "0")
         0
-    } else if !trimmed.chars().any(|c| c.is_ascii_digit()) {
+    } else if had_leading_zeros && !trimmed.chars().any(|c| c.is_ascii_digit()) {
         // Only a size suffix remains after stripping leading zeros
         // (e.g., "0K"). Parse it as 1 unit to validate the suffix, but
         // the value is 0: a zero count times any unit is zero bytes.
         // Otherwise "0K" would parse as 1KiB (bare suffix means 1).
+        // A genuinely bare suffix with no digits at all (e.g. "kiB")
+        // still parses as 1 of that unit.
         parse_size_u64_max(trimmed)?;
         0
     } else {
@@ -229,6 +232,16 @@ mod tests {
 
         let result = parse_signed_num_max("0b").unwrap();
         assert_eq!(result.value, 0);
+    }
+
+    #[test]
+    fn test_bare_suffix_still_parses_as_one() {
+        // a bare suffix with no digits is 1 of that unit, not 0
+        let result = parse_signed_num_max("kiB").unwrap();
+        assert_eq!(result.value, 1024);
+
+        let result = parse_signed_num_max("K").unwrap();
+        assert_eq!(result.value, 1024);
     }
 
     #[test]

--- a/src/uucore/src/lib/features/parser/parse_signed_num.rs
+++ b/src/uucore/src/lib/features/parser/parse_signed_num.rs
@@ -87,6 +87,13 @@ pub fn parse_signed_num_max(src: &str) -> Result<SignedNum, ParseSizeError> {
     let value = if trimmed.is_empty() {
         // All zeros (e.g., "000" or "0")
         0
+    } else if !trimmed.chars().any(|c| c.is_ascii_digit()) {
+        // Only a size suffix remains after stripping leading zeros
+        // (e.g., "0K"). Parse it as 1 unit to validate the suffix, but
+        // the value is 0: a zero count times any unit is zero bytes.
+        // Otherwise "0K" would parse as 1KiB (bare suffix means 1).
+        parse_size_u64_max(trimmed)?;
+        0
     } else {
         parse_size_u64_max(trimmed)?
     };
@@ -199,6 +206,28 @@ mod tests {
         assert!(result.has_plus());
 
         let result = parse_signed_num_max("000").unwrap();
+        assert_eq!(result.value, 0);
+    }
+
+    #[test]
+    fn test_zero_with_suffix() {
+        // "0K" must be 0 bytes, not 1KiB (bare suffix parses as 1)
+        let result = parse_signed_num_max("0K").unwrap();
+        assert_eq!(result.value, 0);
+        assert!(result.is_zero());
+
+        let result = parse_signed_num_max("+0K").unwrap();
+        assert_eq!(result.value, 0);
+        assert!(result.has_plus());
+
+        let result = parse_signed_num_max("-0M").unwrap();
+        assert_eq!(result.value, 0);
+        assert!(result.has_minus());
+
+        let result = parse_signed_num_max("00K").unwrap();
+        assert_eq!(result.value, 0);
+
+        let result = parse_signed_num_max("0b").unwrap();
         assert_eq!(result.value, 0);
     }
 

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -222,6 +222,26 @@ fn test_negative_zero_bytes() {
         .succeeds()
         .stdout_is("qwerty");
 }
+
+#[test]
+fn test_zero_bytes_with_suffix() {
+    // "0K" must be 0 bytes, not 1KiB (bare suffix parses as 1)
+    new_ucmd!()
+        .args(&["--bytes=0K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .no_output();
+    new_ucmd!()
+        .args(&["--bytes=00K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .no_output();
+    new_ucmd!()
+        .args(&["--bytes=+0K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .no_output();
+}
 #[test]
 fn test_no_such_file_or_directory() {
     new_ucmd!()

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -204,6 +204,27 @@ fn test_nc_0_wo_follow() {
 }
 
 #[test]
+fn test_zero_bytes_with_suffix() {
+    // "0K" must be 0 bytes, not 1KiB (bare suffix parses as 1)
+    let ts = TestScenario::new(util_name!());
+    ts.ucmd()
+        .args(&["-c0K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .no_output();
+    ts.ucmd()
+        .args(&["-c00K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .no_output();
+    ts.ucmd()
+        .args(&["-c+0K"])
+        .pipe_in("qwerty")
+        .succeeds()
+        .stdout_is("qwerty");
+}
+
+#[test]
 #[cfg(all(unix, not(target_os = "freebsd")))]
 fn test_nc_0_wo_follow2() {
     use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
**head/tail: parse zero byte counts with size suffix as 0 bytes, not 1KiB**

`head --bytes=0K`, `tail -c 0K` and similar inputs (`00K`, `+0K`, `0M`) print the whole input instead of nothing. GNU coreutils prints nothing for all of these.

Closes #13703

## Root cause

`parse_signed_num_max` strips leading zeros before the size suffix is interpreted, so `0K` becomes the bare suffix `K`. A bare suffix means "1 of that unit" in `parse_size` (empty numeric part parses as 1), so `0K` parsed as 1KiB instead of 0 bytes.

## Fix

When the trimmed string contains no digits (only a suffix remains after stripping leading zeros), parse the suffix once to validate it, then return 0: a zero count times any unit is zero bytes. Invalid bare suffixes still error (e.g. `head -c 0B` errors, matching GNU, because `B` is not valid for head's parser).

Affects only `head -c`/`--bytes` and `tail -c`/`--bytes` (the only users of this parser).

## Verification

- `cargo test -p uucore --lib`: 94 passed (includes 5 new unit tests in `parse_signed_num`)
- `cargo test --features "head tail" test_zero_bytes_with_suffix`: 2 new integration tests passed
- Full suites, no regressions: `test_head::` 63 passed, `test_tail::` 154 passed (12 ignored)
- Behavior cross-checked against GNU coreutils: `head -c 0K`, `head -c 00K`, `head -c +0K`, `tail -c 0K`, `tail -c 00K` print nothing; `tail -c +0K` prints everything; `head -c 0B` errors
