### PR TITLE
printf: avoid overflow for minimum dynamic width

### DIFF
--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -511,7 +511,7 @@ fn resolve_asterisk_width(
         Some(CanAsterisk::Asterisk(loc)) => {
             let nb = args.next_i64(loc);
             if nb < 0 {
-                Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
+                Some((usize::try_from(nb.unsigned_abs()).ok().unwrap_or(0), true))
             } else {
                 Some((usize::try_from(nb).ok().unwrap_or(0), false))
             }
@@ -667,6 +667,17 @@ mod tests {
                         FormatArgument::Unparsed("2".into()),
                         FormatArgument::Unparsed("3".into())
                     ]),
+                )
+            );
+        }
+
+        #[test]
+        fn asterisk_with_i64_min_width() {
+            assert_eq!(
+                Some((1usize.checked_shl(63).unwrap_or(0), true)),
+                resolve_asterisk_width(
+                    Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
+                    &mut FormatArguments::new(&[FormatArgument::SignedInt(i64::MIN)]),
                 )
             );
         }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -591,6 +591,16 @@ fn sub_any_asterisk_first_param_with_integer() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
+fn sub_any_asterisk_first_param_with_i64_min() {
+    new_ucmd!()
+        .args(&["%*d", &i64::MIN.to_string(), "1"])
+        .fails_with_code(1)
+        .stderr_contains("write error")
+        .stdout_is("");
+}
+
+#[test]
 fn sub_any_asterisk_second_param_with_integer() {
     new_ucmd!()
         .args(&["|%.*d|", "3", "10"])


### PR DESCRIPTION
Fixes #13766.

  Resolving a negative dynamic width negated the signed argument directly, which overflows for `i64::MIN`. Use `unsigned_abs()` so the value reaches the existing width handling safely, and add a regression
  test for the minimum signed value.