### PR TITLE
stat: truncate string precision on a byte boundary to avoid a panic

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -405,11 +405,14 @@ fn determine_padding_char(flags: Flags) -> Padding {
 /// * `width` - The width of the field for the printed string.
 /// * `precision` - How many digits of precision, if any.
 fn print_str(s: &str, flags: Flags, width: usize, precision: Precision) {
-    let s = match precision {
-        Precision::Number(p) if p < s.len() => &s[..p],
-        _ => s,
-    };
-    pad_and_print(s, flags.left, width, Padding::Space);
+    // Truncate and pad on the byte representation, so a precision that lands inside a multibyte character does not cause a panic.
+    let _ = write_padded_bytes(
+        std::io::stdout(),
+        s.as_bytes(),
+        flags.left,
+        width,
+        precision,
+    );
 }
 
 /// Prints a `OsString` value based on the provided flags, width, and precision.

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -594,6 +594,17 @@ fn test_invalid_directive_after_multibyte_char() {
 }
 
 #[test]
+fn test_precision_splits_multibyte_char_in_value() {
+    let ts = TestScenario::new(util_name!());
+    let at = &ts.fixtures;
+    at.touch("é");
+    ts.ucmd()
+        .args(&["-c", "%.1n", "é"])
+        .succeeds()
+        .stdout_only_bytes([0xc3, b'\n']);
+}
+
+#[test]
 #[cfg(all(
     feature = "feat_selinux",
     any(target_os = "linux", target_os = "android")


### PR DESCRIPTION
Fixes #13750

`stat`'s `print_str` applied a `%.P` precision by slicing the `&str` value
(`&s[..p]`). When the precision `P` lands inside a multibyte UTF-8 character —
e.g. `stat -c '%.9n'` on a file whose name ends in a two-byte character — the
slice is not on a char boundary and `stat` panics and aborts (exit 134). GNU
`stat` truncates by bytes and exits 0.

```console
$ : > "$(printf 'é')" && stat -c '%.1n' "$(printf 'é')"
thread 'main' panicked at src/uu/stat/src/stat.rs:409:50:
end byte index 1 is not a char boundary; it is inside 'é' (bytes 0..2 of string)
```

## Fix

Route `print_str` through the existing `write_padded_bytes` helper — the same one
`print_os_str` already uses on Unix — so truncation and padding operate on bytes.
The output now matches GNU `stat` byte-for-byte (the partial byte is emitted, as
GNU does) instead of crashing.

## Test

Adds `test_precision_splits_multibyte_char_in_value`, which asserts that a
precision splitting a multibyte character truncates on the byte and succeeds.
