### PR TITLE
install: allow non-directory special files as targets

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -580,6 +580,7 @@ fn is_new_file_path(path: &Path) -> bool {
 /// A valid target is a regular file, a path that can be created as a new file,
 /// or any existing non-directory entry (including device files, FIFOs, sockets
 /// and symlinks). Directories are handled by `copy_files_into_dir`.
+#[inline]
 fn is_valid_target(path: &Path) -> bool {
     path.is_file() || is_new_file_path(path) || path.symlink_metadata().is_ok_and(|m| !m.is_dir())
 }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -575,6 +575,15 @@ fn is_new_file_path(path: &Path) -> bool {
             .is_none_or(|p| p.as_os_str().is_empty() || p.is_dir())
 }
 
+/// Test if the path is a valid target for a single-file install.
+///
+/// A valid target is a regular file, a path that can be created as a new file,
+/// or any existing non-directory entry (including device files, FIFOs, sockets
+/// and symlinks). Directories are handled by `copy_files_into_dir`.
+fn is_valid_target(path: &Path) -> bool {
+    path.is_file() || is_new_file_path(path) || path.symlink_metadata().is_ok_and(|m| !m.is_dir())
+}
+
 /// Test if the path is an existing directory or ends with a trailing separator.
 ///
 /// Returns true, if one of the conditions above is met; else false.
@@ -777,7 +786,7 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
             return Err(InstallError::SameFile(source.clone(), target.clone()).into());
         }
 
-        if target.is_file() || is_new_file_path(&target) {
+        if is_valid_target(&target) {
             #[cfg(unix)]
             if let (Some(ref parent_fd), Some(ref filename)) = (target_parent_fd, target_filename) {
                 if b.compare && !need_copy(source, &target, b) {

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -2935,6 +2935,19 @@ fn test_install_proc_self_mem_as_dst() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_install_dev_full_as_dst() {
+    let scene = TestScenario::new(util_name!());
+
+    scene
+        .ucmd()
+        .arg("/dev/null")
+        .arg("/dev/full")
+        .fails()
+        .stderr_contains("cannot remove '/dev/full'");
+}
+
+#[test]
 fn test_install_backup_nil_same_file() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;


### PR DESCRIPTION
`install /dev/null /dev/full` currently fails with:

```
install: invalid target '/dev/full': No such file or directory
```

GNU install treats `/dev/full` as a valid target and reports the actual failure when trying to remove/replace it:

```
install: cannot remove '/dev/full': Permission denied
```

Changes:
- Introduce `is_valid_target()` which accepts existing non-directory entries (device files, FIFOs, sockets, symlinks) in addition to regular files and new file paths.
- Use it in `standard()` so special files proceed to `copy_file()` instead of being rejected as invalid targets.
- Add a Linux-only regression test for `install /dev/null /dev/full`.

Fixes #9934.

---
🤖 This PR was generated with [Claude Code](https://claude.com/claude-code).
