### PR TITLE
split: fix add-overflow in suffix-length calculation

### DIFF
--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -199,7 +199,8 @@ impl Suffix {
         // Auto pre-calculate new suffix length (auto-width) if necessary
         if let Strategy::Number(number_type) = strategy {
             let chunks = number_type.num_chunks();
-            let required_length = ((start as u64 + chunks) as f64)
+            // u128 keeps the sum from overflowing when start is near usize::MAX.
+            let required_length = ((start as u128 + chunks as u128) as f64)
                 .log(stype.radix() as f64)
                 .ceil() as usize;
 

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -943,6 +943,47 @@ fn test_suffix_length_req() {
 }
 
 #[test]
+fn test_numeric_suffix_huge_start_requires_suffix_length() {
+    new_ucmd!()
+        .args(&[
+            "-n",
+            "5",
+            "--numeric-suffixes=18446744073709551615",
+            "asciilowercase.txt",
+        ])
+        .fails()
+        .stderr_only("split: the suffix length needs to be at least 20\n");
+}
+
+#[test]
+fn test_hex_suffix_huge_start_requires_suffix_length() {
+    new_ucmd!()
+        .args(&[
+            "-n",
+            "5",
+            "--hex-suffixes=ffffffffffffffff",
+            "asciilowercase.txt",
+        ])
+        .fails()
+        .stderr_only("split: the suffix length needs to be at least 16\n");
+}
+
+#[test]
+fn test_numeric_suffix_huge_chunk_count_requires_suffix_length() {
+    new_ucmd!()
+        .args(&[
+            "-n",
+            "18446744073709551615",
+            "--numeric-suffixes=5",
+            "-a",
+            "2",
+            "asciilowercase.txt",
+        ])
+        .fails()
+        .stderr_only("split: the suffix length needs to be at least 20\n");
+}
+
+#[test]
 fn test_large_suffix_length_is_rejected() {
     new_ucmd!()
         .args(&["-a", "66542562175252"])


### PR DESCRIPTION
Fixes #13749

`split` auto-computes the suffix length from the suffix start value
(`--numeric-suffixes=N` / `--hex-suffixes=N`) and the chunk count (`-n`).
`Suffix::from` did this as `start as u64 + chunks`, with no guard against
the sum exceeding `u64::MAX`. A start near `u64::MAX`, or a chunk count
near `u64::MAX` with a nonzero start, overflows the add and panics with
`attempt to add with overflow` under overflow-checks (exit 134).

## Fix

Widen the sum to `u128` so it can't overflow. The value only feeds a `log`
for the digit count, so results are identical for every in-range input,
and the out-of-range case now reports the normal
`the suffix length needs to be at least N` error instead of aborting —
matching GNU (which accepts such a start only once `-a` is large enough).

## Tests

Adds three regression tests covering both operands and both radixes: a huge
decimal start, a huge hex start, and a huge `-n` chunk count. Each panics
before the fix (the test build enables overflow-checks) and passes after.
