### PR TITLE
mkfifo: fix build where mode_t is not u32

### DIFF
--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use clap::{Arg, ArgAction, Command, value_parser};
-use rustix::fs::Mode;
+use rustix::fs::{Mode, RawMode};
 use rustix::process::umask;
 use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, strip_errno};
@@ -69,7 +69,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // attacker could use to swap the FIFO for a symlink between
         // mkfifo and chmod (issue #10020).
         let prev_umask = umask(Mode::empty());
-        let mkfifo_result = create_fifo(f.as_str(), mode);
+        let mkfifo_result = create_fifo(f.as_str(), mode as RawMode);
         umask(prev_umask);
 
         if let Err(e) = mkfifo_result {
@@ -141,13 +141,13 @@ pub fn uu_app() -> Command {
 // libc's path-based `mkfifo` there. Both rely on the caller having cleared
 // the umask so the requested mode is applied atomically (see issue #10020).
 #[cfg(not(target_vendor = "apple"))]
-fn create_fifo(path: &str, mode: u32) -> std::io::Result<()> {
+fn create_fifo(path: &str, mode: RawMode) -> std::io::Result<()> {
     use rustix::fs;
     fs::mkfifoat(fs::CWD, path, Mode::from_bits_truncate(mode)).map_err(Into::into)
 }
 
 #[cfg(target_vendor = "apple")]
-fn create_fifo(path: &str, mode: u32) -> std::io::Result<()> {
+fn create_fifo(path: &str, mode: RawMode) -> std::io::Result<()> {
     use std::ffi::CString;
     let c_path =
         CString::new(path).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;


### PR DESCRIPTION
`rustix::fs::Mode` is a bitflags over `rustix::fs::RawMode`, which aliases `libc::mode_t`. That is `u32` on Linux but `u16` on the BSDs, so handing the `u32` mode straight to `Mode::from_bits_truncate()` fails to compile there:

    error[E0308]: mismatched types
       --> src/uu/mkfifo/src/mkfifo.rs:146:50
        |
    146 |     mkfifoat(CWD, path, Mode::from_bits_truncate(mode))
        |                         ------------------------ ^^^^ expected `u16`, found `u32`

Cast to `RawMode` first, which is a no-op on Linux and matches what `mkdir` already does in src/uu/mkdir/src/mkdir.rs.