### PR TITLE
uucore: fix parse_size overflow on a large `%` size

### DIFF
--- a/src/uucore/src/lib/features/parser/parse_size.rs
+++ b/src/uucore/src/lib/features/parser/parse_size.rs
@@ -255,7 +255,9 @@ impl<'parser> Parser<'parser> {
         if unit == "%" {
             let number: u128 = Self::parse_number(&numeric_string, 10, size)?;
             return match total_physical_memory() {
-                Ok(total) => Ok((number / 100) * total),
+                Ok(total) => (number / 100)
+                    .checked_mul(total)
+                    .ok_or_else(|| ParseSizeError::size_too_big(size)),
                 Err(_) => Err(ParseSizeError::PhysicalMem(size.to_string())),
             };
         }
@@ -861,5 +863,21 @@ mod tests {
         assert!(parse_size_u64("-1%").is_err());
         assert!(parse_size_u64("1.0%").is_err());
         assert!(parse_size_u64("0x1%").is_err());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn parse_percent_overflow() {
+        // A percentage can fit in a u128 while its product with the total
+        // physical memory does not. `u128::MAX` overflows for any machine
+        // reporting more than 100 bytes of memory.
+        let size = format!("{}%", u128::MAX);
+
+        assert!(variant_eq(
+            &parse_size_u128(&size).unwrap_err(),
+            &ParseSizeError::SizeTooBig(String::new())
+        ));
+        assert_eq!(Ok(u128::MAX), parse_size_u128_max(&size));
+        assert_eq!(Ok(u64::MAX), parse_size_u64_max(&size));
     }
 }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -89,6 +89,18 @@ fn test_invalid_buffer_size() {
         .fails_with_code(2)
         .stderr_only("sort: invalid --buffer-size argument '0x123%'\n");
 
+    // A percentage can fit in a u128 while its product with the total
+    // physical memory does not; the parser must report it as too large
+    // rather than panicking or silently wrapping.
+    #[cfg(target_os = "linux")]
+    new_ucmd!()
+        .arg("-S")
+        .arg("340282366920938463463374607431768211455%")
+        .fails_with_code(2)
+        .stderr_only(
+            "sort: --buffer-size argument '340282366920938463463374607431768211455%' too large\n",
+        );
+
     new_ucmd!()
         .arg("-n")
         .arg("-S")


### PR DESCRIPTION
## Summary

Fixes #13736. The `%` (percent-of-physical-memory) branch of `Parser::parse` in `src/uucore/src/lib/features/parser/parse_size.rs` computed `(number / 100) * total` as an unchecked `u128` multiply. A percentage that fits in a `u128` but whose product with the total physical memory does not overflows, panicking with "attempt to multiply with overflow" (exit 134) under `-C overflow-checks` instead of reporting a parse error:

```
$ du --block-size=9223372036854775808000000000000% /tmp
thread 'main' panicked at parse_size.rs:258:33:
attempt to multiply with overflow
```

Since `parse_size` is shared code, this is reachable from every util that accepts a size: `du`, `sort`, `df`, `ls`, `split`, `stdbuf`, `od`, `shred`, `dd`, `head`, and `tail`.

## Fix

Use `checked_mul` and return `ParseSizeError::size_too_big` on overflow, matching how the non-percent path (a few lines below) already handles the same too-large-size condition — per @RenjiSann's comment on the issue. Callers get the same behavior they already have for other too-large sizes like `1Y`: utils that report an error keep reporting one, and utils using `parse_u64_max`/`parse_u128_max` clamp to the maximum, matching GNU.

## Test plan

Added a regression test (`parse_percent_overflow`) covering the exact overflow case, gated `#[cfg(target_os = "linux")]` to match the existing convention for physical-memory-dependent tests in this file (there are several already gated the same way, since `total_physical_memory()` is platform-specific).

- `cargo test -p uucore --lib --features parser-size` — 16/16 existing `parse_size` tests pass (the new Linux-gated test doesn't run on my macOS sandbox, but follows the exact same gating as pre-existing tests in this file, so it'll run in CI)
- `cargo clippy -p uucore --features parser-size --lib -- -D warnings` — clean