### PR TITLE
fmt: remove condition that is always true

### DIFF
--- a/src/uu/fmt/src/parasplit.rs
+++ b/src/uu/fmt/src/parasplit.rs
@@ -285,10 +285,9 @@ impl Iterator for FileLines<'_> {
         // treat it like a blank line, except that since it's
         // not truly blank we will not allow mail headers on the
         // following line)
-        if pmatch
-            && n[poffset + self.opts.prefix.as_ref().map_or(0, String::len)..]
-                .iter()
-                .all(|&b| is_fmt_whitespace_byte(b))
+        if n[poffset + self.opts.prefix.as_ref().map_or(0, String::len)..]
+            .iter()
+            .all(|&b| is_fmt_whitespace_byte(b))
         {
             return Some(Line::NoFormatLine(n, false));
         }


### PR DESCRIPTION
On lines 279 - 281 we do:
```rust
if !pmatch {
    return Some(Line::NoFormatLine(n, false));
}
```
From this point on, `pmatch` must be `true` and so it can be removed from the condition on line 288.