### PR TITLE
date: use `%Od` instead of `%Ol` in test

### DIFF
--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2074,9 +2074,9 @@ fn test_date_strftime_o_modifier() {
         .env("TZ", "UTC")
         .arg("-d")
         .arg("2024-06-15")
-        .arg("+%Om-%Oy-%Ol")
+        .arg("+%Om-%Oy-%Od")
         .succeeds()
-        .stdout_is("06-24-12\n");
+        .stdout_is("06-24-15\n");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes a "surprise" in a test where, at first glance, it appears the output date should differ from the input date.