### PR TITLE
pr: fix overflow issues

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1340,7 +1340,9 @@ fn write_page(
             writer.write_all(line_separator)?;
         }
     }
-    writer.write_all(page_separator)?;
+    if options.display_header_and_trailer || options.form_feed_used {
+        writer.write_all(page_separator)?;
+    }
     writer.flush()?;
     Ok(())
 }
@@ -1504,7 +1506,7 @@ fn write_columns(
                     .as_bytes(),
             )?;
         }
-        if not_found_break && feed_line_present {
+        if not_found_break && (feed_line_present || !options.display_header_and_trailer) {
             break;
         }
         writer.write_all(line_separator)?;

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -36,6 +36,7 @@ const DEFAULT_COLUMN_WIDTH_WITH_S_OPTION: usize = 512;
 const DEFAULT_COLUMN_SEPARATOR: &char = &TAB;
 const FF: u8 = 0x0C_u8;
 const NL: u8 = b'\n';
+const MAX_INT_VALUE: usize = i32::MAX as usize;
 
 mod options {
     pub const HEADER: &str = "header";
@@ -524,7 +525,18 @@ fn print_error(matches: &ArgMatches, err: &PrError) {
     }
 }
 
-fn parse_usize(matches: &ArgMatches, opt: &str) -> Option<Result<usize, PrError>> {
+fn value_too_large(option_message: &str, raw: &str) -> String {
+    format!(
+        "{option_message}: {}: Value too large for defined data type",
+        raw.quote()
+    )
+}
+
+fn parse_usize(
+    matches: &ArgMatches,
+    opt: &str,
+    too_large_error_message: &str,
+) -> Option<Result<usize, PrError>> {
     let from_parse_error_to_pr_error = |value_to_parse: (String, String)| {
         let i = value_to_parse.0;
         let option = value_to_parse.1;
@@ -536,6 +548,16 @@ fn parse_usize(matches: &ArgMatches, opt: &str) -> Option<Result<usize, PrError>
         .get_one::<String>(opt)
         .map(|i| (i.to_owned(), format!("-{opt}")))
         .map(from_parse_error_to_pr_error)
+        .map(|result| match result {
+            Ok(n) if n <= MAX_INT_VALUE => Ok(n),
+            Ok(_) => {
+                let raw = matches.get_one::<String>(opt).map_or("", String::as_str);
+                Err(PrError::EncounteredErrors {
+                    msg: value_too_large(too_large_error_message, raw),
+                })
+            }
+            Err(e) => Err(e),
+        })
 }
 
 fn get_date_format(matches: &ArgMatches) -> String {
@@ -598,8 +620,12 @@ fn build_options(
         .to_string();
 
     let default_first_number = NumberingMode::default().first_number;
-    let first_number =
-        parse_usize(matches, options::FIRST_LINE_NUMBER).unwrap_or(Ok(default_first_number))?;
+    let first_number = parse_usize(
+        matches,
+        options::FIRST_LINE_NUMBER,
+        "'-N NUMBER' invalid starting line number",
+    )
+    .unwrap_or(Ok(default_first_number))?;
 
     let number = matches
         .get_one::<String>(options::NUMBER_LINES)
@@ -608,6 +634,17 @@ fn build_options(
                 msg: format!(
                     "{}\n{}",
                     translate!("pr-error-invalid-number-argument", "arg" => arg),
+                    translate!("pr-try-help-message")
+                ),
+            };
+
+            let invalid_too_large = |arg: &str| PrError::EncounteredErrors {
+                msg: format!(
+                    "{}\n{}",
+                    value_too_large(
+                        "'-n' extra characters or invalid number in the argument",
+                        arg
+                    ),
                     translate!("pr-try-help-message")
                 ),
             };
@@ -624,12 +661,18 @@ fn build_options(
             };
 
             let width = match parse_result {
+                Ok(res) if res > MAX_INT_VALUE => return Err(invalid_too_large(i)),
                 Ok(res) => res,
-                Err(_) => i
-                    .get(1..)
-                    .unwrap_or_default()
-                    .parse::<usize>()
-                    .unwrap_or(NumberingMode::default().width),
+                Err(_) => {
+                    let digits = i.get(1..).unwrap_or_default();
+                    match digits.parse::<usize>() {
+                        Ok(res) if res > MAX_INT_VALUE => {
+                            return Err(invalid_too_large(digits));
+                        }
+                        Ok(res) => res,
+                        Err(_) => NumberingMode::default().width,
+                    }
+                }
             };
 
             Ok(NumberingMode {
@@ -804,8 +847,12 @@ fn build_options(
         LINES_PER_PAGE
     };
 
-    let page_length =
-        parse_usize(matches, options::PAGE_LENGTH).unwrap_or(Ok(default_lines_per_page))?;
+    let page_length = parse_usize(
+        matches,
+        options::PAGE_LENGTH,
+        "'-l PAGE_LENGTH' invalid number of lines",
+    )
+    .unwrap_or(Ok(default_lines_per_page))?;
 
     if page_length == 0 {
         return Err(PrError::EncounteredErrors {
@@ -848,8 +895,12 @@ fn build_options(
         DEFAULT_COLUMN_WIDTH
     };
 
-    let column_width =
-        parse_usize(matches, options::COLUMN_WIDTH).unwrap_or(Ok(default_column_width))?;
+    let column_width = parse_usize(
+        matches,
+        options::COLUMN_WIDTH,
+        "'-w PAGE_WIDTH' invalid number of characters",
+    )
+    .unwrap_or(Ok(default_column_width))?;
 
     if column_width == 0 {
         return Err(PrError::EncounteredErrors {
@@ -860,7 +911,11 @@ fn build_options(
     let page_width = if matches.get_flag(options::JOIN_LINES) {
         None
     } else {
-        match parse_usize(matches, options::PAGE_WIDTH) {
+        match parse_usize(
+            matches,
+            options::PAGE_WIDTH,
+            "'-W PAGE_WIDTH' invalid number of characters",
+        ) {
             Some(res) => Some(res?),
             None => None,
         }
@@ -872,13 +927,18 @@ fn build_options(
         });
     }
 
-    let res = operands.column.as_deref().map(|unparsed_num| {
-        unparsed_num
-            .parse::<usize>()
-            .map_err(|_e| PrError::EncounteredErrors {
+    let res = operands
+        .column
+        .as_deref()
+        .map(|unparsed_num| match unparsed_num.parse::<usize>() {
+            Ok(n) if n > MAX_INT_VALUE => Err(PrError::EncounteredErrors {
+                msg: value_too_large("invalid number of columns", unparsed_num),
+            }),
+            Ok(n) => Ok(n),
+            Err(_e) => Err(PrError::EncounteredErrors {
                 msg: format!("invalid {} argument {}", "-", unparsed_num.quote()),
-            })
-    });
+            }),
+        });
     let start_column_option = match res {
         Some(Ok(0)) => {
             return Err(PrError::EncounteredErrors {
@@ -891,15 +951,16 @@ fn build_options(
 
     // --column has more priority than -column
 
-    let column_option_value = match parse_usize(matches, options::COLUMN) {
-        Some(Ok(0)) => {
-            return Err(PrError::EncounteredErrors {
-                msg: "invalid --column argument '0'".to_string(),
-            });
-        }
-        Some(res) => Some(res?),
-        None => start_column_option,
-    };
+    let column_option_value =
+        match parse_usize(matches, options::COLUMN, "invalid number of columns") {
+            Some(Ok(0)) => {
+                return Err(PrError::EncounteredErrors {
+                    msg: "invalid --column argument '0'".to_string(),
+                });
+            }
+            Some(res) => Some(res?),
+            None => start_column_option,
+        };
 
     let column_mode_options = column_option_value.map(|columns| ColumnModeOptions {
         columns,
@@ -916,10 +977,7 @@ fn build_options(
             Ok(n) if n >= 0 => n as usize,
             Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
                 return Err(PrError::EncounteredErrors {
-                    msg: format!(
-                        "'-o MARGIN' invalid line offset: {}: Value too large for defined data type",
-                        raw.quote()
-                    ),
+                    msg: value_too_large("'-o MARGIN' invalid line offset", raw),
                 });
             }
             _ => {
@@ -1470,7 +1528,7 @@ fn get_line_for_printing(
         "{}{sep}",
         line_width
             .map(|i| {
-                let min_width = (i - (columns - 1)) / columns;
+                let min_width = i.saturating_sub(columns - 1) / columns;
                 if display_length < min_width {
                     for _i in 0..(min_width - display_length) {
                         complete_line.push(' ');
@@ -1490,12 +1548,12 @@ fn get_formatted_line_number(opts: &OutputOptions, line_number: usize, index: us
         let line_str = line_number.to_string();
         let num_opt = opts.number.as_ref().unwrap();
         let width = num_opt.width;
-        let separator = &num_opt.separator;
-        if line_str.len() >= width {
-            format!("{:>width$}{separator}", &line_str[line_str.len() - width..])
-        } else {
-            format!("{line_str:>width$}{separator}")
-        }
+        let digits = &line_str[line_str.len().saturating_sub(width)..];
+        let mut output = String::with_capacity(width + num_opt.separator.len());
+        output.extend(std::iter::repeat_n(' ', width - digits.len()));
+        output.push_str(digits);
+        output.push_str(&num_opt.separator);
+        output
     } else {
         String::new()
     }
@@ -1529,10 +1587,13 @@ fn header_content(options: &OutputOptions, page: usize) -> Vec<String> {
         let padding_before_filename = (space_for_filename - filename_len) / 2;
         let padding_after_filename = space_for_filename - filename_len - padding_before_filename;
 
-        format!(
-            "{date_part}{:padding_before_filename$}{filename}{:padding_after_filename$}{page_part}",
-            "", ""
-        )
+        let mut line = String::with_capacity(total_width);
+        line.push_str(date_part);
+        line.extend(std::iter::repeat_n(' ', padding_before_filename));
+        line.push_str(filename);
+        line.extend(std::iter::repeat_n(' ', padding_after_filename));
+        line.push_str(&page_part);
+        line
     } else {
         // If content is too long, just use single spaces
         format!("{date_part} {filename} {page_part}")

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -537,27 +537,26 @@ fn parse_usize(
     opt: &str,
     too_large_error_message: &str,
 ) -> Option<Result<usize, PrError>> {
-    let from_parse_error_to_pr_error = |value_to_parse: (String, String)| {
-        let i = value_to_parse.0;
-        let option = value_to_parse.1;
-        i.parse().map_err(|_e| PrError::EncounteredErrors {
-            msg: format!("invalid -{option} argument {}", i.quote()),
-        })
-    };
-    matches
-        .get_one::<String>(opt)
-        .map(|i| (i.to_owned(), format!("-{opt}")))
-        .map(from_parse_error_to_pr_error)
-        .map(|result| match result {
+    matches.get_one::<String>(opt).map(|i| {
+        let raw = i.as_str();
+        match raw.parse::<usize>() {
             Ok(n) if n <= MAX_INT_VALUE => Ok(n),
-            Ok(_) => {
-                let raw = matches.get_one::<String>(opt).map_or("", String::as_str);
+            Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
                 Err(PrError::EncounteredErrors {
                     msg: value_too_large(too_large_error_message, raw),
                 })
             }
-            Err(e) => Err(e),
-        })
+            Ok(_) => Err(PrError::EncounteredErrors {
+                msg: value_too_large(too_large_error_message, raw),
+            }),
+            Err(_) => {
+                let option = format!("-{opt}");
+                Err(PrError::EncounteredErrors {
+                    msg: format!("invalid -{option} argument {}", raw.quote()),
+                })
+            }
+        }
+    })
 }
 
 fn get_date_format(matches: &ArgMatches) -> String {
@@ -651,6 +650,13 @@ fn build_options(
 
             let parse_result = i.parse::<usize>();
 
+            if matches!(
+                &parse_result,
+                Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow)
+            ) {
+                return Err(invalid_too_large(i));
+            }
+
             let separator = if parse_result.is_err() {
                 match i.chars().next() {
                     Some(c) if c.is_ascii() => c.to_string(),
@@ -670,6 +676,9 @@ fn build_options(
                             return Err(invalid_too_large(digits));
                         }
                         Ok(res) => res,
+                        Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
+                            return Err(invalid_too_large(digits));
+                        }
                         Err(_) => NumberingMode::default().width,
                     }
                 }
@@ -935,6 +944,11 @@ fn build_options(
                 msg: value_too_large("invalid number of columns", unparsed_num),
             }),
             Ok(n) => Ok(n),
+            Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
+                Err(PrError::EncounteredErrors {
+                    msg: value_too_large("invalid number of columns", unparsed_num),
+                })
+            }
             Err(_e) => Err(PrError::EncounteredErrors {
                 msg: format!("invalid {} argument {}", "-", unparsed_num.quote()),
             }),

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -541,14 +541,14 @@ fn parse_usize(
         let raw = i.as_str();
         match raw.parse::<usize>() {
             Ok(n) if n <= MAX_INT_VALUE => Ok(n),
+            Ok(_) => Err(PrError::EncounteredErrors {
+                msg: value_too_large(too_large_error_message, raw),
+            }),
             Err(e) if matches!(e.kind(), IntErrorKind::PosOverflow) => {
                 Err(PrError::EncounteredErrors {
                     msg: value_too_large(too_large_error_message, raw),
                 })
             }
-            Ok(_) => Err(PrError::EncounteredErrors {
-                msg: value_too_large(too_large_error_message, raw),
-            }),
             Err(_) => {
                 let option = format!("-{opt}");
                 Err(PrError::EncounteredErrors {

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -526,12 +526,13 @@ fn test_column_count_too_large() {
 fn test_large_number_width_does_not_panic() {
     // Widths above u16::MAX used to panic with "Formatting argument out
     // of range"; GNU pads the number out to the full width instead.
-    // The page is padded to its full length, hence the trailing newlines.
+    // With -t (no page headers/footers) GNU emits no page padding, so the
+    // output is exactly the numbered line.
     new_ucmd!()
         .args(&["-t", "-n", "70000"])
         .pipe_in("x\n")
         .succeeds()
-        .stdout_is(format!("{}1\tx\n{}", " ".repeat(69999), "\n".repeat(56)));
+        .stdout_is(format!("{}1\tx\n", " ".repeat(69999)));
 }
 
 #[test]

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -448,6 +448,101 @@ fn test_offset_too_large() {
         ));
 }
 
+#[test]
+fn test_start_line_number_too_large() {
+    let arg = "18446744073709551615";
+    new_ucmd!()
+        .args(&["-n", "-N", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-N NUMBER' invalid starting line number: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_page_length_too_large() {
+    let arg = "9999999999999999999";
+    new_ucmd!()
+        .args(&["-l", arg, "-3"])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-l PAGE_LENGTH' invalid number of lines: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_number_width_too_large() {
+    let arg = "18446744073709551615";
+    new_ucmd!()
+        .args(&["-n", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-n' extra characters or invalid number in the argument: '{arg}': Value too large for defined data type\nTry 'pr --help' for more information.\n"
+        ));
+}
+
+#[test]
+fn test_page_width_too_large() {
+    let arg = "18446744073709551615";
+    new_ucmd!()
+        .args(&["-W", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-W PAGE_WIDTH' invalid number of characters: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_column_width_too_large() {
+    let arg = "18446744073709551615";
+    new_ucmd!()
+        .args(&["-w", arg, "-2"])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: '-w PAGE_WIDTH' invalid number of characters: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_column_count_too_large() {
+    let arg = "9999999999999999999";
+    new_ucmd!()
+        .args(&["--column", arg])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: invalid number of columns: '{arg}': Value too large for defined data type\n"
+        ));
+
+    // The legacy -COLUMN operand form behaves the same.
+    new_ucmd!()
+        .args(&[format!("-{arg}")])
+        .fails_with_code(1)
+        .stderr_is(format!(
+            "pr: invalid number of columns: '{arg}': Value too large for defined data type\n"
+        ));
+}
+
+#[test]
+fn test_large_number_width_does_not_panic() {
+    // Widths above u16::MAX used to panic with "Formatting argument out
+    // of range"; GNU pads the number out to the full width instead.
+    // The page is padded to its full length, hence the trailing newlines.
+    new_ucmd!()
+        .args(&["-t", "-n", "70000"])
+        .pipe_in("x\n")
+        .succeeds()
+        .stdout_is(format!("{}1\tx\n{}", " ".repeat(69999), "\n".repeat(56)));
+}
+
+#[test]
+fn test_large_page_width_does_not_panic() {
+    // A page width above u16::MAX used to panic in the header layout.
+    new_ucmd!()
+        .args(&["-W", "200000"])
+        .pipe_in("x\n")
+        .succeeds();
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn test_offset_large_value_does_not_abort_under_memory_limit() {

--- a/tests/fixtures/pr/test_one_page_no_ht.log.expected
+++ b/tests/fixtures/pr/test_one_page_no_ht.log.expected
@@ -54,4 +54,3 @@ Mon Dec 10 11:42:59.155 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
 Mon Dec 10 11:42:59.157 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
 Mon Dec 10 11:42:59.159 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
 Mon Dec 10 11:42:59.352 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
-

--- a/tests/fixtures/pr/test_page_length1.log.expected
+++ b/tests/fixtures/pr/test_page_length1.log.expected
@@ -3,10 +3,8 @@
     8	Mon Dec 10 11:42:56.856 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
     9	Mon Dec 10 11:42:57.002 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
    10	Mon Dec 10 11:42:57.003 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
-
    11	Mon Dec 10 11:42:57.003 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
    12	Mon Dec 10 11:42:57.152 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
    13	Mon Dec 10 11:42:57.154 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: pppConnectionState 0
    14	Mon Dec 10 11:42:57.154 Info: <Wi-Fi Menu Extra[335]> -[AirPortExtraImplementation processAirPortStateChanges]: old state=4 bars, new state=4 bars
    15	Mon Dec 10 11:42:57.302 Info: <Wi-Fi Menu Extra[335]> 802.1X changed
-


### PR DESCRIPTION
## Fixes

Fixes #12996
Fixes #13735
Fixes #13734

## Description

The `parse_usize` function could panic, when `overflow-checks` is enabled. Now it correctly handles overflow cases. Also all error messages are now returned correctly. Also added tests
