### PR TITLE
cargo: move lints section after dependencies and features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -747,6 +747,9 @@ rustix.workspace = true
 [build-dependencies]
 phf_codegen.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "coreutils"
 path = "src/bin/coreutils.rs"
@@ -773,6 +776,3 @@ strip = true
 inherits = "release"
 panic = "unwind"
 debug = true
-
-[lints]
-workspace = true

--- a/src/uu/arch/Cargo.toml
+++ b/src/uu/arch/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/arch.rs"
 test = false
@@ -24,6 +21,9 @@ platform-info = { workspace = true }
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "arch"

--- a/src/uu/b2sum/Cargo.toml
+++ b/src/uu/b2sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/b2sum.rs"
 test = false
@@ -32,6 +29,9 @@ fluent = { workspace = true }
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "b2sum"

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/base32.rs"
 doctest = false
@@ -23,6 +20,9 @@ clap = { workspace = true }
 rustix = { workspace = true }
 uucore = { workspace = true, features = ["encoding"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "base32"

--- a/src/uu/base64/Cargo.toml
+++ b/src/uu/base64/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/base64.rs"
 test = false
@@ -29,6 +26,9 @@ fluent = { workspace = true }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "base64"

--- a/src/uu/basename/Cargo.toml
+++ b/src/uu/basename/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/basename.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "basename"

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/basenc.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["encoding"] }
 uu_base32 = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "basenc"

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/cat.rs"
 doctest = false
@@ -37,6 +34,9 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 rustix = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "cat"

--- a/src/uu/chcon/Cargo.toml
+++ b/src/uu/chcon/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/chcon.rs"
 test = false
@@ -29,6 +26,9 @@ libc = { workspace = true }
 fts-sys = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "chcon"

--- a/src/uu/checksum_common/Cargo.toml
+++ b/src/uu/checksum_common/Cargo.toml
@@ -10,9 +10,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/lib.rs"
 test = false
@@ -26,6 +23,9 @@ uucore = { workspace = true, features = [
   "hardware",
 ] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 # [[bench]]
 # name = "b2sum_bench"

--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/chgrp.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "chgrp"

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/chmod.rs"
 doctest = false
@@ -26,6 +23,9 @@ fluent = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 uucore = { workspace = true, features = ["safe-traversal"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "chmod"

--- a/src/uu/chown/Cargo.toml
+++ b/src/uu/chown/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/chown.rs"
 doctest = false
@@ -27,6 +24,9 @@ uucore = { workspace = true, features = [
   "safe-traversal",
 ] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "chown"

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/chroot.rs"
 test = false
@@ -25,6 +22,9 @@ rustix = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "chroot"

--- a/src/uu/cksum/Cargo.toml
+++ b/src/uu/cksum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/cksum.rs"
 test = false
@@ -36,6 +33,9 @@ openssl = ["uucore/openssl"]
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "cksum"

--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/comm.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["fs"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "comm"

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/cp.rs"
 doctest = false
@@ -69,3 +66,6 @@ harness = false
 [features]
 feat_selinux = ["selinux", "uucore/selinux"]
 feat_acl = ["exacl"]
+
+[lints]
+workspace = true

--- a/src/uu/csplit/Cargo.toml
+++ b/src/uu/csplit/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/csplit.rs"
 doctest = false
@@ -33,6 +30,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "csplit_bench"

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/cut.rs"
 doctest = false
@@ -28,6 +25,9 @@ fluent = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "cut"

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/date.rs"
 doctest = false
@@ -60,6 +57,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "date_bench"

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/dd.rs"
 doctest = false
@@ -41,6 +38,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "dd_bench"

--- a/src/uu/df/Cargo.toml
+++ b/src/uu/df/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/df.rs"
 doctest = false
@@ -35,6 +32,9 @@ rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 rustix = { workspace = true, features = ["stdio"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "df"

--- a/src/uu/dir/Cargo.toml
+++ b/src/uu/dir/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/dir.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true, features = ["env"] }
 uucore = { workspace = true, features = ["entries", "fs", "quoting-style"] }
 uu_ls = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "dir"

--- a/src/uu/dircolors/Cargo.toml
+++ b/src/uu/dircolors/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/dircolors.rs"
 doctest = false
@@ -22,6 +19,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["colors", "parser"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "dircolors"

--- a/src/uu/dirname/Cargo.toml
+++ b/src/uu/dirname/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/dirname.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "dirname"

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/du.rs"
 doctest = false
@@ -51,6 +48,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "du_bench"

--- a/src/uu/echo/Cargo.toml
+++ b/src/uu/echo/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/echo.rs"
 test = false
@@ -31,6 +28,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "echo_bench"

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/env.rs"
 doctest = false
@@ -27,6 +24,9 @@ fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["signal"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "env"

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/expand.rs"
 doctest = false
@@ -29,6 +26,9 @@ uucore = { workspace = true }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "expand"

--- a/src/uu/expr/Cargo.toml
+++ b/src/uu/expr/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/expr.rs"
 doctest = false
@@ -30,6 +27,9 @@ fluent = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "expr"

--- a/src/uu/factor/Cargo.toml
+++ b/src/uu/factor/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [dependencies]
 clap = { workspace = true }
 uucore = { workspace = true }
@@ -29,6 +26,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [lib]
 path = "src/factor.rs"

--- a/src/uu/false/Cargo.toml
+++ b/src/uu/false/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/false.rs"
 test = false
@@ -32,6 +29,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "false_bench"

--- a/src/uu/fmt/Cargo.toml
+++ b/src/uu/fmt/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/fmt.rs"
 doctest = false
@@ -23,6 +20,9 @@ clap = { workspace = true }
 uucore = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "fmt"

--- a/src/uu/fold/Cargo.toml
+++ b/src/uu/fold/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/fold.rs"
 test = false
@@ -29,6 +26,9 @@ unicode-width = { workspace = true }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "fold"

--- a/src/uu/groups/Cargo.toml
+++ b/src/uu/groups/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/groups.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "groups"

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/head.rs"
 doctest = false
@@ -30,6 +27,9 @@ uucore = { workspace = true, features = [
   "fs",
 ] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "head"

--- a/src/uu/hostid/Cargo.toml
+++ b/src/uu/hostid/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/hostid.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 libc = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "hostid"

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -14,9 +14,6 @@ readme.workspace = true
 [package.metadata.cargo-udeps.ignore]
 normal = ["uucore_procs"]
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/hostname.rs"
 test = false
@@ -49,3 +46,6 @@ harness = false
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/id.rs"
 test = false
@@ -35,3 +32,6 @@ path = "src/main.rs"
 [features]
 feat_selinux = ["selinux"]
 smack = ["uucore/smack"]
+
+[lints]
+workspace = true

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/install.rs"
 
@@ -39,6 +36,9 @@ selinux = { workspace = true, optional = true }
 
 [features]
 selinux = ["dep:selinux", "uucore/selinux"]
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "install"

--- a/src/uu/join/Cargo.toml
+++ b/src/uu/join/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/join.rs"
 test = false
@@ -34,6 +31,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "join_bench"

--- a/src/uu/kill/Cargo.toml
+++ b/src/uu/kill/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/kill.rs"
 doctest = false
@@ -27,6 +24,9 @@ fluent = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 rustix = { workspace = true, features = ["process"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "kill"

--- a/src/uu/link/Cargo.toml
+++ b/src/uu/link/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/link.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "link"

--- a/src/uu/ln/Cargo.toml
+++ b/src/uu/ln/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/ln.rs"
 test = false
@@ -27,6 +24,9 @@ fluent = { workspace = true }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "ln"

--- a/src/uu/logname/Cargo.toml
+++ b/src/uu/logname/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/logname.rs"
 test = false
@@ -24,6 +21,9 @@ libc = { workspace = true }
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "logname"

--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/ls.rs"
 doctest = false
@@ -67,3 +64,6 @@ harness = false
 [features]
 feat_selinux = ["selinux", "uucore/selinux"]
 smack = ["uucore/smack"]
+
+[lints]
+workspace = true

--- a/src/uu/md5sum/Cargo.toml
+++ b/src/uu/md5sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/md5sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "md5sum"

--- a/src/uu/mkdir/Cargo.toml
+++ b/src/uu/mkdir/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/mkdir.rs"
 test = false
@@ -30,6 +27,9 @@ rustix = { workspace = true, features = ["process", "fs"] }
 [features]
 selinux = ["uucore/selinux"]
 smack = ["uucore/smack"]
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "mkdir"

--- a/src/uu/mkfifo/Cargo.toml
+++ b/src/uu/mkfifo/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/mkfifo.rs"
 test = false
@@ -33,6 +30,9 @@ libc = { workspace = true }
 [features]
 selinux = ["uucore/selinux"]
 smack = ["uucore/smack"]
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "mkfifo"

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 name = "uu_mknod"
 path = "src/mknod.rs"
@@ -29,6 +26,9 @@ nix = { workspace = true }
 [features]
 selinux = ["uucore/selinux"]
 smack = ["uucore/smack"]
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "mknod"

--- a/src/uu/mktemp/Cargo.toml
+++ b/src/uu/mktemp/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/mktemp.rs"
 doctest = false
@@ -25,6 +22,9 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "mktemp"

--- a/src/uu/more/Cargo.toml
+++ b/src/uu/more/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/more.rs"
 doctest = false
@@ -36,3 +33,6 @@ path = "src/main.rs"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/mv.rs"
 doctest = false
@@ -48,7 +45,6 @@ windows-sys = { workspace = true, features = [
 libc = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
 
-
 [features]
 selinux = ["uucore/selinux"]
 
@@ -60,6 +56,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "mv_bench"

--- a/src/uu/nice/Cargo.toml
+++ b/src/uu/nice/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/nice.rs"
 test = false
@@ -26,6 +23,9 @@ fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["process"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "nice"

--- a/src/uu/nl/Cargo.toml
+++ b/src/uu/nl/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/nl.rs"
 doctest = false
@@ -29,6 +26,9 @@ fluent = { workspace = true }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "nl"

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/nohup.rs"
 test = false
@@ -26,6 +23,9 @@ rustix = { workspace = true, features = ["process", "stdio"] }
 uucore = { workspace = true, features = ["fs"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "nohup"

--- a/src/uu/nproc/Cargo.toml
+++ b/src/uu/nproc/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/nproc.rs"
 test = false
@@ -26,6 +23,8 @@ libc = { workspace = true }
 rustix = { workspace = true, features = ["thread"] }
 uucore = { workspace = true, features = ["fs"] }
 
+[lints]
+workspace = true
 
 [[bin]]
 name = "nproc"

--- a/src/uu/numfmt/Cargo.toml
+++ b/src/uu/numfmt/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/numfmt.rs"
 
@@ -32,6 +29,9 @@ memchr = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "numfmt"

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/od.rs"
 
@@ -25,6 +22,9 @@ rustix = { workspace = true, features = ["stdio"] }
 uucore = { workspace = true, features = ["fs", "parser-size"] }
 fluent = { workspace = true }
 libc.workspace = true
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "od"

--- a/src/uu/paste/Cargo.toml
+++ b/src/uu/paste/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/paste.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["i18n-charmap"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "paste"

--- a/src/uu/pathchk/Cargo.toml
+++ b/src/uu/pathchk/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/pathchk.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 libc = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "pathchk"

--- a/src/uu/pinky/Cargo.toml
+++ b/src/uu/pinky/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [features]
 feat_systemd_logind = ["uucore/feat_systemd_logind"]
 
@@ -27,6 +24,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["utmpx", "entries"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "pinky"

--- a/src/uu/pr/Cargo.toml
+++ b/src/uu/pr/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/pr.rs"
 test = false
@@ -27,6 +24,9 @@ memchr = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "pr"

--- a/src/uu/printenv/Cargo.toml
+++ b/src/uu/printenv/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/printenv.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "printenv"

--- a/src/uu/printf/Cargo.toml
+++ b/src/uu/printf/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/printf.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["format", "quoting-style"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "printf"

--- a/src/uu/ptx/Cargo.toml
+++ b/src/uu/ptx/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/ptx.rs"
 test = false
@@ -25,6 +22,9 @@ regex = { workspace = true }
 uucore = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "ptx"

--- a/src/uu/pwd/Cargo.toml
+++ b/src/uu/pwd/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/pwd.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "pwd"

--- a/src/uu/readlink/Cargo.toml
+++ b/src/uu/readlink/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/readlink.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["fs"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "readlink"

--- a/src/uu/realpath/Cargo.toml
+++ b/src/uu/realpath/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/realpath.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["fs"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "realpath"

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/rm.rs"
 doctest = false
@@ -42,6 +39,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "rm_bench"

--- a/src/uu/rmdir/Cargo.toml
+++ b/src/uu/rmdir/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/rmdir.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["fs"] }
 libc = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "rmdir"

--- a/src/uu/runcon/Cargo.toml
+++ b/src/uu/runcon/Cargo.toml
@@ -11,9 +11,6 @@ license.workspace = true
 version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/runcon.rs"
 test = false
@@ -27,6 +24,9 @@ selinux = { workspace = true }
 thiserror = { workspace = true }
 libc = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "runcon"

--- a/src/uu/seq/Cargo.toml
+++ b/src/uu/seq/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/seq.rs"
 doctest = false
@@ -42,6 +39,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "seq_bench"

--- a/src/uu/sha1sum/Cargo.toml
+++ b/src/uu/sha1sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sha1sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sha1sum"

--- a/src/uu/sha224sum/Cargo.toml
+++ b/src/uu/sha224sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sha224sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sha224sum"

--- a/src/uu/sha256sum/Cargo.toml
+++ b/src/uu/sha256sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sha256sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sha256sum"

--- a/src/uu/sha384sum/Cargo.toml
+++ b/src/uu/sha384sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sha384sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sha384sum"

--- a/src/uu/sha512sum/Cargo.toml
+++ b/src/uu/sha512sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sha512sum.rs"
 test = false
@@ -35,6 +32,9 @@ openssl = ["uucore/openssl"]
 
 [dev-dependencies]
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sha512sum"

--- a/src/uu/shred/Cargo.toml
+++ b/src/uu/shred/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/shred.rs"
 doctest = false
@@ -24,6 +21,9 @@ rand = { workspace = true }
 uucore = { workspace = true, features = ["parser-size"] }
 libc = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "shred"

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/shuf.rs"
 doctest = false
@@ -39,3 +36,6 @@ harness = false
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true

--- a/src/uu/sleep/Cargo.toml
+++ b/src/uu/sleep/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sleep.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["parser"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sleep"

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sort.rs"
 doctest = false
@@ -67,6 +64,9 @@ uucore = { workspace = true, features = [
   "i18n-collator",
   "i18n-datetime",
 ] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sort"

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/split.rs"
 doctest = false
@@ -34,6 +31,9 @@ path = "src/main.rs"
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "split_bench"

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/stat.rs"
 doctest = false
@@ -34,6 +31,9 @@ fluent = { workspace = true }
 
 [features]
 selinux = ["uucore/selinux"]
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "stat"

--- a/src/uu/stdbuf/Cargo.toml
+++ b/src/uu/stdbuf/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/stdbuf.rs"
 test = false
@@ -49,6 +46,9 @@ libstdbuf = { package = "uu_stdbuf_libstdbuf", version = "0.9.0", path = "src/li
 
 [features]
 feat_external_libstdbuf = []
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "stdbuf"

--- a/src/uu/stdbuf/src/libstdbuf/Cargo.toml
+++ b/src/uu/stdbuf/src/libstdbuf/Cargo.toml
@@ -10,9 +10,6 @@ categories.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 name = "stdbuf"
 path = "src/libstdbuf.rs"
@@ -22,3 +19,6 @@ test = false
 [dependencies]
 ctor = { workspace = true }
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/uu/stty/Cargo.toml
+++ b/src/uu/stty/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/stty.rs"
 doctest = false
@@ -25,6 +22,9 @@ fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["ioctl", "term"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "stty"

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sum.rs"
 test = false
@@ -24,6 +21,9 @@ clap = { workspace = true }
 rustix = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sum"

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -14,9 +14,6 @@ readme.workspace = true
 [package.metadata.cargo-udeps.ignore]
 normal = ["uucore_procs"]
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/sync.rs"
 test = false
@@ -36,6 +33,9 @@ windows-sys = { workspace = true, features = [
   "Win32_System_WindowsProgramming",
   "Win32_Foundation",
 ] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "sync"

--- a/src/uu/tac/Cargo.toml
+++ b/src/uu/tac/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tac.rs"
 doctest = false
@@ -30,6 +27,9 @@ uucore = { workspace = true, features = ["signals"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "tac"

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tail.rs"
 doctest = false
@@ -44,6 +41,9 @@ windows-sys = { workspace = true, features = [
 
 [dev-dependencies]
 rstest = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "tail"

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tee.rs"
 test = false
@@ -32,6 +29,9 @@ uucore = { workspace = true, features = ["benchmark"] }
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 rustix = { workspace = true, features = ["pipe"] }
 uucore = { workspace = true, features = ["pipes"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "tee"

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/test.rs"
 doctest = false
@@ -27,6 +24,9 @@ uucore = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "test"

--- a/src/uu/timeout/Cargo.toml
+++ b/src/uu/timeout/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/timeout.rs"
 test = false
@@ -35,6 +32,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "timeout_bench"

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/touch.rs"
 doctest = false
@@ -40,6 +37,9 @@ windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
 ] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "touch"

--- a/src/uu/tr/Cargo.toml
+++ b/src/uu/tr/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tr.rs"
 test = false
@@ -30,6 +27,9 @@ bytecount = { workspace = true, features = ["runtime-dispatch-simd"] }
 divan = { workspace = true }
 rustix = { workspace = true, features = ["stdio", "fs"] }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "tr"

--- a/src/uu/true/Cargo.toml
+++ b/src/uu/true/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/true.rs"
 test = false
@@ -31,6 +28,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "true_bench"

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/truncate.rs"
 doctest = false
@@ -22,6 +19,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["parser-size"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "truncate"

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -12,9 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tsort.rs"
 test = false
@@ -38,6 +35,9 @@ path = "src/main.rs"
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "tsort_bench"

--- a/src/uu/tty/Cargo.toml
+++ b/src/uu/tty/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/tty.rs"
 test = false
@@ -32,6 +29,9 @@ windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
 ] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "tty"

--- a/src/uu/uname/Cargo.toml
+++ b/src/uu/uname/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/uname.rs"
 test = false
@@ -24,6 +21,9 @@ platform-info = { workspace = true }
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "uname"

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/unexpand.rs"
 doctest = false
@@ -29,6 +26,9 @@ uucore = { workspace = true }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "unexpand"

--- a/src/uu/uniq/Cargo.toml
+++ b/src/uu/uniq/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/uniq.rs"
 test = false
@@ -27,6 +24,9 @@ fluent = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark", "parser"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "uniq"

--- a/src/uu/unlink/Cargo.toml
+++ b/src/uu/unlink/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/unlink.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "unlink"

--- a/src/uu/uptime/Cargo.toml
+++ b/src/uu/uptime/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [features]
 feat_systemd_logind = ["uucore/feat_systemd_logind"]
 
@@ -30,6 +27,9 @@ thiserror = { workspace = true }
 uucore = { workspace = true, features = ["libc", "utmpx", "uptime"] }
 fluent = { workspace = true }
 jiff = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "uptime"

--- a/src/uu/users/Cargo.toml
+++ b/src/uu/users/Cargo.toml
@@ -13,9 +13,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [features]
 feat_systemd_logind = ["uucore/feat_systemd_logind"]
 
@@ -31,6 +28,9 @@ fluent = { workspace = true }
 
 [target.'cfg(target_os = "openbsd")'.dependencies]
 utmp-classic = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "users"

--- a/src/uu/vdir/Cargo.toml
+++ b/src/uu/vdir/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/vdir.rs"
 test = false
@@ -23,6 +20,9 @@ doctest = false
 clap = { workspace = true, features = ["env"] }
 uucore = { workspace = true, features = ["entries", "fs", "quoting-style"] }
 uu_ls = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "vdir"

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/wc.rs"
 test = false
@@ -40,6 +37,9 @@ rustix = { workspace = true, features = ["fs"] }
 divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "wc"

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -1,6 +1,5 @@
 # spell-checker:ignore logind
 
-
 [package]
 name = "uu_who"
 description = "who ~ (uutils) display information about currently logged-in users"
@@ -13,9 +12,6 @@ categories.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
-
-[lints]
-workspace = true
 
 [features]
 feat_systemd_logind = ["uucore/feat_systemd_logind"]
@@ -30,6 +26,9 @@ clap = { workspace = true }
 rustix = { workspace = true, features = ["termios"] }
 uucore = { workspace = true, features = ["utmpx"] }
 fluent = { workspace = true }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "who"

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/whoami.rs"
 test = false
@@ -30,6 +27,9 @@ windows-sys = { workspace = true, features = [
   "Win32_System_WindowsProgramming",
   "Win32_Foundation",
 ] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "whoami"

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -11,9 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/yes.rs"
 doctest = false
@@ -24,6 +21,9 @@ itertools = { workspace = true }
 fluent = { workspace = true }
 rustix = { workspace = true, features = ["stdio", "pipe"] }
 uucore = { workspace = true, features = ["fs", "pipes"] }
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "yes"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -15,9 +15,6 @@ version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/lib/lib.rs"
 
@@ -225,3 +222,6 @@ tty = []
 time = ["jiff"]
 uptime = ["jiff", "libc", "windows-sys", "utmpx", "utmp-classic"]
 benchmark = ["divan", "itertools", "tempfile"]
+
+[lints]
+workspace = true

--- a/tests/uutests/Cargo.toml
+++ b/tests/uutests/Cargo.toml
@@ -15,9 +15,6 @@ version.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-[lints]
-workspace = true
-
 [lib]
 path = "src/lib/lib.rs"
 
@@ -44,3 +41,6 @@ rlimit = { workspace = true }
 
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "openbsd"))))'.dependencies]
 xattr = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Reorder the cargo manifest so that the `[lints]` section is emitted after the `[dependencies]` and `[features]` sections.

This ordering better matches the structure commonly seen in Rust projects.

No functional changes; this is purely a reordering of manifest sections.