### PR TITLE
csplit: avoid negate-with-overflow on an i32::MIN regex line offset

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -480,7 +480,7 @@ impl SplitWriter<'_> {
             // but do not rewind it either since no match should be done within.
             // The consequence is that the buffer may already be full with lines from a previous
             // split, which is taken care of when calling `shrink_buffer_to_size`.
-            let offset_usize = -offset as usize;
+            let offset_usize = offset.unsigned_abs() as usize;
             input_iter.set_size_of_buffer(offset_usize);
             while let Some((ln, line)) = input_iter.next() {
                 let line = line?;

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -237,6 +237,22 @@ fn test_up_to_match_negative_offset() {
 }
 
 #[test]
+fn test_up_to_match_negative_offset_min_i32() {
+    new_ucmd!()
+        .args(&["numbers50.txt", "/45/-2147483648"])
+        .fails()
+        .stderr_is("csplit: '/45/-2147483648': line number out of range\n");
+}
+
+#[test]
+fn test_skip_to_match_negative_offset_min_i32() {
+    new_ucmd!()
+        .args(&["numbers50.txt", "%45%-2147483648"])
+        .fails()
+        .stderr_is("csplit: '%45%-2147483648': line number out of range\n");
+}
+
+#[test]
 fn test_up_to_match_negative_offset_repeat_twice() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "/9$/-3", "{2}"])


### PR DESCRIPTION
Fixes #13751

A `csplit` regex pattern may carry a signed line offset — `/regex/OFFSET`
or `%regex%OFFSET` — parsed into an `i32`. For a negative offset,
`do_to_match` computed `-offset as usize`. When `OFFSET` is `i32::MIN`
(`-2147483648`), the negation has no positive `i32` counterpart and
overflows, panicking with `attempt to negate with overflow` under
overflow-checks (exit 134). GNU `csplit` rejects the offset gracefully.

## Fix

Use `offset.unsigned_abs()`, which yields the magnitude of `i32::MIN`
without overflowing. The out-of-range offset then produces the normal
`line number out of range` error, matching GNU (and uutils' own default
release build).

## Test

Adds `test_up_to_match_negative_offset_min_i32` and
`test_skip_to_match_negative_offset_min_i32`, covering both the `/regex/`
and `%regex%` offset forms. They panic before the fix (the test build has
overflow-checks enabled) and pass after.
