### PR TITLE
parse_size: avoid overflow when applying large percent-of-memory sizes

### DIFF
--- a/src/uucore/src/lib/features/parser/parse_size.rs
+++ b/src/uucore/src/lib/features/parser/parse_size.rs
@@ -255,7 +255,9 @@ impl<'parser> Parser<'parser> {
         if unit == "%" {
             let number: u128 = Self::parse_number(&numeric_string, 10, size)?;
             return match total_physical_memory() {
-                Ok(total) => Ok((number / 100) * total),
+                Ok(total) => (number / 100)
+                    .checked_mul(total)
+                    .ok_or_else(|| ParseSizeError::size_too_big(size)),
                 Err(_) => Err(ParseSizeError::PhysicalMem(size.to_string())),
             };
         }
@@ -861,5 +863,9 @@ mod tests {
         assert!(parse_size_u64("-1%").is_err());
         assert!(parse_size_u64("1.0%").is_err());
         assert!(parse_size_u64("0x1%").is_err());
+
+        // A percentage whose product with total physical memory overflows u128
+        // should return an error instead of panicking.
+        assert!(parse_size_u128("9223372036854775808000000000000%").is_err());
     }
 }


### PR DESCRIPTION
The shared size parser computes `(number / 100) * total_physical_memory` as an unchecked `u128` multiply. A percentage large enough to overflow the product panics under `-C overflow-checks` (exit 134), as reported in #13736.

Use `checked_mul` and return `SizeTooBig` when the product does not fit in `u128`. I also added a regression test for the overflowing case.

I used Claude Code to assist with this change and reviewed the diff manually.
