### PR TITLE
uucore: use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,6 +402,7 @@ version = "0.9.0"
 
 [workspace.dependencies]
 ansi-width = "0.1.0"
+base64-simd = "0.8"
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
 bstr = "1.9.1"
@@ -415,8 +416,11 @@ compare = "0.1.0"
 crossterm = { version = "0.29.0", default-features = false }
 ctor = "1.0.0"
 ctrlc = { version = "3.5.2", features = ["termination"] }
+data-encoding = "2.6"
+data-encoding-macro = "0.1.15"
 divan = { package = "codspeed-divan-compat", version = "5.0.0" }
 dns-lookup = { version = "3.0.0" }
+dunce = "1.0.4"
 exacl = "0.13.0"
 file_diff = "1.0.0"
 filetime = "0.2.29"
@@ -451,6 +455,7 @@ num-bigint = "0.4.4"
 num-prime = "0.5.0"
 num-traits = "0.2.19"
 onig = { version = "~6.5.1", default-features = false }
+os_display = "0.1.3"
 parse_datetime = "0.15.0"
 phf = "0.14.0"
 phf_codegen = "0.14.0"
@@ -482,9 +487,11 @@ unit-prefix = "0.5"
 utmp-classic = "0.1.6"
 uutils_term_grid = "0.8"
 walkdir = "2.5"
+wild = "2.2.1"
 winapi-util = "0.1.8"
 windows-sys = { version = "0.61.0", default-features = false }
 xattr = "1.3.1"
+z85 = "3.0.5"
 zip = { version = "8.0.0", default-features = false, features = ["deflate"] }
 
 hex = "0.4.3"

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -19,13 +19,13 @@ all-features = true
 path = "src/lib/lib.rs"
 
 [dependencies]
-base64-simd = { version = "0.8", optional = true }
+base64-simd = { workspace = true, optional = true }
 bstr = { workspace = true, optional = true }
 clap = { workspace = true }
-data-encoding = { version = "2.6", optional = true }
-data-encoding-macro = { version = "0.1.15", optional = true }
+data-encoding = { workspace = true, optional = true }
+data-encoding-macro = { workspace = true, optional = true }
 dns-lookup = { workspace = true, optional = true }
-dunce = { version = "1.0.4", optional = true }
+dunce = { workspace = true, optional = true }
 glob = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 jiff = { workspace = true, optional = true, features = [
@@ -34,7 +34,7 @@ jiff = { workspace = true, optional = true, features = [
   "tzdb-concatenated",
 ] }
 libc = { workspace = true, optional = true }
-os_display = "0.1.3"
+os_display = { workspace = true }
 rustc-hash = { workspace = true }
 rustix = { workspace = true, features = ["fs", "net", "pipe", "process"] }
 time = { workspace = true, optional = true, features = [
@@ -48,7 +48,7 @@ time = { workspace = true, optional = true, features = [
 unicode-width = { workspace = true }
 unit-prefix = { workspace = true, optional = true }
 uucore_procs = { workspace = true }
-z85 = { version = "3.0.5", optional = true }
+z85 = { workspace = true, optional = true }
 
 # Benchmark dependencies (optional)
 divan = { workspace = true, optional = true }
@@ -118,7 +118,7 @@ xattr = { workspace = true, optional = true }
 procfs = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-wild = "2.2.1"
+wild = { workspace = true }
 winapi-util = { workspace = true, optional = true }
 windows-sys = { workspace = true, optional = true, default-features = false, features = [
   "Wdk_System_SystemInformation",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -19,10 +19,11 @@ all-features = true
 path = "src/lib/lib.rs"
 
 [dependencies]
+base64-simd = { version = "0.8", optional = true }
 bstr = { workspace = true, optional = true }
 clap = { workspace = true }
-uucore_procs = { workspace = true }
-unit-prefix = { workspace = true, optional = true }
+data-encoding = { version = "2.6", optional = true }
+data-encoding-macro = { version = "0.1.15", optional = true }
 dns-lookup = { workspace = true, optional = true }
 dunce = { version = "1.0.4", optional = true }
 glob = { workspace = true, optional = true }
@@ -32,6 +33,8 @@ jiff = { workspace = true, optional = true, features = [
   "tzdb-zoneinfo",
   "tzdb-concatenated",
 ] }
+libc = { workspace = true, optional = true }
+os_display = "0.1.3"
 rustc-hash = { workspace = true }
 rustix = { workspace = true, features = ["fs", "net", "pipe", "process"] }
 time = { workspace = true, optional = true, features = [
@@ -39,17 +42,13 @@ time = { workspace = true, optional = true, features = [
   "local-offset",
   "macros",
 ] }
-# * "problem" dependencies (pinned)
-data-encoding = { version = "2.6", optional = true }
-data-encoding-macro = { version = "0.1.15", optional = true }
-z85 = { version = "3.0.5", optional = true }
-base64-simd = { version = "0.8", optional = true }
-libc = { workspace = true, optional = true }
-os_display = "0.1.3"
 # Not optional: os_display already pulls unicode-width into every uucore build,
 # so making it a direct dependency here is free and keeps char_width available
 # on all targets (a feature-gated optional dep failed to activate on wasm).
 unicode-width = { workspace = true }
+unit-prefix = { workspace = true, optional = true }
+uucore_procs = { workspace = true }
+z85 = { version = "3.0.5", optional = true }
 
 # Benchmark dependencies (optional)
 divan = { workspace = true, optional = true }


### PR DESCRIPTION
None of these dependencies are pinned, so the existing comment is misleading. Remove it and refactor the dependencies section by alphabetizing the entries and using workspace dependencies.