### PR TITLE
Introduce ariadne to provide better error messages + chmod support

### DIFF
--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -84,6 +84,7 @@ powi
 println
 repr
 rfind
+rsplit
 struct
 structs
 substr

--- a/.vscode/cspell.dictionaries/workspace.wordlist.txt
+++ b/.vscode/cspell.dictionaries/workspace.wordlist.txt
@@ -4,6 +4,7 @@ doctest
 
 # * crates
 aho-corasick
+ariadne
 blake2b_simd
 rustix
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width 0.2.2",
+ "yansi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1281,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.55",
+ "zerocopy 0.8.56",
 ]
 
 [[package]]
@@ -1290,6 +1300,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hex"
@@ -1613,12 +1629,12 @@ checksum = "2e0ee79a0bb29772465234bfbad6ea04fbc5220bef9fa4f318cc53eb8897070e"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2358,7 +2374,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.55",
+ "zerocopy 0.8.56",
 ]
 
 [[package]]
@@ -4546,6 +4562,7 @@ dependencies = [
 name = "uucore"
 version = "0.10.0"
 dependencies = [
+ "ariadne",
  "base64-simd",
  "bigdecimal",
  "blake2b_simd",
@@ -5071,11 +5088,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
- "zerocopy-derive 0.8.55",
+ "zerocopy-derive 0.8.56",
 ]
 
 [[package]]
@@ -5091,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -397,6 +397,7 @@ version = "0.10.0"
 
 [workspace.dependencies]
 ansi-width = "0.1.0"
+ariadne = "0.6.0"
 base64-simd = "0.8"
 bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"

--- a/deny.toml
+++ b/deny.toml
@@ -88,6 +88,8 @@ skip = [
   { name = "itertools", version = "0.14.0" },
   # ordered-multimap
   { name = "hashbrown", version = "0.14.5" },
+  # lru (via num-prime), string-interner
+  { name = "hashbrown", version = "0.16.1" },
   # cexpr (via bindgen)
   { name = "nom", version = "7.1.3" },
   # const-random-macro, rand_core

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2057,7 @@ dependencies = [
 name = "uucore"
 version = "0.10.0"
 dependencies = [
+ "ariadne",
  "base64-simd",
  "bigdecimal",
  "blake2b_simd",
@@ -2311,6 +2322,12 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/src/uu/chmod/Cargo.toml
+++ b/src/uu/chmod/Cargo.toml
@@ -18,7 +18,13 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 thiserror = { workspace = true }
-uucore = { workspace = true, features = ["entries", "fs", "mode", "perms"] }
+uucore = { workspace = true, features = [
+  "diagnostics",
+  "entries",
+  "fs",
+  "mode",
+  "perms",
+] }
 fluent = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]

--- a/src/uu/chmod/locales/en-US.ftl
+++ b/src/uu/chmod/locales/en-US.ftl
@@ -32,3 +32,9 @@ chmod-verbose-neither-changed = neither symbolic link {$file} nor referent has b
 chmod-verbose-mode-retained = mode of {$file} retained as {$mode_octal} ({$mode_display})
 chmod-verbose-failed-change = failed to change mode of file {$file} from {$old_mode} ({$old_mode_display}) to {$new_mode} ({$new_mode_display})
 chmod-verbose-mode-changed = mode of {$file} changed from {$old_mode} ({$old_mode_display}) to {$new_mode} ({$new_mode_display})
+
+# Diagnostic labels: what the caret points at in a mode
+chmod-diag-label-invalid-operator = expected +, - or = here
+chmod-diag-label-missing-operator = this clause says who, but not what to change
+chmod-diag-label-invalid-number = not an octal mode
+chmod-diag-help-mode-syntax = a mode is either octal, as in 644, or clauses such as u+rwx,go-w

--- a/src/uu/chmod/locales/fr-FR.ftl
+++ b/src/uu/chmod/locales/fr-FR.ftl
@@ -34,3 +34,9 @@ chmod-verbose-neither-changed = ni le lien symbolique {$file} ni la référence 
 chmod-verbose-mode-retained = mode de {$file} conservé comme {$mode_octal} ({$mode_display})
 chmod-verbose-failed-change = échec du changement de mode du fichier {$file} de {$old_mode} ({$old_mode_display}) vers {$new_mode} ({$new_mode_display})
 chmod-verbose-mode-changed = mode de {$file} changé de {$old_mode} ({$old_mode_display}) vers {$new_mode} ({$new_mode_display})
+
+# Étiquettes de diagnostic : ce que le caret désigne dans un mode
+chmod-diag-label-invalid-operator = +, - ou = attendu ici
+chmod-diag-label-missing-operator = cette clause indique qui, mais pas quoi changer
+chmod-diag-label-invalid-number = n'est pas un mode octal
+chmod-diag-help-mode-syntax = un mode est soit octal, comme 644, soit des clauses comme u+rwx,go-w

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -48,6 +48,8 @@ enum ChmodError {
 
 impl UError for ChmodError {}
 
+mod diagnostics;
+
 mod options {
     pub const HELP: &str = "help";
     pub const CHANGES: &str = "changes";
@@ -118,7 +120,11 @@ fn extract_negative_modes(mut args: impl uucore::Args) -> (Option<String>, Vec<O
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let (parsed_cmode, args) = extract_negative_modes(args.skip(1)); // skip binary name
+    let args: Vec<OsString> = args.skip(1).collect(); // skip binary name
+    // Kept for the caret in mode diagnostics, which needs the mode as typed,
+    // before `extract_negative_modes` replaces a negative mode by a pseudo one.
+    let mode_args = uucore::diagnostics::enabled().then(|| args.clone());
+    let (parsed_cmode, args) = extract_negative_modes(args.into_iter());
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let changes = matches.get_flag(options::CHANGES);
@@ -175,6 +181,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         cmode,
         traverse_symlinks,
         dereference,
+        args: mode_args,
     };
 
     chmoder.chmod(&files)
@@ -272,6 +279,8 @@ struct Chmoder {
     cmode: Option<String>,
     traverse_symlinks: TraverseSymlinks,
     dereference: bool,
+    /// The arguments as typed, kept only when a diagnostic may be rendered.
+    args: Option<Vec<OsString>>,
 }
 
 impl Chmoder {
@@ -285,7 +294,13 @@ impl Chmoder {
             let mut new_mode = current_mode;
             let mut naively_expected_new_mode = current_mode;
 
+            // Where the clause being parsed starts inside `cmode_unwrapped`, so
+            // that an error can be pointed back at it.
+            let mut offset = 0;
             for mode in cmode_unwrapped.split(',') {
+                let clause_start = offset;
+                offset += mode.len() + 1; // past the clause and its comma
+
                 let result = if mode.chars().any(|c| c.is_ascii_digit()) {
                     mode::parse_numeric(new_mode, mode, is_dir).map(|v| (v, v))
                 } else {
@@ -303,12 +318,17 @@ impl Chmoder {
                         new_mode = mode;
                         naively_expected_new_mode = naive_mode;
                     }
-                    Err(f) => {
-                        return if self.quiet {
-                            Err(ExitCode::new(1))
-                        } else {
-                            Err(USimpleError::new(1, f.to_string()))
-                        };
+                    Err(error) => {
+                        if self.quiet {
+                            return Err(ExitCode::new(1));
+                        }
+                        if let Some(args) = &self.args
+                            && diagnostics::render(args, &cmode_unwrapped, clause_start, &error)
+                        {
+                            // The diagnostic is already on stderr; exit quietly.
+                            return Err(ExitCode::new(1));
+                        }
+                        return Err(USimpleError::new(1, error.to_string()));
                     }
                 }
             }

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -307,7 +307,7 @@ impl Chmoder {
                         return if self.quiet {
                             Err(ExitCode::new(1))
                         } else {
-                            Err(USimpleError::new(1, f))
+                            Err(USimpleError::new(1, f.to_string()))
                         };
                     }
                 }

--- a/src/uu/chmod/src/diagnostics.rs
+++ b/src/uu/chmod/src/diagnostics.rs
@@ -1,0 +1,38 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Maps a [`ModeError`] onto the clause of the mode it came from, so that
+//! [`uucore::diagnostics`] can render it with a caret.
+
+use std::ffi::OsString;
+
+use uucore::diagnostics::Snapshot;
+use uucore::mode::{ModeError, ModeErrorKind};
+use uucore::translate;
+
+/// Render `err` against `args`.
+///
+/// `mode` is the whole mode operand and `clause_start` where the clause that
+/// failed begins inside it, since a mode is parsed one comma-separated clause
+/// at a time.
+///
+/// Returns `false` when the mode cannot be found among the arguments, in which
+/// case the caller should fall back to the plain one-line message.
+pub fn render(args: &[OsString], mode: &str, clause_start: usize, err: &ModeError) -> bool {
+    let span = clause_start + err.span.start..clause_start + err.span.end;
+    let label = match err.kind {
+        ModeErrorKind::InvalidOperator => "chmod-diag-label-invalid-operator",
+        ModeErrorKind::MissingOperator => "chmod-diag-label-missing-operator",
+        ModeErrorKind::InvalidNumber => "chmod-diag-label-invalid-number",
+    };
+
+    Snapshot::new(args).render_inside(
+        mode,
+        span,
+        &err.message,
+        &translate!(label),
+        Some(&translate!("chmod-diag-help-mode-syntax")),
+    )
+}

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -375,7 +375,7 @@ fn behavior(matches: &ArgMatches) -> UResult<Behavior> {
         Some(uucore::mode::parse(x, considering_dir, 0).map_err(|err| {
             show_error!(
                 "{}",
-                translate!("install-error-invalid-mode", "error" => err)
+                translate!("install-error-invalid-mode", "error" => err.to_string())
             );
             1
         })?)

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -61,7 +61,9 @@ fn get_mode(_matches: &ArgMatches) -> Result<Option<u32>, String> {
 fn get_mode(matches: &ArgMatches) -> Result<Option<u32>, String> {
     // Not tested on Windows
     if let Some(m) = matches.get_one::<String>(options::MODE) {
-        mode::parse_chmod(DEFAULT_PERM, m, true, mode::get_umask()).map(Some)
+        mode::parse_chmod(DEFAULT_PERM, m, true, mode::get_umask())
+            .map(Some)
+            .map_err(|e| e.to_string())
     } else {
         // If no mode argument, let the kernel apply umask and ACLs naturally.
         Ok(None)

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -166,7 +166,7 @@ fn calculate_mode(mode_option: Option<&String>) -> Result<u32, String> {
     let mode = 0o666; // Default mode for FIFOs
 
     if let Some(m) = mode_option {
-        uucore::mode::parse_chmod(mode, m, false, umask)
+        uucore::mode::parse_chmod(mode, m, false, umask).map_err(|e| e.to_string())
     } else {
         Ok(mode & !umask) // Apply umask if no mode is specified
     }

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -276,7 +276,7 @@ fn parse_mode(str_mode: &str) -> Result<u32, String> {
         .map_err(|e| {
             translate!(
                 "mknod-error-invalid-mode",
-                "error" => e
+                "error" => e.to_string()
             )
         })
         .and_then(|mode| {

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1037,7 +1037,7 @@ impl Stater {
 
     fn exec(&self) -> i32 {
         #[cfg(unix)]
-        let stdin_is_fifo = rustix::fs::fstat(std::io::stdin())
+        let stdin_is_fifo = rustix::fs::fstat(io::stdin())
             .is_ok_and(|s| rustix::fs::FileType::from_raw_mode(s.st_mode).is_fifo());
 
         let mut ret = 0;

--- a/src/uu/test/Cargo.toml
+++ b/src/uu/test/Cargo.toml
@@ -20,7 +20,7 @@ clap = { workspace = true }
 fluent = { workspace = true }
 libc = { workspace = true }
 thiserror = { workspace = true }
-uucore = { workspace = true, features = ["process", "wide"] }
+uucore = { workspace = true, features = ["diagnostics", "process", "wide"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/src/uu/test/locales/en-US.ftl
+++ b/src/uu/test/locales/en-US.ftl
@@ -149,6 +149,10 @@ test-after-help = Exit with the status determined by EXPRESSION.
   NOTE: your shell may have its own version of test and/or {"["}, which usually supersedes the version described here.
   Please refer to your shell's documentation for details about the options it supports.
 
+  Errors are reported with the expression echoed back and a caret under the
+  argument at fault whenever stderr is a terminal; anything else reading
+  stderr gets the usual single-line message.
+
 # Error messages
 test-error-missing-closing-bracket = missing '{"]"}'
 test-error-expected = expected { $value }
@@ -158,3 +162,13 @@ test-error-extra-argument = extra argument { $argument }
 test-error-unknown-operator = unknown operator { $operator }
 test-error-invalid-integer = invalid integer { $value }
 test-error-unary-operator-expected = { $operator }: unary operator expected
+
+# Diagnostic labels, used when errors are rendered with a source snippet
+test-diag-label-expected = this is where the closing parenthesis was expected
+test-diag-label-missing-argument = nothing follows this
+test-diag-label-extra-argument = the expression was already complete here
+test-diag-label-unknown-operator = not a known operator
+test-diag-label-invalid-integer = expected an integer here
+test-diag-label-unary-operator-expected = this needs an expression on both sides
+test-diag-help-integer-op = -eq, -ne, -lt, -le, -gt and -ge compare integers; use =, {"!"}=, {"<"} or {">"} to compare strings
+test-diag-help-unknown-operator = run '{ $name } --help' for the list of supported operators

--- a/src/uu/test/locales/fr-FR.ftl
+++ b/src/uu/test/locales/fr-FR.ftl
@@ -149,6 +149,10 @@ test-after-help = Quitter avec le statut déterminé par EXPRESSION.
   NOTE : votre shell peut avoir sa propre version de test et/ou {"["}, qui remplace généralement la version décrite ici.
   Veuillez vous référer à la documentation de votre shell pour les détails sur les options qu'il prend en charge.
 
+  Les erreurs sont signalées en réaffichant l'expression avec un caret sous
+  l'argument fautif dès que la sortie d'erreur est un terminal ; sinon, le
+  message habituel sur une seule ligne est conservé.
+
 # Messages d'erreur
 test-error-missing-closing-bracket = '{"]"}' manquant
 test-error-expected = { $value } attendu
@@ -158,3 +162,13 @@ test-error-extra-argument = argument supplémentaire { $argument }
 test-error-unknown-operator = opérateur inconnu { $operator }
 test-error-invalid-integer = entier invalide { $value }
 test-error-unary-operator-expected = { $operator } : opérateur unaire attendu
+
+# Étiquettes de diagnostic, utilisées quand les erreurs sont rendues avec un extrait
+test-diag-label-expected = c'est ici que la parenthèse fermante était attendue
+test-diag-label-missing-argument = rien ne suit
+test-diag-label-extra-argument = l'expression était déjà complète ici
+test-diag-label-unknown-operator = n'est pas un opérateur connu
+test-diag-label-invalid-integer = un entier était attendu ici
+test-diag-label-unary-operator-expected = nécessite une expression de chaque côté
+test-diag-help-integer-op = -eq, -ne, -lt, -le, -gt et -ge comparent des entiers ; utilisez =, {"!"}=, {"<"} ou {">"} pour comparer des chaînes
+test-diag-help-unknown-operator = lancez « { $name } --help » pour la liste des opérateurs pris en charge

--- a/src/uu/test/src/diagnostics.rs
+++ b/src/uu/test/src/diagnostics.rs
@@ -1,0 +1,61 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Maps a [`ParseError`] onto the argument it points at, so that
+//! [`uucore::diagnostics`] can render it with a caret.
+
+use std::ffi::OsString;
+
+use uucore::diagnostics::Snapshot;
+use uucore::translate;
+
+use crate::error::{ErrorAt, ParseError, ParseErrorKind};
+
+/// Render `err` against `args`.
+///
+/// Returns `false` when the error cannot be tied to an argument, in which case
+/// the caller should fall back to the plain one-line message.
+pub fn render(args: &[OsString], err: &ParseError) -> bool {
+    let snapshot = Snapshot::new(args);
+
+    let index = match &err.at {
+        ErrorAt::Unknown => return false,
+        ErrorAt::Token(index) => *index,
+        // Recovered from the value, for errors raised after parsing.
+        ErrorAt::Value(value) => match snapshot.index_of(value) {
+            Some(index) => index,
+            None => return false,
+        },
+    };
+
+    let (label, help) = match &err.kind {
+        ParseErrorKind::Expected(_) => ("test-diag-label-expected", None),
+        ParseErrorKind::ExtraArgument(_) => ("test-diag-label-extra-argument", None),
+        ParseErrorKind::MissingArgument(_) => ("test-diag-label-missing-argument", None),
+        ParseErrorKind::UnaryOperatorExpected(_) => {
+            ("test-diag-label-unary-operator-expected", None)
+        }
+        ParseErrorKind::InvalidInteger(_) => (
+            "test-diag-label-invalid-integer",
+            Some(translate!("test-diag-help-integer-op")),
+        ),
+        ParseErrorKind::UnknownOperator(_) => (
+            "test-diag-label-unknown-operator",
+            Some(translate!(
+                "test-diag-help-unknown-operator",
+                "name" => uucore::util_name()
+            )),
+        ),
+        // Never carries a position, so it is filtered out above.
+        ParseErrorKind::ExpectedValue => return false,
+    };
+
+    snapshot.render(
+        index,
+        &err.kind.to_string(),
+        &translate!(label),
+        help.as_deref(),
+    )
+}

--- a/src/uu/test/src/error.rs
+++ b/src/uu/test/src/error.rs
@@ -3,12 +3,13 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use std::ffi::{OsStr, OsString};
 use thiserror::Error;
 use uucore::translate;
 
 /// Represents an error encountered while parsing a test expression
 #[derive(Error, Debug)]
-pub enum ParseError {
+pub enum ParseErrorKind {
     #[error("{}", translate!("test-error-expected-value"))]
     ExpectedValue,
     #[error("{}", translate!("test-error-expected", "value" => .0))]
@@ -23,6 +24,55 @@ pub enum ParseError {
     InvalidInteger(String),
     #[error("{}", translate!("test-error-unary-operator-expected", "operator" => .0))]
     UnaryOperatorExpected(String),
+}
+
+/// Where in the original argument list an error occurred.
+///
+/// Only read when a source snippet is rendered.
+#[derive(Debug, Default)]
+pub enum ErrorAt {
+    /// No position could be attributed to the error.
+    #[default]
+    Unknown,
+    /// Zero-based index into the arguments handed to the parser.
+    Token(usize),
+    /// The first argument equal to this value.
+    Value(OsString),
+}
+
+/// A parse or evaluation error, together with the position it points at.
+#[derive(Error, Debug)]
+#[error("{kind}")]
+pub struct ParseError {
+    pub kind: ParseErrorKind,
+    pub at: ErrorAt,
+}
+
+impl From<ParseErrorKind> for ParseError {
+    fn from(kind: ParseErrorKind) -> Self {
+        Self {
+            kind,
+            at: ErrorAt::Unknown,
+        }
+    }
+}
+
+impl ParseError {
+    /// An error pointing at the argument with index `index`.
+    pub fn at_token(kind: ParseErrorKind, index: usize) -> Self {
+        Self {
+            kind,
+            at: ErrorAt::Token(index),
+        }
+    }
+
+    /// An error pointing at the first argument equal to `token`.
+    pub fn at_value(kind: ParseErrorKind, token: &OsStr) -> Self {
+        Self {
+            kind,
+            at: ErrorAt::Value(token.to_os_string()),
+        }
+    }
 }
 
 /// A Result type for parsing test expressions

--- a/src/uu/test/src/parser.rs
+++ b/src/uu/test/src/parser.rs
@@ -8,7 +8,7 @@
 use std::ffi::{OsStr, OsString};
 use std::iter::Peekable;
 
-use super::error::{ParseError, ParseResult};
+use super::error::{ParseError, ParseErrorKind, ParseResult};
 
 use uucore::display::Quotable;
 
@@ -130,7 +130,11 @@ impl std::fmt::Display for Symbol {
 ///
 #[derive(Debug)]
 struct Parser {
+    /// Only `next_raw` may advance this iterator, so that `pos` stays in sync.
+    /// Lookahead must go through `peek` or a `clone` of the iterator.
     tokens: Peekable<std::vec::IntoIter<OsString>>,
+    /// Index of the next token to be consumed.
+    pos: usize,
     pub stack: Vec<Symbol>,
 }
 
@@ -139,20 +143,38 @@ impl Parser {
     fn new(tokens: Vec<OsString>) -> Self {
         Self {
             tokens: tokens.into_iter().peekable(),
+            pos: 0,
             stack: vec![],
         }
     }
 
+    /// Consume the next token from the input stream, tracking its position.
+    fn next_raw(&mut self) -> Option<OsString> {
+        let token = self.tokens.next();
+        if token.is_some() {
+            self.pos += 1;
+        }
+        token
+    }
+
     /// Fetch the next token from the input stream as a Symbol.
     fn next_token(&mut self) -> Symbol {
-        Symbol::new(self.tokens.next())
+        Symbol::new(self.next_raw())
+    }
+
+    /// Index of the token most recently consumed.
+    fn last_pos(&self) -> usize {
+        self.pos.saturating_sub(1)
     }
 
     /// Consume the next token & verify that it matches the provided value.
     fn expect(&mut self, value: &str) -> ParseResult<()> {
         match self.next_token() {
             Symbol::Literal(s) if s == value => Ok(()),
-            _ => Err(ParseError::Expected(value.quote().to_string())),
+            _ => Err(ParseError::at_token(
+                ParseErrorKind::Expected(value.quote().to_string()),
+                self.last_pos(),
+            )),
         }
     }
 
@@ -225,7 +247,11 @@ impl Parser {
 
         match peek3.as_slice() {
             // case 2: error if end of stream is `( <any_token>`
-            [symbol] => Err(ParseError::MissingArgument(format!("{symbol}"))),
+            // `symbol` was only peeked at, so it sits at the current position
+            [symbol] => Err(ParseError::at_token(
+                ParseErrorKind::MissingArgument(format!("{symbol}")),
+                self.pos,
+            )),
 
             // case 3: `( uop <any_token> )` → parenthesized unary operation;
             //         this case ensures we don’t get confused by `( -f ) )`
@@ -408,7 +434,10 @@ impl Parser {
 
             match self.next_token() {
                 Symbol::None => {
-                    return Err(ParseError::MissingArgument(format!("{op}")));
+                    return Err(ParseError::at_token(
+                        ParseErrorKind::MissingArgument(format!("{op}")),
+                        self.last_pos(),
+                    ));
                 }
                 token => self.stack.push(token.into_literal()),
             }
@@ -423,8 +452,11 @@ impl Parser {
     fn parse(&mut self) -> ParseResult<()> {
         self.expr()?;
 
-        match self.tokens.next() {
-            Some(token) => Err(ParseError::ExtraArgument(token.quote().to_string())),
+        match self.next_raw() {
+            Some(token) => Err(ParseError::at_token(
+                ParseErrorKind::ExtraArgument(token.quote().to_string()),
+                self.last_pos(),
+            )),
             None => Ok(()),
         }
     }

--- a/src/uu/test/src/test.rs
+++ b/src/uu/test/src/test.rs
@@ -5,13 +5,14 @@
 
 // spell-checker:ignore (vars) egid euid FiletestOp StrlenOp
 
+mod diagnostics;
 pub(crate) mod error;
 mod parser;
 #[cfg(windows)]
 mod platform;
 
 use clap::Command;
-use error::{ParseError, ParseResult};
+use error::{ParseError, ParseErrorKind, ParseResult};
 use parser::{Operator, Symbol, UnaryOperator, parse};
 use std::cmp::Ordering;
 use std::ffi::{OsStr, OsString};
@@ -72,9 +73,23 @@ pub fn uumain(mut args: impl uucore::Args) -> UResult<()> {
         // Show actual name with error
         let _ = uu_app().name("test");
     }
-    let result = parse(args).map(|mut stack| eval(&mut stack))??;
+    // `parse` consumes the arguments, so keep a copy for the diagnostic — but
+    // only when one could actually be rendered.
+    let expression = uucore::diagnostics::enabled().then(|| args.clone());
 
-    if result { Ok(()) } else { Err(1.into()) }
+    match parse(args).and_then(|mut stack| eval(&mut stack)) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(1.into()),
+        Err(e) => {
+            if let Some(expression) = &expression
+                && diagnostics::render(expression, &e)
+            {
+                // The diagnostic is already on stderr; exit quietly.
+                return Err(uucore::error::ExitCode::new(2));
+            }
+            Err(e.into())
+        }
+    }
 }
 
 /// Evaluate a stack of Symbols, returning the result of the evaluation or
@@ -123,7 +138,12 @@ fn eval(stack: &mut Vec<Symbol>) -> ParseResult<bool> {
                 Some(Symbol::Literal(s)) => s,
                 Some(Symbol::None) => OsString::from(""),
                 None => return Ok(true),
-                _ => return Err(ParseError::MissingArgument(op.quote().to_string())),
+                _ => {
+                    return Err(ParseError::at_value(
+                        ParseErrorKind::MissingArgument(op.quote().to_string()),
+                        &op,
+                    ));
+                }
             };
 
             Ok((op == "-z") == s.is_empty())
@@ -160,7 +180,10 @@ fn eval(stack: &mut Vec<Symbol>) -> ParseResult<bool> {
         Some(Symbol::None) | None => Ok(false),
         Some(Symbol::BoolOp(op)) => {
             if (op == "-a" || op == "-o") && stack.len() < 2 {
-                return Err(ParseError::UnaryOperatorExpected(op.quote().to_string()));
+                return Err(ParseError::at_value(
+                    ParseErrorKind::UnaryOperatorExpected(op.quote().to_string()),
+                    &op,
+                ));
             }
 
             let b = eval(stack)?;
@@ -168,7 +191,7 @@ fn eval(stack: &mut Vec<Symbol>) -> ParseResult<bool> {
 
             Ok(if op == "-a" { a && b } else { a || b })
         }
-        _ => Err(ParseError::ExpectedValue),
+        _ => Err(ParseErrorKind::ExpectedValue.into()),
     }
 }
 
@@ -247,10 +270,12 @@ impl PartialOrd for Integer<'_> {
 /// `op` the operation (ex: -eq, -lt, etc)
 fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
     // Parse the two inputs
-    let left =
-        Integer::parse(a).ok_or_else(|| ParseError::InvalidInteger(a.quote().to_string()))?;
-    let right =
-        Integer::parse(b).ok_or_else(|| ParseError::InvalidInteger(b.quote().to_string()))?;
+    let left = Integer::parse(a).ok_or_else(|| {
+        ParseError::at_value(ParseErrorKind::InvalidInteger(a.quote().to_string()), a)
+    })?;
+    let right = Integer::parse(b).ok_or_else(|| {
+        ParseError::at_value(ParseErrorKind::InvalidInteger(b.quote().to_string()), b)
+    })?;
 
     // Do the maths
     let order = left.cmp(&right);
@@ -262,7 +287,12 @@ fn integers(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
         Some("-ge") => order.is_ge(),
         Some("-lt") => order.is_lt(),
         Some("-le") => order.is_le(),
-        _ => return Err(ParseError::UnknownOperator(op.quote().to_string())),
+        _ => {
+            return Err(ParseError::at_value(
+                ParseErrorKind::UnknownOperator(op.quote().to_string()),
+                op,
+            ));
+        }
     })
 }
 
@@ -284,7 +314,12 @@ fn files(a: &OsStr, b: &OsStr, op: &OsStr) -> ParseResult<bool> {
         (Some("-ot"), Ok(f_a), Ok(f_b)) => f_a.modified().unwrap() < f_b.modified().unwrap(),
         (Some("-ot"), _, Ok(_)) => true,
         (Some("-ef" | "-nt" | "-ot"), _, _) => false,
-        (_, _, _) => return Err(ParseError::UnknownOperator(op.quote().to_string())),
+        (_, _, _) => {
+            return Err(ParseError::at_value(
+                ParseErrorKind::UnknownOperator(op.quote().to_string()),
+                op,
+            ));
+        }
     };
 
     Ok(result)
@@ -294,7 +329,9 @@ fn isatty(fd: &OsStr) -> ParseResult<bool> {
     fd.to_str()
         .map(str::trim)
         .and_then(|s| s.parse().ok())
-        .ok_or_else(|| ParseError::InvalidInteger(fd.quote().to_string()))
+        .ok_or_else(|| {
+            ParseError::at_value(ParseErrorKind::InvalidInteger(fd.quote().to_string()), fd)
+        })
         .map(|i| unsafe { libc::isatty(i) == 1 })
 }
 

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 path = "src/lib/lib.rs"
 
 [dependencies]
+ariadne = { workspace = true, optional = true }
 base64-simd = { workspace = true, optional = true }
 bstr = { workspace = true, optional = true }
 clap = { workspace = true }
@@ -143,6 +144,7 @@ default = ["signals"]
 # * non-default features
 backup-control = []
 colors = []
+diagnostics = ["dep:ariadne"]
 checksum = ["quoting-style", "sum", "base64-simd"]
 encoding = ["data-encoding", "data-encoding-macro", "z85", "base64-simd"]
 entries = ["libc"]

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -17,6 +17,8 @@ pub mod char_width;
 pub mod checksum;
 #[cfg(feature = "colors")]
 pub mod colors;
+#[cfg(feature = "diagnostics")]
+pub mod diagnostics;
 #[cfg(feature = "encoding")]
 pub mod encoding;
 #[cfg(feature = "extendedbigdecimal")]

--- a/src/uucore/src/lib/features/diagnostics.rs
+++ b/src/uucore/src/lib/features/diagnostics.rs
@@ -1,0 +1,432 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Render an error against the argument list it came from.
+//!
+//! Utilities whose arguments *are* the expression they evaluate — `test`, `expr`
+//! — can only say so much in a single line of stderr. This module echoes the
+//! arguments back as a source line and points a caret at the one that is at
+//! fault.
+//!
+//! A utility is expected to map its own error type to an argument index, a
+//! label, and optionally a line of advice; everything user-facing is passed in
+//! already localized, so this module holds no messages of its own.
+//!
+//! Rendering only happens when stderr is a terminal, so anything reading our
+//! output — a script, a pipe, a test suite — still sees the plain one-line
+//! message it always did.
+//!
+//! ```text
+//! Error: invalid integer 'zap'
+//!    ╭─[ test:1:7 ]
+//!    │
+//!  1 │ 7 -eq zap
+//!    │       ─┬─
+//!    │        ╰─── expected an integer here
+//! ───╯
+//! ```
+
+// spell-checker:ignore étage
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fmt::Write as _;
+use std::io::IsTerminal;
+use std::ops::Range;
+
+use ariadne::{CharSet, Color, Config, IndexType, Label, Report, ReportKind, Source};
+
+use crate::display::Quotable;
+
+/// Whether errors should be rendered against their argument list.
+///
+/// Callers should check this before doing any work that only a diagnostic needs,
+/// so that the default path costs nothing.
+///
+/// # Returns
+///
+/// `true` when stderr is a terminal — a person is watching, and gets the rich
+/// form. `false` in a script or a pipe, where whatever reads stderr gets the
+/// plain message it can grep for.
+pub fn enabled() -> bool {
+    std::io::stderr().is_terminal()
+}
+
+/// An argument list rendered as a single line, with the position of every
+/// argument inside it.
+pub struct Snapshot {
+    /// The arguments joined by spaces, quoted where needed.
+    text: String,
+    /// Byte range of each argument inside `text`.
+    spans: Vec<Range<usize>>,
+    /// Whether each argument was written out as-is, so that an offset inside it
+    /// also holds inside `text`.
+    verbatim: Vec<bool>,
+    /// The arguments themselves, for [`Snapshot::index_of`].
+    args: Vec<OsString>,
+}
+
+impl Snapshot {
+    /// Build a snapshot of an argument list.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The arguments as passed to the utility, without the utility
+    ///   name itself.
+    pub fn new<S: AsRef<OsStr>>(args: &[S]) -> Self {
+        let mut snapshot = Self::with_capacity(args.len());
+        for arg in args {
+            snapshot.push(arg.as_ref().to_os_string());
+        }
+        snapshot
+    }
+
+    /// Build a snapshot of an argument list held as raw bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The arguments as raw bytes, as produced by
+    ///   [`crate::os_string_to_vec`].
+    pub fn from_bytes<S: AsRef<[u8]>>(args: &[S]) -> Self {
+        let mut snapshot = Self::with_capacity(args.len());
+        for arg in args {
+            snapshot.push(match crate::os_str_from_bytes(arg.as_ref()) {
+                Ok(arg) => arg.into_owned(),
+                // Only reachable on platforms where `OsStr` is not raw bytes;
+                // show the argument lossily rather than not at all.
+                Err(_) => String::from_utf8_lossy(arg.as_ref()).into_owned().into(),
+            });
+        }
+        snapshot
+    }
+
+    fn with_capacity(len: usize) -> Self {
+        Self {
+            text: String::new(),
+            spans: Vec::with_capacity(len),
+            verbatim: Vec::with_capacity(len),
+            args: Vec::with_capacity(len),
+        }
+    }
+
+    fn push(&mut self, arg: OsString) {
+        if !self.spans.is_empty() {
+            self.text.push(' ');
+        }
+        let start = self.text.len();
+        // Offsets are taken from the rendered text rather than from the
+        // argument itself: quoting changes the length (a non-UTF-8 argument is
+        // shown as `$'fo\x80o'`) and the caret has to line up with what is
+        // actually printed.
+        let verbatim = match arg.to_str() {
+            // Operators such as `=` or `!=` are shell-special, but quoting them
+            // here would only obscure the expression.
+            Some(s) if !s.is_empty() && !s.chars().any(char::is_whitespace) => {
+                self.text.push_str(s);
+                true
+            }
+            _ => {
+                let _ = write!(self.text, "{}", arg.maybe_quote());
+                false
+            }
+        };
+        self.spans.push(start..self.text.len());
+        self.verbatim.push(verbatim);
+        self.args.push(arg);
+    }
+
+    /// Whether there is anything to point at.
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+
+    /// Index of the first argument equal to `arg`.
+    ///
+    /// Useful for errors raised after parsing, which know the value at fault but
+    /// no longer know where it came from.
+    ///
+    /// # Arguments
+    ///
+    /// * `arg` - The argument to look for.
+    ///
+    /// # Returns
+    ///
+    /// The index of the first argument equal to `arg`, or `None` if there is
+    /// none. A repeated value resolves to its first occurrence.
+    pub fn index_of(&self, arg: &OsStr) -> Option<usize> {
+        self.args.iter().position(|candidate| candidate == arg)
+    }
+
+    /// Index of the first argument equal to `arg`, held as raw bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `arg` - The argument to look for, as raw bytes.
+    ///
+    /// # Returns
+    ///
+    /// The index of the first argument equal to `arg`, or `None` if there is
+    /// none or the bytes cannot be represented as an [`OsStr`] on this
+    /// platform.
+    pub fn index_of_bytes(&self, arg: &[u8]) -> Option<usize> {
+        self.index_of(&crate::os_str_from_bytes(arg).ok()?)
+    }
+
+    /// Byte range of the argument at `index`.
+    ///
+    /// An index past the end means "end of input" and is clamped to the last
+    /// argument, so the caret never falls outside the text.
+    fn span_at(&self, index: usize) -> Option<Range<usize>> {
+        self.spans.get(index).or_else(|| self.spans.last()).cloned()
+    }
+
+    /// Write a report for the argument at `index` to stderr.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - Position of the argument at fault. An index past the end
+    ///   points at the last argument.
+    /// * `message` - The error message, already localized.
+    /// * `label` - Text placed under the caret, already localized.
+    /// * `help` - An optional line of advice, already localized.
+    ///
+    /// # Returns
+    ///
+    /// `false` if nothing could be rendered, in which case the caller should
+    /// fall back to a plain one-line message.
+    pub fn render(&self, index: usize, message: &str, label: &str, help: Option<&str>) -> bool {
+        let Some(span) = self.span_at(index) else {
+            return false;
+        };
+        self.report(span, message, label, help)
+    }
+
+    /// Write a report pointing at `range`, a byte range *inside* `operand`.
+    ///
+    /// For utilities whose operands are small languages of their own — a `sort`
+    /// key, a `chmod` mode — the argument as a whole is rarely the answer; the
+    /// caret belongs under the one character that broke the parse. `operand` is
+    /// looked up among the arguments, so a key passed as `-k2.3x` and one passed
+    /// as `-k 2.3x` both point at the same place.
+    ///
+    /// Falls back to underlining the whole argument when quoting means an offset
+    /// inside `operand` no longer lines up with what is printed.
+    ///
+    /// # Arguments
+    ///
+    /// * `operand` - The operand at fault, as it was parsed.
+    /// * `range` - Byte range inside `operand` to point at. An empty range
+    ///   marks the character it starts at.
+    /// * `message` - The error message, already localized.
+    /// * `label` - Text placed under the caret, already localized.
+    /// * `help` - An optional line of advice, already localized.
+    ///
+    /// # Returns
+    ///
+    /// `false` if nothing could be rendered, in which case the caller should
+    /// fall back to a plain one-line message.
+    pub fn render_inside(
+        &self,
+        operand: &str,
+        range: Range<usize>,
+        message: &str,
+        label: &str,
+        help: Option<&str>,
+    ) -> bool {
+        let Some(span) = self.locate(operand, range) else {
+            return false;
+        };
+        self.report(span, message, label, help)
+    }
+
+    /// Byte range covered by `range` — an offset inside `operand` — once
+    /// `operand` has been found among the arguments.
+    fn locate(&self, operand: &str, range: Range<usize>) -> Option<Range<usize>> {
+        let index = self
+            .args
+            .iter()
+            .position(|arg| arg.as_encoded_bytes().ends_with(operand.as_bytes()))?;
+        let whole = self.spans[index].clone();
+        if !self.verbatim[index] {
+            return Some(whole);
+        }
+
+        let base = whole.end - operand.len();
+        // Offsets come from someone else's parser, so they are only trusted as
+        // far as the text agrees with them.
+        let start = self.floor_boundary(base + range.start.min(operand.len()));
+        let end = self.floor_boundary(base + range.end.clamp(range.start, operand.len()));
+        if start < end {
+            return Some(start..end);
+        }
+        // An empty range means something is missing rather than wrong; give the
+        // caret the character it stopped at, or the whole argument if the
+        // operand ran out.
+        match self.text[start..].chars().next() {
+            Some(c) if start < whole.end => Some(start..start + c.len_utf8()),
+            _ => Some(whole),
+        }
+    }
+
+    /// `offset`, moved back to the nearest character boundary.
+    fn floor_boundary(&self, offset: usize) -> usize {
+        (0..=offset)
+            .rev()
+            .find(|&i| self.text.is_char_boundary(i))
+            .unwrap_or(0)
+    }
+
+    fn report(&self, span: Range<usize>, message: &str, label: &str, help: Option<&str>) -> bool {
+        let id = crate::util_name().to_owned();
+        let color = env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal();
+        let config = Config::default()
+            // ariadne counts characters unless told otherwise, which would drift
+            // on multi-byte arguments.
+            .with_index_type(IndexType::Byte)
+            .with_color(color)
+            .with_char_set(CharSet::Unicode);
+
+        let mut report = Report::build(ReportKind::Error, (id.clone(), span.clone()))
+            .with_config(config)
+            .with_message(message)
+            .with_label(
+                Label::new((id.clone(), span))
+                    .with_message(label)
+                    .with_color(Color::Red),
+            );
+
+        if let Some(help) = help {
+            report = report.with_help(help);
+        }
+
+        report
+            .finish()
+            .eprint((id, Source::from(self.text.as_str())))
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(args: &[&str]) -> Snapshot {
+        Snapshot::new(args)
+    }
+
+    #[test]
+    fn spans_cover_each_argument() {
+        let snap = snapshot(&["a", "=", ""]);
+        assert_eq!(snap.text, "a = ''");
+        assert_eq!(snap.spans, vec![0..1, 2..3, 4..6]);
+    }
+
+    #[test]
+    fn empty_argument_list_has_nothing_to_point_at() {
+        let snap = snapshot(&[]);
+        assert!(snap.is_empty());
+        assert_eq!(snap.text, "");
+        assert_eq!(snap.span_at(0), None);
+    }
+
+    #[test]
+    fn spans_are_byte_ranges_for_multibyte_arguments() {
+        let snap = snapshot(&["étage", "!=", "x"]);
+        let spans = snap.spans.clone();
+        assert_eq!(&snap.text[spans[0].clone()], "étage");
+        assert_eq!(&snap.text[spans[1].clone()], "!=");
+        assert_eq!(&snap.text[spans[2].clone()], "x");
+    }
+
+    #[test]
+    fn arguments_with_whitespace_are_quoted() {
+        let snap = snapshot(&["two words", "-lt", "5"]);
+        assert_eq!(snap.text, "'two words' -lt 5");
+        assert_eq!(&snap.text[snap.span_at(0).unwrap()], "'two words'");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spans_follow_the_quoted_form_of_invalid_utf8() {
+        let snap = Snapshot::from_bytes(&[&b"qu\x91x"[..], b"-eq", b"7"]);
+        let span = snap.span_at(0).unwrap();
+        // The caret covers the escaped rendering, not the four raw bytes.
+        assert_eq!(&snap.text[span.clone()], r"$'qu\x91x'");
+        assert!(span.len() > 4);
+    }
+
+    #[test]
+    fn byte_arguments_round_trip() {
+        let snap = Snapshot::from_bytes(&[b"9", b"+", b"4"]);
+        assert_eq!(snap.text, "9 + 4");
+        assert_eq!(snap.index_of(OsStr::new("+")), Some(1));
+        assert_eq!(snap.index_of_bytes(b"4"), Some(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_utf8_arguments_can_still_be_found() {
+        let snap = Snapshot::from_bytes(&[&b"ba\x80d"[..], b"+", b"1"]);
+        // A lossy conversion would not compare equal to the raw argument.
+        assert_eq!(snap.index_of_bytes(b"ba\x80d"), Some(0));
+    }
+
+    #[test]
+    fn index_past_the_end_clamps_to_the_last_argument() {
+        let snap = snapshot(&["7", "-lt"]);
+        assert_eq!(snap.span_at(99), Some(2..5));
+    }
+
+    #[test]
+    fn a_range_inside_an_operand_is_found_whether_it_is_glued_to_the_option() {
+        for args in [&["-k2.3x", "f"][..], &["-k", "2.3x", "f"][..]] {
+            let snap = snapshot(args);
+            let span = snap.locate("2.3x", 3..4).unwrap();
+            assert_eq!(&snap.text[span], "x");
+        }
+    }
+
+    #[test]
+    fn an_empty_range_still_gets_one_character() {
+        let snap = snapshot(&["u+rwx,g"]);
+        let span = snap.locate("u+rwx,g", 6..6).unwrap();
+        assert_eq!(&snap.text[span], "g");
+    }
+
+    #[test]
+    fn a_range_at_the_end_of_an_operand_falls_back_to_the_argument() {
+        let snap = snapshot(&["-k1,"]);
+        assert_eq!(snap.locate("1,", 2..2), Some(0..4));
+    }
+
+    #[test]
+    fn a_quoted_operand_falls_back_to_the_whole_argument() {
+        let snap = snapshot(&["a b", "-k1"]);
+        // Offsets inside `a b` would land on the quotes that were added.
+        assert_eq!(snap.locate("a b", 1..2), Some(0..5));
+        assert_eq!(&snap.text[snap.locate("a b", 1..2).unwrap()], "'a b'");
+    }
+
+    #[test]
+    fn an_operand_that_is_not_an_argument_cannot_be_located() {
+        let snap = snapshot(&["-k1"]);
+        assert_eq!(snap.locate("2.3", 0..1), None);
+    }
+
+    #[test]
+    fn offsets_inside_a_multibyte_operand_stay_on_character_boundaries() {
+        let snap = snapshot(&["--from=éx"]);
+        // Mid-character offset, walked back rather than slicing a code point.
+        let span = snap.locate("éx", 1..3).unwrap();
+        assert_eq!(&snap.text[span], "éx");
+    }
+
+    #[test]
+    fn index_of_finds_the_first_match() {
+        let snap = snapshot(&["dup", "-ef", "dup"]);
+        assert_eq!(snap.index_of(OsStr::new("dup")), Some(0));
+        assert_eq!(snap.index_of(OsStr::new("absent")), None);
+    }
+}

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -7,21 +7,87 @@
 
 // spell-checker:ignore (vars) fperm srwx
 
+use std::fmt::{self, Display};
+use std::ops::Range;
+
 #[cfg(windows)]
 use libc::umask;
 
 use crate::translate;
 
-pub fn parse_numeric(fperm: u32, mut mode: &str, considering_dir: bool) -> Result<u32, String> {
+/// A mode string that does not parse, and the part of it that is at fault.
+///
+/// `span` is a byte range inside the mode string that was handed to the parser,
+/// so that a caller can point a caret at the one clause — often the one
+/// character — that broke it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModeError {
+    pub message: String,
+    pub span: Range<usize>,
+    pub kind: ModeErrorKind,
+}
+
+/// What went wrong, for callers that want to say more than the message does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModeErrorKind {
+    /// Something other than `+`, `-` or `=` where an operator was expected.
+    InvalidOperator,
+    /// Who the clause applies to, and then nothing.
+    MissingOperator,
+    /// A numeric mode that is not octal, or is out of range.
+    InvalidNumber,
+}
+
+impl ModeError {
+    fn new(message: String, span: Range<usize>, kind: ModeErrorKind) -> Self {
+        Self {
+            message,
+            span,
+            kind,
+        }
+    }
+
+    /// Move the range so that it is relative to a string starting `offset`
+    /// bytes earlier.
+    fn shift(self, offset: usize) -> Self {
+        Self {
+            span: self.span.start + offset..self.span.end + offset,
+            ..self
+        }
+    }
+}
+
+impl Display for ModeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ModeError {}
+
+pub fn parse_numeric(fperm: u32, mode: &str, considering_dir: bool) -> Result<u32, ModeError> {
+    let original = mode;
     let (op, pos) = parse_op(mode).map_or_else(|_| (None, 0), |(op, pos)| (Some(op), pos));
-    mode = mode[pos..].trim();
+    let digits = mode[pos..].trim();
+    let mode = digits;
     let change = if mode.is_empty() {
         0
     } else {
-        u32::from_str_radix(mode, 8).map_err(|e| e.to_string())?
+        let at = original.len() - original.trim_end().len();
+        u32::from_str_radix(mode, 8).map_err(|e| {
+            ModeError::new(
+                e.to_string(),
+                pos..original.len() - at,
+                ModeErrorKind::InvalidNumber,
+            )
+        })?
     };
     if change > 0o7777 {
-        Err(format!("mode is too large ({change:o} > 7777)"))
+        Err(ModeError::new(
+            format!("mode is too large ({change:o} > 7777)"),
+            0..original.len(),
+            ModeErrorKind::InvalidNumber,
+        ))
     } else {
         Ok(match op {
             Some('+') => fperm | change,
@@ -37,18 +103,28 @@ pub fn parse_numeric(fperm: u32, mut mode: &str, considering_dir: bool) -> Resul
 
 pub fn parse_symbolic(
     mut fperm: u32,
-    mut mode: &str,
+    mode: &str,
     umask: u32,
     considering_dir: bool,
-) -> Result<u32, String> {
+) -> Result<u32, ModeError> {
+    let original = mode;
+    // Everything below is a suffix of `original`, so how much is left is also
+    // where we are.
+    let at = |rest: &str| original.len() - rest.len();
+
     let (mask, pos) = parse_levels(mode);
     if pos == mode.len() {
-        return Err(format!("invalid mode ({mode})"));
+        // Who the clause applies to, and then nothing: no operator followed.
+        return Err(ModeError::new(
+            format!("invalid mode ({mode})"),
+            0..mode.len(),
+            ModeErrorKind::MissingOperator,
+        ));
     }
     let respect_umask = pos == 0;
-    mode = &mode[pos..];
+    let mut mode = &mode[pos..];
     while !mode.is_empty() {
-        let (op, pos) = parse_op(mode)?;
+        let (op, pos) = parse_op(mode).map_err(|err| err.shift(at(mode)))?;
         mode = &mode[pos..];
         let (mut srwx, pos) = parse_change(mode, fperm, considering_dir);
         if respect_umask {
@@ -90,14 +166,21 @@ fn parse_levels(mode: &str) -> (u32, usize) {
     (mask, pos)
 }
 
-fn parse_op(mode: &str) -> Result<(char, usize), String> {
-    let ch = mode
-        .chars()
-        .next()
-        .ok_or_else(|| translate!("mode-error-unexpected-end"))?;
+fn parse_op(mode: &str) -> Result<(char, usize), ModeError> {
+    let Some(ch) = mode.chars().next() else {
+        return Err(ModeError::new(
+            translate!("mode-error-unexpected-end"),
+            0..0,
+            ModeErrorKind::MissingOperator,
+        ));
+    };
     match ch {
         '+' | '-' | '=' => Ok((ch, 1)),
-        _ => Err(translate!("mode-error-invalid-operator", "operator" => ch)),
+        _ => Err(ModeError::new(
+            translate!("mode-error-invalid-operator", "operator" => ch),
+            0..ch.len_utf8(),
+            ModeErrorKind::InvalidOperator,
+        )),
     }
 }
 
@@ -145,28 +228,34 @@ pub fn parse_chmod(
     mode_string: &str,
     considering_dir: bool,
     umask: u32,
-) -> Result<u32, String> {
+) -> Result<u32, ModeError> {
     let mut new_mode: u32 = current_mode;
 
     // Split by commas and process each mode part sequentially
-    for mode_part in mode_string.split(',') {
-        let mode_part = mode_part.trim();
+    let mut offset = 0;
+    for raw_part in mode_string.split(',') {
+        let start = offset + (raw_part.len() - raw_part.trim_start().len());
+        // Past the part and the comma that followed it.
+        offset += raw_part.len() + 1;
+
+        let mode_part = raw_part.trim();
         if mode_part.is_empty() {
             continue;
         }
 
         new_mode = if mode_part.chars().any(|c| c.is_ascii_digit()) {
-            parse_numeric(new_mode, mode_part, considering_dir)?
+            parse_numeric(new_mode, mode_part, considering_dir)
         } else {
-            parse_symbolic(new_mode, mode_part, umask, considering_dir)?
-        };
+            parse_symbolic(new_mode, mode_part, umask, considering_dir)
+        }
+        .map_err(|err| err.shift(start))?;
     }
 
     Ok(new_mode)
 }
 
 /// Takes a user-supplied string and tries to parse to u32 mode bitmask.
-pub fn parse(mode_string: &str, considering_dir: bool, umask: u32) -> Result<u32, String> {
+pub fn parse(mode_string: &str, considering_dir: bool, umask: u32) -> Result<u32, ModeError> {
     parse_chmod(0, mode_string, considering_dir, umask)
 }
 

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -45,6 +45,8 @@ pub use crate::features::char_width;
 pub use crate::features::checksum;
 #[cfg(feature = "colors")]
 pub use crate::features::colors;
+#[cfg(feature = "diagnostics")]
+pub use crate::features::diagnostics;
 #[cfg(feature = "encoding")]
 pub use crate::features::encoding;
 #[cfg(feature = "extendedbigdecimal")]

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -1524,3 +1524,138 @@ fn test_chmod_symlink_two_links_same_dir() {
         .stdout_contains("mode of 'base/link2/file'");
     // cSpell:enable
 }
+
+mod diagnostics {
+    use super::*;
+    /// Column of the caret in a report header such as `[ chmod:1:5 ]`.
+    #[cfg(unix)]
+    fn caret_column(stderr: &str) -> Option<usize> {
+        let header = stderr.lines().find(|line| line.contains("chmod:1:"))?;
+        let column = header.rsplit(':').next()?;
+        column.trim_end_matches(" ]").parse().ok()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_bad_operator() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["g+rw?x", "probe"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        assert!(stderr.contains("invalid operator"), "{stderr}");
+        // The caret lands on `?`, the fifth character of the mode.
+        assert_eq!(caret_column(stderr), Some(5), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_into_the_second_clause() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["o=r,ug!w", "probe"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        // Clauses are parsed one at a time, but the caret is placed in the
+        // whole mode: `!` is its seventh character.
+        assert_eq!(caret_column(stderr), Some(7), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_marks_a_clause_with_no_operator() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["go", "probe"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        assert!(stderr.contains("invalid mode"), "{stderr}");
+        assert_eq!(caret_column(stderr), Some(1), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_marks_a_non_octal_mode() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        ucmd.terminal_sim_stderr()
+            .args(&["779", "probe"])
+            .fails_with_code(1)
+            .stderr_contains("779");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_into_a_negative_mode() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        // A leading-dash mode is pulled out of the argument list before clap
+        // sees it, but the caret still lands on `%`, its fourth character.
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["-rw%x", "probe"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        assert!(stderr.contains("invalid operator"), "{stderr}");
+        assert_eq!(caret_column(stderr), Some(4), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_plain_message_when_negative_modes_are_joined() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        // Several negative modes are joined into one mode that matches no
+        // single argument, so there is nothing to point at.
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["-w", "-r%x", "probe"])
+            .fails_with_code(1);
+
+        // The pseudo-terminal turns the newline into CRLF, hence the trim.
+        assert_eq!(
+            result.stderr_str().trim_end(),
+            "chmod: invalid operator (expected +, -, or =, but found %)"
+        );
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        // The test harness pipes stderr, so the report must not appear.
+        ucmd.args(&["g+rw?x", "probe"])
+            .fails_with_code(1)
+            .stderr_only("chmod: invalid operator (expected +, -, or =, but found ?)\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_quiet_stays_quiet() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        // -f suppresses the message entirely, report included.
+        ucmd.terminal_sim_stderr()
+            .args(&["-f", "g+rw?x", "probe"])
+            .fails_with_code(1)
+            .no_output();
+    }
+}

--- a/tests/by-util/test_test.rs
+++ b/tests/by-util/test_test.rs
@@ -1191,3 +1191,58 @@ fn test_unary_op_as_literal_in_three_arg_form() {
     new_ucmd!().args(&["-f", "=", "a"]).fails_with_code(1);
     new_ucmd!().args(&["-f", "=", "a", "-o", "b"]).succeeds();
 }
+
+mod diagnostics {
+    use super::*;
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_offending_argument() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["7", "-eq", "zap"])
+            .fails_with_code(2);
+        let stderr = result.stderr_str();
+
+        // The expression is echoed back, with the caret column matching `zap`.
+        assert!(stderr.contains("7 -eq zap"), "{stderr}");
+        assert!(stderr.contains("1:7"), "{stderr}");
+        assert!(stderr.contains("invalid integer 'zap'"), "{stderr}");
+        // The help line points at the string operators instead.
+        assert!(stderr.contains("compare integers"), "{stderr}");
+        // The plain `test: ` prefix is replaced by the report header.
+        assert!(!stderr.starts_with("test: "), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_is_the_default() {
+        // The test harness pipes stderr, so the report must not appear.
+        new_ucmd!()
+            .args(&["7", "-eq", "zap"])
+            .fails_with_code(2)
+            .stderr_is("test: invalid integer 'zap'\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_extra_argument_points_past_the_expression() {
+        new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["k", "!=", "m", "spare"])
+            .fails_with_code(2)
+            .stderr_contains("extra argument 'spare'")
+            .stderr_contains("k != m spare");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_bracket_form_reports_under_its_own_name() {
+        // The trailing `]` is dropped before the expression is echoed back.
+        TestScenario::new("[")
+            .ucmd()
+            .terminal_sim_stderr()
+            .args(&["7", "-eq", "zap", "]"])
+            .fails_with_code(2)
+            .stderr_contains("[:1:7")
+            .stderr_contains("7 -eq zap");
+    }
+}

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -1723,6 +1723,21 @@ impl UCommand {
         self
     }
 
+    /// Attach stderr (and only stderr) to a simulated terminal, with colors
+    /// disabled through `NO_COLOR`.
+    ///
+    /// This is useful to test output that is only rendered when
+    /// `stderr.is_terminal()` is `true`, such as the rich error reports of
+    /// `chmod` or `test`, while letting assertions see plain text.
+    #[cfg(unix)]
+    pub fn terminal_sim_stderr(&mut self) -> &mut Self {
+        self.terminal_sim_stdio(TerminalSimulation {
+            stderr: true,
+            ..Default::default()
+        })
+        .env("NO_COLOR", "1")
+    }
+
     #[cfg(unix)]
     fn read_from_pty(pty_fd: OwnedFd, out: File) {
         let read_file = File::from(pty_fd);


### PR DESCRIPTION
example:
```
╰╴❯ LANG=C ./target/debug/coreutils chmod "g+rw?x" a  
Error: invalid operator (expected +, -, or =, but found ?)
   ╭─[ chmod:1:5 ]
   │
 1 │ g+rw?x a
   │     ┬
   │     ╰── expected +, - or = here
   │
   │ Help: a mode is either octal, as in 644, or clauses such as u+rwx,go-w
───╯
```

screenshot with color:
<img width="1069" height="333" alt="image" src="https://github.com/user-attachments/assets/496ec3c6-0008-4273-a997-5f0de371ec02" />


more programs will follow