### PR TITLE
head: fix flaky `test_zero_bytes_with_suffix`

### DIFF
--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -225,19 +225,25 @@ fn test_negative_zero_bytes() {
 
 #[test]
 fn test_zero_bytes_with_suffix() {
+    // --bytes=0K makes head stop before draining stdin, so the harness's write may fail
+    // with EPIPE. That is expected and must not fail the test.
+    //
     // "0K" must be 0 bytes, not 1KiB (bare suffix parses as 1)
     new_ucmd!()
         .args(&["--bytes=0K"])
+        .ignore_stdin_write_error()
         .pipe_in("qwerty")
         .succeeds()
         .no_output();
     new_ucmd!()
         .args(&["--bytes=00K"])
+        .ignore_stdin_write_error()
         .pipe_in("qwerty")
         .succeeds()
         .no_output();
     new_ucmd!()
         .args(&["--bytes=+0K"])
+        .ignore_stdin_write_error()
         .pipe_in("qwerty")
         .succeeds()
         .no_output();


### PR DESCRIPTION
I noticed that the recently added `test_zero_bytes_with_suffix` fails from time to time in the CI with "failed to write to stdin of child: Broken pipe (os error 32)" (see, for example, https://github.com/uutils/coreutils/actions/runs/31048509400/job/92450775585).

This PR is an attempt to fix the issue, inspired by https://github.com/uutils/grep/pull/94

Fixes https://github.com/uutils/coreutils/issues/13771