### PR TITLE
date: apply flags and widths to %N

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -312,8 +312,6 @@ fn get_default_width(specifier: &str) -> usize {
         Some('g') => 2,
         // Epoch seconds: typically 10 digits (but variable)
         Some('s') => 0,
-        // Nanoseconds: 9 digits
-        Some('N') => 9,
         // Quarter: 1 digit
         Some('q') => 1,
         // Timezone offset: varies
@@ -359,6 +357,14 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
     let flags = parsed.flags;
     let width = parsed.width;
     let specifier = parsed.spec;
+
+    // `%N` is a fraction, not an integer: it is left-aligned, its width is a
+    // precision rather than a minimum size, and it pads on the right. None of
+    // that fits the logic below, so it gets its own routine.
+    if specifier.ends_with('N') {
+        return format_nanoseconds(value, flags, width);
+    }
+
     let mut result = value.to_string();
 
     // Determine default pad character based on specifier type
@@ -498,11 +504,6 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             padded.push_str(&result);
             result = padded;
         }
-    } else if specifier.ends_with('N')
-        && effective_width <= get_default_width(specifier)
-        && effective_width != 0
-    {
-        result.truncate(effective_width);
     }
 
     Ok(result)
@@ -527,6 +528,61 @@ fn try_alloc_padded(
     s.try_reserve(target_len)
         .map_err(|_| field_width_too_large(width, specifier))?;
     Ok(s)
+}
+
+/// Format `%N` (nanoseconds) the way GNU does.
+///
+/// `%N` prints the fractional part of the second, so its rules are the mirror
+/// image of every other numeric specifier:
+///
+/// * the width is a **precision** — narrower than the native 9 digits truncates
+///   (`%3N` is milliseconds), wider appends zeros on the right;
+/// * `-` and `_` drop *trailing* zeros, because a trailing zero in a fraction
+///   carries no information, whereas a leading one does (`0004` != `4`);
+/// * padding goes on the right.
+///
+/// `value` is the zero-padded 9-digit nanosecond count produced by jiff.
+fn format_nanoseconds(
+    value: &str,
+    flags: &str,
+    width: Option<usize>,
+) -> Result<String, FormatError> {
+    // GNU's date(1) never lets a bare `%-N` reach strftime: `adjust_resolution`
+    // in coreutils' src/date.c rewrites the literal three bytes `%-N` into
+    // `%<digits>N`, where <digits> is what the hardware clock can resolve. The
+    // `-` flag is replaced, not honoured. CLOCK_REALTIME reports full nanosecond
+    // resolution on the platforms uutils targets, so the rewrite is `%9N`.
+    // Anything else — `%_-N`, `%-9N` — misses the pattern and keeps its flags.
+    let (flags, width) = if flags == "-" && width.is_none() {
+        ("", Some(value.len()))
+    } else {
+        (flags, width)
+    };
+    let target = width.filter(|&w| w > 0).unwrap_or(value.len());
+    if target > MAX_FORMAT_WIDTH {
+        return Err(field_width_too_large(target, "N"));
+    }
+
+    // The last padding flag wins, matching gnulib.
+    let pad = flags.chars().rev().find(|c| "-_0+".contains(*c));
+
+    // Bring the digits to the requested precision.
+    let kept_digits = value.len().min(target);
+    let extra_zeros = target.saturating_sub(value.len());
+    let mut result = try_alloc_padded(kept_digits, extra_zeros, target, "N")?;
+    result.push_str(&value[..kept_digits]);
+    result.extend(std::iter::repeat_n('0', extra_zeros));
+
+    let strips_zeros = matches!(pad, Some('_' | '-'));
+    if strips_zeros {
+        let significant = result.trim_end_matches('0').len().max(1);
+        result.truncate(significant);
+        if pad == Some('_') {
+            result.extend(std::iter::repeat_n(' ', target - significant));
+        }
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2027,7 +2027,6 @@ fn test_date_strftime_case_flag_on_alt_ampm() {
 }
 
 #[test]
-#[ignore = "https://github.com/uutils/coreutils/issues/11658 — GNU date applies flags/widths to `%N` (nanoseconds); uutils ignores/mishandles them."]
 fn test_date_strftime_n_width_and_flags() {
     // `%_3N` should space-pad nanoseconds to width 3. GNU outputs `0  `; uutils outputs `0`.
     new_ucmd!()
@@ -2048,6 +2047,43 @@ fn test_date_strftime_n_width_and_flags() {
         .arg("+%-N")
         .succeeds()
         .stdout_is("000000000\n");
+}
+
+#[test]
+fn test_date_strftime_n_precision_and_padding() {
+    // Values checked against `date (GNU coreutils) 9.10`.
+    for (input, format, expected) in [
+        // Width is a precision: it truncates or appends zeros on the right.
+        ("@0.123456", "+%3N", "123\n"),
+        ("@0.123456", "+%12N", "123456000000\n"),
+        // `_` and `-` drop trailing zeros; leading zeros are significant.
+        ("@0.123456", "+%_N", "123456   \n"),
+        ("@0.000456", "+%_4N", "0004\n"),
+        ("@0.000456", "+%-9N", "000456\n"),
+        // At least one digit always survives.
+        ("@0", "+%-6N", "0\n"),
+        ("@0", "+%_6N", "0     \n"),
+        // `0` and `+` behave like no flag at all.
+        ("@0.123456", "+%09N", "123456000\n"),
+        ("@0.123456", "+%+9N", "123456000\n"),
+        // The last padding flag wins.
+        ("@0", "+%_-3N", "0\n"),
+        ("@0", "+%-0N", "000000000\n"),
+        // Only a literal `%-N` is rewritten to the clock resolution by
+        // date(1); `%_-N` and `%-9N` keep the `-` flag and drop trailing zeros.
+        ("@0.123456", "+%-N", "123456000\n"),
+        ("@0.123456", "+%_-N", "123456\n"),
+        ("@0.123456", "+%-9N", "123456\n"),
+    ] {
+        new_ucmd!()
+            .env("LC_ALL", "C")
+            .env("TZ", "UTC")
+            .arg("-d")
+            .arg(input)
+            .arg(format)
+            .succeeds()
+            .stdout_is(expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #11658

`%N` is a fraction, so it follows the mirror image of the rules every other
numeric specifier follows: the width is a precision (`%3N` truncates to
milliseconds, `%12N` appends zeros), `-` and `_` drop *trailing* zeros rather
than leading padding, and the field pads on the right.

`apply_modifiers` implements right-aligned integer fields, so `%N` was going
through it and coming out wrong in both directions. This routes `%N` to its own
function on entry and drops the two partial workarounds that were compensating
for it (the `'N'` arm in `get_default_width` and the trailing `truncate`).

One subtlety worth flagging: a bare `%-N` never reaches strftime in GNU. The
`adjust_resolution` function in coreutils' `src/date.c` rewrites the literal
three bytes `%-N` into `%<digits>N`, where `<digits>` comes from
`gettime_res()`, so the `-` flag is replaced rather than honoured. `%_-N` and
`%-9N` miss that pattern and keep the flag. This PR reproduces that behaviour
and assumes nanosecond clock resolution — true on every platform we target —
instead of calling `clock_getres`. Happy to wire up the real syscall if
preferred.

Verified against `date (GNU coreutils) 9.10` across 336 combinations of value ×
flags × width; all match.