### PR TITLE
od: improve perf for --skip-bytes non-seekable input by splice(2)

### DIFF
--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -19,7 +19,7 @@ byteorder = { workspace = true }
 clap = { workspace = true }
 half = { workspace = true }
 rustix = { workspace = true, features = ["stdio"] }
-uucore = { workspace = true, features = ["fs", "parser-size"] }
+uucore = { workspace = true, features = ["fs", "parser-size", "pipes"] }
 fluent = { workspace = true }
 libc.workspace = true
 

--- a/src/uu/od/src/multifile_reader.rs
+++ b/src/uu/od/src/multifile_reader.rs
@@ -39,6 +39,16 @@ impl io::Read for CurrentReader {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl rustix::fd::AsFd for CurrentReader {
+    fn as_fd(&self) -> rustix::fd::BorrowedFd<'_> {
+        match self {
+            Self::File(f) => f.as_fd(),
+            Self::Stdin(s) => s.0,
+        }
+    }
+}
+
 // MultifileReader - concatenate all our input, file or stdin.
 pub struct MultifileReader<'a> {
     ni: Vec<InputSource<'a>>,
@@ -182,8 +192,17 @@ fn skip_in_file(curr: &mut CurrentReader, n_skip: u64) -> io::Result<u64> {
             }
         }
     }
-    let read = uucore::io::read_and_discard(curr, n_skip, SKIP_BUFFER_SIZE)?;
-    Ok(n_skip - read)
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    match uucore::pipes::discard_n_bytes(&curr, n_skip as usize) {
+        Ok(spliced) => Ok(n_skip - spliced as u64),
+        Err(spliced) => {
+            let read =
+                uucore::io::read_and_discard(curr, n_skip - spliced as u64, SKIP_BUFFER_SIZE)?;
+            Ok(n_skip - spliced as u64 - read)
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    Ok(n_skip - uucore::io::read_and_discard(curr, n_skip, SKIP_BUFFER_SIZE)?)
 }
 
 /// Seek `f` forward by `n` bytes. Returns `Ok(true)` if the seek happened, or

--- a/src/uu/od/src/multifile_reader.rs
+++ b/src/uu/od/src/multifile_reader.rs
@@ -41,6 +41,16 @@ impl io::Read for CurrentReader {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl rustix::fd::AsFd for CurrentReader {
+    fn as_fd(&self) -> rustix::fd::BorrowedFd<'_> {
+        match self {
+            Self::File(f) => f.as_fd(),
+            Self::Stdin(s) => s.0,
+        }
+    }
+}
+
 // MultifileReader - concatenate all our input, file or stdin.
 pub struct MultifileReader<'a> {
     ni: Vec<InputSource<'a>>,
@@ -186,8 +196,17 @@ fn skip_in_file(curr: &mut CurrentReader, n_skip: u64) -> io::Result<u64> {
             }
         }
     }
-    let read = uucore::io::read_and_discard(curr, n_skip, SKIP_BUFFER_SIZE)?;
-    Ok(n_skip - read)
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    match uucore::pipes::discard_n_bytes(&curr, n_skip as usize) {
+        Ok(spliced) => Ok(n_skip - spliced as u64),
+        Err(spliced) => {
+            let read =
+                uucore::io::read_and_discard(curr, n_skip - spliced as u64, SKIP_BUFFER_SIZE)?;
+            Ok(n_skip - spliced as u64 - read)
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    Ok(n_skip - uucore::io::read_and_discard(curr, n_skip, SKIP_BUFFER_SIZE)?)
 }
 
 /// Seek `f` forward by `n` bytes. Returns `Ok(true)` if the seek happened, or

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -154,6 +154,35 @@ pub fn send_n_bytes(input: impl AsFd, target: impl AsFd, n: u64) -> std::io::Res
     Ok(bytes_written)
 }
 
+/// discard `n` bytes by splice
+/// return actually discarded bytes
+/// Err(b) means we discarded b bytes, but we should try to discarding remaining bytes by read
+#[inline]
+pub fn discard_n_bytes(fd: impl AsFd, n: usize) -> Result<usize, usize> {
+    let mut discarded = 0;
+    let dev_null = dev_null().ok_or(0_usize)?;
+    while discarded < n
+        && let Ok(s) = splice(&fd, &dev_null, n - discarded)
+    {
+        if s == 0 {
+            return Ok(discarded);
+        }
+        discarded += s;
+    }
+    // else, input is not a pipe
+    let (pipe_read, pipe_write) = pipe::<false>().map_err(|_| discarded)?;
+    while discarded < n
+        && let Ok(s @ 1..) = splice(&fd, &pipe_write, n - discarded)
+    {
+        discarded += s;
+        // pipe to null is not blocked. So this returns the same length at most cases
+        // next splice does not hang if we discarded 1+ pages
+        splice(&pipe_read, &dev_null, s).map_err(|_| discarded)?;
+    }
+
+    Ok(discarded)
+}
+
 /// Return verified /dev/null
 ///
 /// `splice` to /dev/null is faster than `read` when we skip or count the non-seekable input

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -181,6 +181,35 @@ pub fn send_n_bytes(input: impl AsFd, target: impl AsFd, n: u64) -> std::io::Res
     Ok(bytes_written)
 }
 
+/// discard `n` bytes by splice
+/// return actually discarded bytes
+/// Err(b) means we discarded b bytes, but we should try to discarding remaining bytes by read
+#[inline]
+pub fn discard_n_bytes(fd: impl AsFd, n: usize) -> Result<usize, usize> {
+    let mut discarded = 0;
+    let dev_null = dev_null().ok_or(0_usize)?;
+    while discarded < n
+        && let Ok(s) = splice(&fd, &dev_null, n - discarded)
+    {
+        if s == 0 {
+            return Ok(discarded);
+        }
+        discarded += s;
+    }
+    // else, input is not a pipe
+    let (pipe_read, pipe_write) = pipe::<false>().map_err(|_| discarded)?;
+    while discarded < n
+        && let Ok(s @ 1..) = splice(&fd, &pipe_write, n - discarded)
+    {
+        discarded += s;
+        // pipe to null is not blocked. So this returns the same length at most cases
+        // next splice does not hang if we discarded 1+ pages
+        splice(&pipe_read, &dev_null, s).map_err(|_| discarded)?;
+    }
+
+    Ok(discarded)
+}
+
 /// Return verified /dev/null
 ///
 /// `splice` to /dev/null is faster than `read` when we skip or count the non-seekable input


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/issues/12598
This PR adds splice fast-path for `--skip-bytes` for non-seekable input as same as `wc -c`.

```
> truncate -s 1GB /tmp/huge
> time cat /tmp/huge|target/release/od-splice --skip-bytes 1GB
7346545000

________________________________________________________
Executed in   17.97 millis    fish           external
   usr time    0.95 millis    0.00 millis    0.95 millis
   sys time   31.25 millis    3.02 millis   28.23 millis

> time cat /tmp/huge|target/release/od --skip-bytes 1GB
7346545000

________________________________________________________
Executed in  160.61 millis    fish           external
   usr time  109.92 millis    0.89 millis  109.03 millis
   sys time  181.50 millis    2.76 millis  178.73 millis
```

```
> hyperfine "cat /tmp/huge|target/release/od --skip-bytes 1GB" "cat /tmp/huge|target/release/od-splice --skip-bytes 1GB" 
Benchmark 1: cat /tmp/huge|target/release/od --skip-bytes 1GB
  Time (mean ± σ):     155.4 ms ±  26.3 ms    [User: 105.1 ms, System: 183.9 ms]
  Range (min … max):   141.6 ms … 260.3 ms    20 runs
 
Benchmark 2: cat /tmp/huge|target/release/od-splice --skip-bytes 1GB
  Time (mean ± σ):      18.9 ms ±   6.1 ms    [User: 3.6 ms, System: 27.3 ms]
  Range (min … max):    15.5 ms …  68.1 ms    154 runs
 
Summary
  cat /tmp/huge|target/release/od-splice --skip-bytes 1GB ran
    8.24 ± 3.00 times faster than cat /tmp/huge|target/release/od --skip-bytes 1GB
```