### PR TITLE
tr: replace rustix socketpair with filedescriptor in test_stdin_is_socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "ctor",
+ "filedescriptor",
  "filetime",
  "fluent-syntax",
  "glob",
@@ -1007,12 +1008,11 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 [[package]]
 name = "filedescriptor"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+source = "git+https://github.com/wezterm/wezterm.git?branch=main#08e5e0afc6007567d3d131bc2ec1382423c0d2da"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime foldhash serde gethostid kqueue libcrypto libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner getauxval
+# spell-checker:ignore (libs) bigdecimal datetime filedescriptor foldhash serde gethostid kqueue libcrypto libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner getauxval
 
 [package]
 name = "coreutils"
@@ -433,6 +433,7 @@ data-encoding-macro = "0.1.15"
 divan = { package = "codspeed-divan-compat", version = "5.0.0" }
 dns-lookup = { version = "4.0.0" }
 dunce = "1.0.4"
+filedescriptor = "0.8.3"
 filetime = "0.2.29"
 foldhash = "0.2.0"
 fs_extra = "1.3.0"
@@ -594,6 +595,7 @@ ignored = ["clap", "fluent", "libstdbuf"]
 clap.workspace = true
 clap_complete = { workspace = true, optional = true }
 clap_mangen = { workspace = true, optional = true }
+filedescriptor.workspace = true
 fluent-syntax = { workspace = true, optional = true }
 itertools.workspace = true
 jiff = { workspace = true, optional = true }
@@ -771,6 +773,9 @@ phf_codegen.workspace = true
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+filedescriptor = { git = "https://github.com/wezterm/wezterm.git", branch = "main" }
 
 [[bin]]
 name = "coreutils"

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1588,17 +1588,13 @@ fn test_broken_pipe_no_error() {
 fn test_stdin_is_socket() {
     use std::io::Write as _;
 
-    let (fd1, fd2) = rustix::net::socketpair(
-        rustix::net::AddressFamily::UNIX,
-        rustix::net::SocketType::STREAM,
-        rustix::net::SocketFlags::empty(),
-        None,
-    )
-    .unwrap();
-    std::fs::File::from(fd1).write_all(b"::").unwrap();
+    let (mut writer, reader) = filedescriptor::socketpair().unwrap();
+    writer.write_all(b"::").unwrap();
+    drop(writer);
+
     new_ucmd!()
         .args(&[":", ";"])
-        .set_stdin(fd2)
+        .set_stdin(reader)
         .succeeds()
         .stdout_is(";;");
 }


### PR DESCRIPTION
WIP: Depends on a new `filedescriptor` crate release to remove the `patch.crates-io` override.