### PR TITLE
od: avoid panic on large ASCII dump widths

### DIFF
--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -720,13 +720,9 @@ fn write_bytes(
             let missing_spacing = output_info
                 .print_width_line
                 .saturating_sub(output_text.chars().count());
-            write!(
-                output_text,
-                "{:>missing_spacing$}  {}",
-                "",
-                format_ascii_dump(input_decoder.get_buffer(0)),
-            )
-            .unwrap();
+            output_text.extend(std::iter::repeat_n(' ', missing_spacing));
+            output_text.push_str("  ");
+            output_text.push_str(&format_ascii_dump(input_decoder.get_buffer(0)));
         }
 
         if first {

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -541,6 +541,20 @@ fn test_very_wide_hex_byte_output() {
 }
 
 #[test]
+fn test_very_wide_hex_byte_ascii_dump() {
+    const WIDTH: usize = 100_000;
+    let expected = format!(" 41{}  >A<\n", " ".repeat(WIDTH * 3 - 3));
+
+    new_ucmd!()
+        .arg("-An")
+        .arg(format!("-w{WIDTH}"))
+        .arg("-tx1z")
+        .pipe_in("A")
+        .succeeds()
+        .stdout_only(expected);
+}
+
+#[test]
 fn test_suppress_duplicates() {
     let input: [u8; 41] = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
## Summary

- Avoid a panic when `od` uses a large `--width` with an ASCII dump format.
- Append the ASCII-column padding directly instead of passing a width larger than `u16::MAX` to Rust formatting.
- Add a regression test for `od -An -w100000 -tx1z`.

## Testing

- `cargo test --no-default-features --features od test_very_wide_hex_byte_ascii_dump`
- `cargo test --no-default-features --features od`
- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features od --all-targets -- -D warnings`

Fixes #13767