### PR TITLE
ci: remove `brew install coreutils`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -545,9 +545,6 @@ jobs:
           ;;
         esac
         case '${{ matrix.job.os }}' in
-          macos-latest) brew install coreutils ;; # needed for testing
-        esac
-        case '${{ matrix.job.os }}' in
           ubuntu-*)
             # selinux and systemd headers needed to build tests
             sudo apt-get -y update
@@ -766,9 +763,6 @@ jobs:
       shell: bash
       run: |
         ## Install/setup prerequisites
-        case '${{ matrix.job.os }}' in
-          macos-latest) brew install coreutils ;; # needed for testing
-        esac
 
         case '${{ matrix.job.os }}' in
           ubuntu-latest)

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -69,10 +69,6 @@ jobs:
             sudo locale-gen --keep-existing hu_HU.UTF-8 # Hungary
             sudo update-locale
           ;;
-          macos-*)
-            # needed for testing
-            brew install coreutils
-          ;;
         esac
     - name: Test l10n functionality
       shell: bash


### PR DESCRIPTION
A test to see whether `brew install coreutils` is still needed.

With some luck it fixes #13772