### PR TITLE
fix(printf): compute asterisk width magnitude in unsigned arithmetic

### DIFF
--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -511,7 +511,8 @@ fn resolve_asterisk_width(
         Some(CanAsterisk::Asterisk(loc)) => {
             let nb = args.next_i64(loc);
             if nb < 0 {
-                Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
+                // Unsigned arithmetic, so `i64::MIN` (magnitude 2^63) doesn't overflow.
+                Some((usize::try_from(nb.unsigned_abs()).ok().unwrap_or(0), true))
             } else {
                 Some((usize::try_from(nb).ok().unwrap_or(0), false))
             }
@@ -669,6 +670,26 @@ mod tests {
                     ]),
                 )
             );
+        }
+
+        #[test]
+        fn asterisk_i64_min_width() {
+            // Regression test for https://github.com/uutils/coreutils/issues/13766
+            // |i64::MIN| = 2^63 overflows i64, so the magnitude of a negative
+            // `*` width must be computed in unsigned arithmetic.
+            let expected = usize::try_from(i64::MIN.unsigned_abs()).unwrap_or(0);
+            for arg in [
+                FormatArgument::SignedInt(i64::MIN),
+                FormatArgument::Unparsed(i64::MIN.to_string().into()),
+            ] {
+                assert_eq!(
+                    Some((expected, true)),
+                    resolve_asterisk_width(
+                        Some(CanAsterisk::Asterisk(ArgumentLocation::NextArgument)),
+                        &mut FormatArguments::new(&[arg]),
+                    )
+                );
+            }
         }
     }
 

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1539,6 +1539,22 @@ fn test_extreme_field_width_overflow() {
 }
 
 #[test]
+fn test_asterisk_width_i64_min_no_panic() {
+    // Regression test for https://github.com/uutils/coreutils/issues/13766
+    // An `i64::MIN` '*' width used to panic with "attempt to negate with overflow".
+    // It must not panic: on 64-bit it fails with a write error, on 32-bit the
+    // width is clamped to 0 and printf succeeds.
+    let result = new_ucmd!()
+        .args(&["|%*d|", &i64::MIN.to_string(), "1"])
+        .run();
+    assert!(
+        result.succeeded() || result.code() == 1,
+        "printf must not panic on an i64::MIN '*' width (got exit code {})",
+        result.code()
+    );
+}
+
+#[test]
 fn test_q_string_control_chars_with_quotes() {
     // Test %q with control characters and single quotes combined.
     // This tests the fix for the GNU compatibility issue where control


### PR DESCRIPTION
Fixes #13766

## Summary

A negative `*` field-width argument of `i64::MIN` (`printf '%*d' -9223372036854775808 1`) made `resolve_asterisk_width` panic with `attempt to negate with overflow`: the old code computed the magnitude as `-(nb as isize)`, and `|i64::MIN| = 2^63` is not representable in `i64`/`isize`.

The fix computes the magnitude with `nb.unsigned_abs()`, which is designed for exactly this case and returns `2^63` in unsigned (`u64`) arithmetic.

## Behavior

- Before: `panic` / exit 134 (`attempt to negate with overflow`)
- After: the width `2^63` exceeds `MAX_FORMAT_WIDTH`, so `printf` fails gracefully with `printf: write error: formatting width too large` (exit 1), matching the handling of other oversized widths.

## Verification

Formal verification of the width-resolution arithmetic was done in Dafny (4.11): it specifies the intended behavior (negative width ⇒ left-align with magnitude), proves `|i64::MIN|` overflows `i64` but fits `u64`/`usize`, and proves the `unsigned_abs()`-based implementation is overflow-free and matches the spec. Proof: `15 verified, 0 errors`.

## Tests

- New unit test `resolve_asterisk_width::asterisk_i64_min_width` (both `SignedInt` and `Unparsed` argument forms)
- New integration test `test_printf::test_asterisk_width_i64_min_no_panic`
- Full `printf` suite passes: 131 passed, 0 failed, 1 ignored; `cargo fmt` and `clippy` clean.