### PR TITLE
nl: continue processing files after error

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -395,9 +395,17 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
     loop {
         line.clear();
         // reads up to and including b'\n'; returns 0 on EOF
-        let n = reader
-            .read_until(b'\n', &mut line)
-            .map_err_context(|| translate!("nl-error-could-not-read-line"))?;
+        let n = match reader.read_until(b'\n', &mut line) {
+            Ok(bytes_read) => bytes_read,
+            Err(err) => {
+                show_error!(
+                    "{}",
+                    err.map_err_context(|| translate!("nl-error-could-not-read-line"))
+                );
+                set_exit_code(1);
+                break;
+            }
+        };
         if n == 0 {
             break;
         }

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -930,3 +930,13 @@ fn test_repeated_section_delimiter_flag() {
         .succeeds()
         .stdout_is("\n       a\n       b\n       c\n");
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_no_skip_after_error() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f", "hello");
+    ucmd.args(&["/proc/self/mem", "f"])
+        .fails()
+        .stdout_is("     1\thello\n");
+}


### PR DESCRIPTION
Fixes #13126.

When nl encounters an error with one file, it stops execution and skips the rest of files to process.

The fix captures the error, shows it and continues the `nl` loop on the other arguments.