### PR TITLE
test: fix comparison of integers wider than i128

### DIFF
--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -11,6 +11,7 @@ mod parser;
 use clap::Command;
 use error::{ParseError, ParseResult};
 use parser::{Operator, Symbol, UnaryOperator, parse};
+use std::cmp::Ordering;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 #[cfg(unix)]
@@ -169,32 +170,96 @@ fn eval(stack: &mut Vec<Symbol>) -> ParseResult<bool> {
     }
 }
 
+/// An integer operand of a comparison, split into a sign and its decimal digits.
+///
+/// Keeping the digits as text instead of converting them to a fixed-width
+/// integer is what lets operands of any length be compared, matching GNU, which
+/// places no limit on the width of the integers `test` accepts.
+#[derive(Debug, PartialEq, Eq)]
+struct Integer<'a> {
+    negative: bool,
+    /// The digits without leading zeros. Empty when the value is zero.
+    digits: &'a str,
+}
+
+impl<'a> Integer<'a> {
+    /// Parse an operand of the form `[+-]?[0-9]+`, surrounded by optional
+    /// whitespace, returning [`None`] when it has any other shape.
+    fn parse(value: &'a OsStr) -> Option<Self> {
+        let value = value.to_str()?.trim();
+
+        // Only ASCII `+`/`-` are sliced off, so this always cuts on a char boundary.
+        let (negative, digits) = match value.as_bytes().first()? {
+            b'-' => (true, &value[1..]),
+            b'+' => (false, &value[1..]),
+            _ => (false, value),
+        };
+
+        if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+
+        let digits = digits.trim_start_matches('0');
+
+        // Zero is neither positive nor negative, so `-0` compares equal to `0`.
+        Some(Self {
+            negative: negative && !digits.is_empty(),
+            digits,
+        })
+    }
+}
+
+impl Ord for Integer<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self.negative, other.negative) {
+            (false, true) => Ordering::Greater,
+            (true, false) => Ordering::Less,
+            (negative, _) => {
+                // Leading zeros are already gone, so the longer run of digits is
+                // the larger magnitude and equal-length runs order bytewise.
+                let magnitude = self
+                    .digits
+                    .len()
+                    .cmp(&other.digits.len())
+                    .then_with(|| self.digits.cmp(other.digits));
+
+                if negative {
+                    magnitude.reverse()
+                } else {
+                    magnitude
+                }
+            }
+        }
+    }
+}
+
+impl PartialOrd for Integer<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 /// Operations to compare integers
 /// `a` is the left hand side
-/// `b` is the left hand side
+/// `b` is the right hand side
 /// `op` the operation (ex: -eq, -lt, etc)
 fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
     // Parse the two inputs
-    let a: i128 = a
-        .to_str()
-        .map(str::trim)
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| ParseError::InvalidInteger(a.quote().to_string()))?;
-
-    let b: i128 = b
-        .to_str()
-        .map(str::trim)
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| ParseError::InvalidInteger(b.quote().to_string()))?;
+    let left =
+        Integer::parse(a).ok_or_else(|| ParseError::InvalidInteger(a.quote().to_string()))?;
+    let right =
+        Integer::parse(b).ok_or_else(|| ParseError::InvalidInteger(b.quote().to_string()))?;
 
     // Do the maths
+    let order = left.cmp(&right);
+
     Ok(match op.to_str() {
-        Some("-eq") => a == b,
-        Some("-ne") => a != b,
-        Some("-gt") => a > b,
-        Some("-ge") => a >= b,
-        Some("-lt") => a < b,
-        Some("-le") => a <= b,
+        Some("-eq") => order.is_eq(),
+        Some("-ne") => order.is_ne(),
+        Some("-gt") => order.is_gt(),
+        Some("-ge") => order.is_ge(),
+        Some("-lt") => order.is_lt(),
+        Some("-le") => order.is_le(),
         _ => return Err(ParseError::UnknownOperator(op.quote().to_string())),
     })
 }
@@ -441,5 +506,121 @@ mod tests {
         let a = OsStr::new("42");
         let b = OsStr::new("42");
         assert!(!integers(a, b, OsStr::new("-ne")).unwrap());
+    }
+
+    /// The 71-digit operand reported in the GNU compatibility issue, which is
+    /// far wider than any fixed-size integer type.
+    const BIG: &str = "16267277278126277227728782172782882627278282882172762677623672762783782";
+    /// `BIG` with its final digit incremented, so the two only differ in the
+    /// least significant digit.
+    const BIG_PLUS_ONE: &str =
+        "16267277278126277227728782172782882627278282882172762677623672762783783";
+    /// One digit shorter than `BIG`, so the two differ in width.
+    const SMALLER: &str = "1626727727812627722772878217278288262727828288217276267762367276278378";
+
+    #[test]
+    fn test_integer_op_beyond_i128() {
+        let big = OsStr::new(BIG);
+        let big_plus_one = OsStr::new(BIG_PLUS_ONE);
+        let smaller = OsStr::new(SMALLER);
+        let one = OsStr::new("1");
+
+        assert!(integers(big, big, OsStr::new("-eq")).unwrap());
+        assert!(!integers(big, big, OsStr::new("-ne")).unwrap());
+        assert!(integers(big, big, OsStr::new("-ge")).unwrap());
+        assert!(integers(big, big, OsStr::new("-le")).unwrap());
+
+        assert!(integers(one, big, OsStr::new("-ne")).unwrap());
+        assert!(integers(one, big, OsStr::new("-lt")).unwrap());
+        assert!(integers(big, one, OsStr::new("-gt")).unwrap());
+
+        // Same width, differing only in the least significant digit.
+        assert!(integers(big_plus_one, big, OsStr::new("-gt")).unwrap());
+        assert!(integers(big, big_plus_one, OsStr::new("-lt")).unwrap());
+        assert!(!integers(big, big_plus_one, OsStr::new("-eq")).unwrap());
+
+        // Differing widths.
+        assert!(integers(big, smaller, OsStr::new("-gt")).unwrap());
+        assert!(integers(smaller, big, OsStr::new("-lt")).unwrap());
+    }
+
+    #[test]
+    fn test_integer_op_beyond_i128_negative() {
+        let big = OsStr::new(BIG);
+        let neg_big =
+            OsStr::new("-16267277278126277227728782172782882627278282882172762677623672762783782");
+        let neg_smaller =
+            OsStr::new("-1626727727812627722772878217278288262727828288217276267762367276278378");
+
+        assert!(integers(neg_big, neg_big, OsStr::new("-eq")).unwrap());
+        assert!(integers(neg_big, OsStr::new("0"), OsStr::new("-lt")).unwrap());
+        assert!(integers(neg_big, big, OsStr::new("-lt")).unwrap());
+        assert!(integers(big, neg_big, OsStr::new("-gt")).unwrap());
+
+        // A wider negative number is the smaller of the two.
+        assert!(integers(neg_big, neg_smaller, OsStr::new("-lt")).unwrap());
+        assert!(integers(neg_smaller, neg_big, OsStr::new("-gt")).unwrap());
+    }
+
+    #[test]
+    fn test_integer_parse_normalizes_sign_and_leading_zeros() {
+        // Zero carries no sign, so `-0` and `0` are the same value.
+        assert_eq!(
+            Integer::parse(OsStr::new("-0")),
+            Integer::parse(OsStr::new("0"))
+        );
+        assert_eq!(
+            Integer::parse(OsStr::new("+0")),
+            Integer::parse(OsStr::new("-0"))
+        );
+        assert_eq!(
+            Integer::parse(OsStr::new("007")),
+            Integer::parse(OsStr::new("7"))
+        );
+        assert_eq!(
+            Integer::parse(OsStr::new("-007")),
+            Integer::parse(OsStr::new("-7"))
+        );
+        // Surrounding whitespace is ignored.
+        assert_eq!(
+            Integer::parse(OsStr::new(" 42 ")),
+            Integer::parse(OsStr::new("42"))
+        );
+        // Normalization is not limited by width either.
+        let padded = OsString::from(format!("+00{BIG}"));
+        assert_eq!(Integer::parse(&padded), Integer::parse(OsStr::new(BIG)));
+    }
+
+    #[test]
+    fn test_integer_op_rejects_malformed_operands() {
+        // Widening the accepted range must not make any of these parse.
+        // "\u{664}\u{662}" and "\u{ff11}\u{ff12}" are non-ASCII digits, which
+        // also exercise operands that are not one byte per character.
+        for operand in [
+            "",
+            "-",
+            "+",
+            "++5",
+            "--5",
+            "5-",
+            "+-5",
+            "1_0",
+            "0x10",
+            "1e3",
+            "123.45",
+            "4 2",
+            "\u{664}\u{662}",
+            "\u{ff11}\u{ff12}",
+        ] {
+            let operand = OsStr::new(operand);
+            assert!(
+                integers(operand, OsStr::new("0"), OsStr::new("-eq")).is_err(),
+                "{operand:?} should not parse as an integer"
+            );
+            assert!(
+                integers(OsStr::new("0"), operand, OsStr::new("-eq")).is_err(),
+                "{operand:?} should not parse as an integer"
+            );
+        }
     }
 }

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -255,11 +255,117 @@ fn test_some_int_compares() {
 }
 
 #[test]
-#[ignore = "fixme: evaluation error (code 1); GNU returns 0"]
 fn test_values_greater_than_i64_allowed() {
     new_ucmd!()
         .args(&["9223372036854775808", "-gt", "0"])
         .succeeds();
+}
+
+/// The 71-digit operand reported in GNU compatibility issue #12874.
+const BIG: &str = "16267277278126277227728782172782882627278282882172762677623672762783782";
+/// `BIG` with its final digit incremented, so the two operands have the same
+/// width and differ only in the least significant digit.
+const BIG_PLUS_ONE: &str =
+    "16267277278126277227728782172782882627278282882172762677623672762783783";
+/// One digit shorter than `BIG`, so the two operands differ in width.
+const SMALLER: &str = "1626727727812627722772878217278288262727828288217276267762367276278378";
+
+#[test]
+fn test_values_greater_than_i128_allowed() {
+    // i128::MAX + 1
+    new_ucmd!()
+        .args(&["170141183460469231731687303715884105728", "-gt", "0"])
+        .succeeds();
+    // i128::MIN - 1
+    new_ucmd!()
+        .args(&["-170141183460469231731687303715884105729", "-lt", "0"])
+        .succeeds();
+}
+
+#[test]
+fn test_large_int_compares() {
+    let scenario = TestScenario::new(util_name!());
+
+    let tests = [
+        [BIG, "-eq", BIG],
+        [BIG, "-ge", BIG],
+        [BIG, "-le", BIG],
+        [BIG, "-ne", "1"],
+        ["1", "-lt", BIG],
+        [BIG, "-gt", "1"],
+        // Same width, differing only in the least significant digit.
+        [BIG_PLUS_ONE, "-gt", BIG],
+        [BIG, "-lt", BIG_PLUS_ONE],
+        // Differing widths.
+        [BIG, "-gt", SMALLER],
+        [SMALLER, "-lt", BIG],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+
+    // run the inverse of all these tests
+    for test in &tests {
+        scenario.ucmd().arg("!").args(&test[..]).fails_with_code(1);
+    }
+}
+
+#[test]
+fn test_large_negative_int_compares() {
+    let scenario = TestScenario::new(util_name!());
+    let neg_big = format!("-{BIG}");
+    let neg_smaller = format!("-{SMALLER}");
+
+    let tests = [
+        [neg_big.as_str(), "-eq", neg_big.as_str()],
+        [neg_big.as_str(), "-lt", "0"],
+        [neg_big.as_str(), "-lt", BIG],
+        [BIG, "-gt", neg_big.as_str()],
+        // A wider negative number is the smaller of the two.
+        [neg_big.as_str(), "-lt", neg_smaller.as_str()],
+        [neg_smaller.as_str(), "-gt", neg_big.as_str()],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+
+    // run the inverse of all these tests
+    for test in &tests {
+        scenario.ucmd().arg("!").args(&test[..]).fails_with_code(1);
+    }
+}
+
+#[test]
+fn test_int_compares_ignore_redundant_sign_and_leading_zeros() {
+    let scenario = TestScenario::new(util_name!());
+    let padded_big = format!("+00{BIG}");
+
+    let tests = [
+        // Zero carries no sign.
+        ["-0", "-eq", "0"],
+        ["+0", "-eq", "-0"],
+        ["0", "-eq", "0000000000"],
+        ["007", "-eq", "7"],
+        ["-007", "-eq", "-7"],
+        [padded_big.as_str(), "-eq", BIG],
+    ];
+
+    for test in &tests {
+        scenario.ucmd().args(&test[..]).succeeds();
+    }
+}
+
+#[test]
+fn test_malformed_integers_are_still_errors() {
+    // Accepting wider operands must not make any of these parse.
+    for operand in ["1_0", "0x10", "1e3", "++5", "5-", "-", "+", "", "4 2"] {
+        new_ucmd!()
+            .args(&[operand, "-eq", "0"])
+            .fails_with_code(2)
+            .stderr_is(format!("test: invalid integer '{operand}'\n"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #12874

`test` rejects integers that don't fit in `i128`:

```console
$ test 1 -eq 16267277278126277227728782172782882627278282882172762677623672762783782
test: invalid integer '16267277278126277227728782172782882627278282882172762677623672762783782'
$ echo $?
2
```

GNU has no width limit here. All six integer operators are affected.

`integers()` parsed both operands as `i128`, so anything wider failed `parse()`.
They're now parsed into a sign plus decimal digits (leading zeros stripped, `-0`
normalized) and compared on sign, then digit count, then bytewise. No width limit
and no new dependency.

The set of accepted operands is unchanged - `0x10`, `1e3`, `123.45`, `1_0`, `5-`,
`-`, `+`, empty and non-UTF-8 all still fail the same way with exit 2. The digits
are validated here rather than handed to a bignum type because that reject set has
to be preserved either way, and once the validator exists the comparison is short.

`test_values_greater_than_i64_allowed` was `#[ignore]`d, but its input fits in
`i128` and passes on main today, so the ignore was stale. Re-enabled, with a new
test for `i128::MAX + 1` and `i128::MIN - 1`.

Checked with `cargo test -p uu_test` and the `test_test` integration suite, and
diffed against GNU `test` over 50 cases covering all six operators, large
negatives, sign and leading-zero handling, and the invalid inputs above. Output
matched. The GNU build I had available was 8.32, not 9.x.
