### PR TITLE
join: apply the -e filler to empty output fields

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -219,18 +219,26 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         !self.format.is_empty()
     }
 
-    /// Write the field or empty filler if the field is not set.
+    /// Resolve an output field to the bytes that should be printed for it.
+    ///
+    /// The `-e` filler stands in for output fields that are empty, which
+    /// covers both fields missing from the input line and fields that are
+    /// present but zero length. When `-e` is not given the filler is itself
+    /// empty, so this leaves the output unchanged.
+    fn field_or_empty<'b>(&'b self, field: Option<&'b [u8]>) -> &'b [u8] {
+        match field {
+            Some(field) if !field.is_empty() => field,
+            _ => self.empty,
+        }
+    }
+
+    /// Write the field or the empty filler if the field is empty or not set.
     fn write_field(
         &self,
         writer: &mut impl Write,
         field: Option<&[u8]>,
     ) -> Result<(), std::io::Error> {
-        let value = match field {
-            Some(field) => field,
-            None => self.empty,
-        };
-
-        writer.write_all(value)
+        writer.write_all(self.field_or_empty(field))
     }
 
     /// Write each field except the one at the index.
@@ -243,13 +251,13 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         for i in 0..line.field_ranges.len() {
             if i != index {
                 writer.write_all(self.separator.output_separator())?;
-                writer.write_all(line.get_field(i).unwrap())?;
+                writer.write_all(self.field_or_empty(line.get_field(i)))?;
             }
         }
         Ok(())
     }
 
-    /// Write each field or the empty filler if the field is not set.
+    /// Write each field or the empty filler if the field is empty or not set.
     fn write_format<F>(&self, writer: &mut impl Write, f: F) -> Result<(), std::io::Error>
     where
         F: Fn(&Spec) -> Option<&'a [u8]>,
@@ -259,12 +267,7 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
                 writer.write_all(self.separator.output_separator())?;
             }
 
-            let field = match f(&self.format[i]) {
-                Some(value) => value,
-                None => self.empty,
-            };
-
-            writer.write_all(field)?;
+            writer.write_all(self.field_or_empty(f(&self.format[i])))?;
         }
         Ok(())
     }

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -339,6 +339,71 @@ fn missing_format_fields() {
 }
 
 #[test]
+fn empty_fields_use_empty_filler() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    // A blank line splits into a single empty field, so the join field is
+    // present but zero length rather than missing.
+    at.write("blank", "hello\n\n\n");
+
+    ts.ucmd()
+        .args(&["-e", "EMPTY", "blank", "blank"])
+        .succeeds()
+        .stdout_only("hello\nEMPTY\nEMPTY\nEMPTY\nEMPTY\n");
+
+    // The same holds for a line containing only whitespace.
+    at.write("spaces", "   \n");
+
+    ts.ucmd()
+        .args(&["-e", "EMPTY", "-o", "0,1.1", "spaces", "spaces"])
+        .succeeds()
+        .stdout_only("EMPTY EMPTY\n");
+
+    // A field between two adjacent separators is also present but empty.
+    at.write("gap", "a,,b\n");
+
+    ts.ucmd()
+        .args(&[
+            "-t",
+            ",",
+            "-e",
+            "EMPTY",
+            "-o",
+            "0,1.1,1.2,1.3",
+            "gap",
+            "gap",
+        ])
+        .succeeds()
+        .stdout_only("a,a,EMPTY,b\n");
+
+    ts.ucmd()
+        .args(&["-t", ",", "-e", "EMPTY", "gap", "gap"])
+        .succeeds()
+        .stdout_only("a,EMPTY,b,EMPTY,b\n");
+}
+
+#[test]
+fn empty_fields_kept_without_empty_filler() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+
+    at.write("gap", "a,,b\n");
+
+    // Without -e an empty field stays empty.
+    ts.ucmd()
+        .args(&["-t", ",", "-o", "0,1.1,1.2,1.3", "gap", "gap"])
+        .succeeds()
+        .stdout_only("a,a,,b\n");
+
+    // Passing an empty string to -e is equivalent to not passing it at all.
+    ts.ucmd()
+        .args(&["-t", ",", "-e", "", "-o", "0,1.1,1.2,1.3", "gap", "gap"])
+        .succeeds()
+        .stdout_only("a,a,,b\n");
+}
+
+#[test]
 fn nocheck_order() {
     new_ucmd!()
         .arg("fields_1.txt")


### PR DESCRIPTION
Fixes #12770

## The problem

`-e` was applied only when a requested output field was *absent* — that is, when the field index ran past the end of the input line. It was not applied when the field was present but zero length. POSIX specifies `-e` as replacing "empty output fields", and GNU `join` substitutes in both cases.

A blank line is the case from the issue: under whitespace splitting it produces a single empty field rather than no fields at all, so the join key was an empty string and the filler was never reached.

Measured against GNU coreutils 8.32 on `main` (`b13ee7a`), with `a` containing `hello` followed by two blank lines and `gap` containing `a,,b`:

| command | GNU | uutils before |
| --- | --- | --- |
| `join -e X a a` | `hello`, `X`, `X`, `X`, `X` | `hello` followed by four blank lines |
| `join -t, -e X -o 0,1.1,1.2,1.3 gap gap` | `a,a,X,b` | `a,a,,b` |
| `join -t, -e X gap gap` | `a,X,b,X,b` | `a,,b,,b` |

## The change

Adds `Repr::field_or_empty`, which yields the `-e` filler for a field that is either missing or empty, and routes the three output paths through it:

- `write_field` — the join key in the default output format
- `write_fields` — the remaining fields in the default output format. This one never consulted the filler at all, so `-e` had no effect on non-key fields; the change also removes an `.unwrap()`
- `write_format` — the `-o` path, including `-o auto`

The filler defaults to the empty string, so **output is unchanged when `-e` is not given**, and `-e ''` behaves the same as omitting the flag. All 35 existing `join` tests pass untouched, including the three that already exercise `-e`.

I first suspected `WhitespaceSep::field_ranges` of manufacturing a spurious trailing empty field, but GNU reports the same field counts there — `join -e X` on the single line `a b ` (trailing space) prints `a b X b X` — so the splitter is correct and is left alone.

## Verification

Ubuntu 22.04, rustc 1.97.1. Expected behaviour was established by running the GNU binary as a black box and from the POSIX wording for `-e`; no GNU source was consulted.

- 21 flag/input combinations diffed against GNU `join`, comparing stdout, stderr and exit status. 7 differed before the change, 0 differ after.
- `cargo test --no-default-features --features join --test tests -- test_join` — 37 passed, 0 failed (35 pre-existing plus 2 new).
- `cargo clippy --no-default-features --features join --bin coreutils --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

I did not run the GNU upstream test suite locally, so I am not claiming anything about its results.
