### PR TITLE
use std::io::Result<*> instead of Result<*,std::io::Error>

### DIFF
--- a/fuzz/fuzz_targets/fuzz_cksum.rs
+++ b/fuzz/fuzz_targets/fuzz_cksum.rs
@@ -10,7 +10,7 @@ use rand::RngExt;
 use std::env::temp_dir;
 use std::ffi::OsString;
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{self, Write};
 use std::process::Command;
 use uu_cksum::uumain;
 use uufuzz::{
@@ -79,11 +79,7 @@ fn generate_cksum_args() -> Vec<String> {
     args
 }
 
-fn generate_checksum_file(
-    algo: &str,
-    file_path: &str,
-    digest_opts: &[&str],
-) -> Result<String, std::io::Error> {
+fn generate_checksum_file(algo: &str, file_path: &str, digest_opts: &[&str]) -> io::Result<String> {
     let checksum_file_path = temp_dir().join("checksum_file");
     let mut cmd = Command::new(CMD_PATH);
     cmd.arg("-a").arg(algo);

--- a/fuzz/fuzz_targets/fuzz_non_utf8_paths.rs
+++ b/fuzz/fuzz_targets/fuzz_non_utf8_paths.rs
@@ -122,7 +122,7 @@ fn generate_non_utf8_osstring() -> OsString {
     OsString::from_vec(generate_non_utf8_bytes())
 }
 
-fn setup_test_files() -> Result<(PathBuf, Vec<PathBuf>), std::io::Error> {
+fn setup_test_files() -> std::io::Result<(PathBuf, Vec<PathBuf>)> {
     let mut rng = rand::rng();
     let temp_root = temp_dir().join(format!("utf8_test_{}", rng.random::<u64>()));
     fs::create_dir_all(&temp_root)?;

--- a/fuzz/uufuzz/src/lib.rs
+++ b/fuzz/uufuzz/src/lib.rs
@@ -15,12 +15,11 @@ use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout};
 use std::env::temp_dir;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::pipe;
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{self, Seek, SeekFrom, Write, pipe};
 use std::process::{Command, Stdio};
 use std::sync::atomic::Ordering;
 use std::sync::{Once, atomic::AtomicBool};
-use std::{io, thread};
+use std::thread;
 
 pub mod pretty_print;
 
@@ -41,7 +40,7 @@ pub struct CommandResult {
 static CHECK_GNU: Once = Once::new();
 static IS_GNU: AtomicBool = AtomicBool::new(false);
 
-pub fn is_gnu_cmd(cmd_path: &str) -> Result<(), std::io::Error> {
+pub fn is_gnu_cmd(cmd_path: &str) -> io::Result<()> {
     CHECK_GNU.call_once(|| {
         let version_output = Command::new(cmd_path).arg("--version").output().unwrap();
 
@@ -69,10 +68,8 @@ where
     F: FnOnce(std::vec::IntoIter<OsString>) -> i32 + Send + 'static,
 {
     // Duplicate the stdout and stderr file descriptors to restore later
-    let original_stdout_fd_owned =
-        dup(std::io::stdout()).expect("Failed to duplicate STDOUT_FILENO");
-    let original_stderr_fd_owned =
-        dup(std::io::stderr()).expect("Failed to duplicate STDERR_FILENO");
+    let original_stdout_fd_owned = dup(io::stdout()).expect("Failed to duplicate STDOUT_FILENO");
+    let original_stderr_fd_owned = dup(io::stderr()).expect("Failed to duplicate STDERR_FILENO");
 
     println!("Running test {:?}", &args[0..]);
     let (read_pipe_stdout, write_pipe_stdout) = pipe().expect("Failed to create pipes");
@@ -90,7 +87,7 @@ where
         input_file.seek(SeekFrom::Start(0)).unwrap();
 
         // Redirect stdin to read from the in-memory file
-        let stdin_fd = dup(std::io::stdin()).expect("Failed to duplicate STDIN");
+        let stdin_fd = dup(io::stdin()).expect("Failed to duplicate STDIN");
 
         // Redirect stdin to read from the in-memory file
         dup2_stdin(&input_file).expect("Failed to set up stdin redirection");
@@ -352,7 +349,7 @@ pub fn generate_random_string(max_length: usize) -> String {
 }
 
 #[allow(dead_code)]
-pub fn generate_random_file() -> Result<String, std::io::Error> {
+pub fn generate_random_file() -> io::Result<String> {
     let mut rng = rand::rng();
     let file_name: String = (0..10)
         .map(|_| rng.random_range(b'a'..=b'z') as char)

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -5,7 +5,7 @@
 // spell-checker:ignore reflink ftruncate pwrite fiemap lseek nofollow
 
 use rustix::fs::{SeekFrom, ftruncate, ioctl_ficlone, seek};
-use std::io::Read;
+use std::io::{self, Read};
 use std::os::unix::fs::FileExt;
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::MetadataExt;
@@ -96,7 +96,7 @@ where
     if ioctl_ficlone(dst_file, src_file).is_err() {
         return match fallback {
             CloneFallback::Error => Err(CpError::IoErrContext(
-                std::io::Error::last_os_error(),
+                io::Error::last_os_error(),
                 context.to_owned(),
             )),
             CloneFallback::FSCopy => fs_copy(source, dest, nofollow, context),
@@ -112,7 +112,7 @@ where
 /// Checks whether a file contains any non null bytes i.e. any byte != 0x0
 /// This function returns a tuple of (bool, u64, u64) signifying a tuple of (whether a file has
 /// data, its size, no of blocks it has allocated in disk)
-fn check_for_data(source: &Path, nofollow: bool) -> Result<(bool, u64, u64), std::io::Error> {
+fn check_for_data(source: &Path, nofollow: bool) -> io::Result<(bool, u64, u64)> {
     let mut src_file = open_source(source, nofollow)?;
     let metadata = src_file.metadata()?;
 
@@ -131,7 +131,7 @@ fn check_for_data(source: &Path, nofollow: bool) -> Result<(bool, u64, u64), std
 
 /// Checks whether a file is sparse i.e. it contains holes, uses the crude heuristic blocks < size / 512
 /// Reference:`<https://doc.rust-lang.org/std/os/unix/fs/trait.MetadataExt.html#tymethod.blocks>`
-fn check_sparse_detection(source: &Path, nofollow: bool) -> Result<bool, std::io::Error> {
+fn check_sparse_detection(source: &Path, nofollow: bool) -> io::Result<bool> {
     let src_file = open_source(source, nofollow)?;
     let metadata = src_file.metadata()?;
     let size = metadata.size();
@@ -155,7 +155,7 @@ where
         )
     })?;
 
-    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
+    let ctx_err = |e: io::Error| CpError::IoErrContext(e, context.to_owned());
 
     let size = src_file.metadata().map_err(&ctx_err)?.size();
     ftruncate(&dst_file, size).map_err(|e| CpError::IoErrContext(e.into(), context.to_owned()))?;
@@ -201,7 +201,7 @@ where
         )
     })?;
 
-    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
+    let ctx_err = |e: io::Error| CpError::IoErrContext(e, context.to_owned());
 
     let size: usize = src_file
         .metadata()
@@ -274,7 +274,7 @@ where
         )
     })?;
 
-    let ctx_err = |e: std::io::Error| CpError::IoErrContext(e, context.to_owned());
+    let ctx_err = |e: io::Error| CpError::IoErrContext(e, context.to_owned());
 
     let dest_is_stream = is_stream(&dst_file.metadata().map_err(&ctx_err)?);
     if !dest_is_stream {
@@ -283,7 +283,7 @@ where
     }
 
     buf_copy::copy_fast(&mut src_file, &mut dst_file)
-        .map_err(|e| std::io::Error::other(format!("{e}")))
+        .map_err(|e| io::Error::other(format!("{e}")))
         .map_err(&ctx_err)?;
 
     Ok(())
@@ -444,7 +444,7 @@ fn handle_reflink_auto_sparse_always(
     source: &Path,
     dest: &Path,
     nofollow: bool,
-) -> Result<(CopyDebug, CopyMethod), std::io::Error> {
+) -> io::Result<(CopyDebug, CopyMethod)> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::Unsupported,
@@ -477,10 +477,7 @@ fn handle_reflink_auto_sparse_always(
 
 /// Handles debug results when flags are "--reflink=auto" and "--sparse=auto" and specifies what
 /// type of copy should be used
-fn handle_reflink_never_sparse_never(
-    source: &Path,
-    nofollow: bool,
-) -> Result<CopyDebug, std::io::Error> {
+fn handle_reflink_never_sparse_never(source: &Path, nofollow: bool) -> io::Result<CopyDebug> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::No,
@@ -501,10 +498,7 @@ fn handle_reflink_never_sparse_never(
 
 /// Handles debug results when flags are "--reflink=auto" and "--sparse=never", files will be copied
 /// through cloning them with fallback switching to [`std::fs::copy`]
-fn handle_reflink_auto_sparse_never(
-    source: &Path,
-    nofollow: bool,
-) -> Result<CopyDebug, std::io::Error> {
+fn handle_reflink_auto_sparse_never(source: &Path, nofollow: bool) -> io::Result<CopyDebug> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::No,
@@ -530,7 +524,7 @@ fn handle_reflink_auto_sparse_auto(
     source: &Path,
     dest: &Path,
     nofollow: bool,
-) -> Result<(CopyDebug, CopyMethod), std::io::Error> {
+) -> io::Result<(CopyDebug, CopyMethod)> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::Unsupported,
@@ -574,7 +568,7 @@ fn handle_reflink_never_sparse_auto(
     source: &Path,
     dest: &Path,
     nofollow: bool,
-) -> Result<(CopyDebug, CopyMethod), std::io::Error> {
+) -> io::Result<(CopyDebug, CopyMethod)> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::No,
@@ -611,7 +605,7 @@ fn handle_reflink_never_sparse_always(
     source: &Path,
     dest: &Path,
     nofollow: bool,
-) -> Result<(CopyDebug, CopyMethod), std::io::Error> {
+) -> io::Result<(CopyDebug, CopyMethod)> {
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,
         reflink: OffloadReflinkDebug::No,

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashSet as HashSet;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, DirEntry, File, Metadata};
-use std::io::{BufRead, BufReader, Write, stdout};
+use std::io::{self, BufRead, BufReader, Write, stdout};
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
@@ -137,7 +137,7 @@ impl Stat {
         path: &Path,
         dir_entry: Option<&DirEntry>,
         options: &TraversalOptions,
-    ) -> std::io::Result<Self> {
+    ) -> io::Result<Self> {
         // Determine whether to dereference (follow) the symbolic link
         let should_dereference = match &options.dereference {
             Deref::All => true,
@@ -179,7 +179,7 @@ impl Stat {
         dir_fd: &DirFd,
         full_path: &Path,
         time: Option<MetadataTimeField>,
-    ) -> std::io::Result<Self> {
+    ) -> io::Result<Self> {
         // Get metadata for the directory itself using fstat
         let safe_metadata = dir_fd.metadata()?;
 
@@ -223,7 +223,7 @@ fn get_blocks(_path: &Path, metadata: &Metadata) -> u64 {
 // fails with access denied unless `FILE_FLAG_BACKUP_SEMANTICS` is set), so
 // use that flag explicitly to be able to query directories as well as files.
 #[cfg(windows)]
-fn open_for_query(path: &Path) -> std::io::Result<File> {
+fn open_for_query(path: &Path) -> io::Result<File> {
     fs::OpenOptions::new()
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
@@ -337,7 +337,7 @@ fn safe_du(
     seen_inodes: &mut HashSet<FileInfo>,
     print_tx: &mpsc::Sender<UResult<StatPrintInfo>>,
     parent_fd: Option<&DirFd>,
-    initial_stat: Option<std::io::Result<Stat>>,
+    initial_stat: Option<io::Result<Stat>>,
 ) -> Result<Stat, Box<mpsc::SendError<UResult<StatPrintInfo>>>> {
     // The caller provides an already-computed stat for this entry, which lets us
     // avoid re-stating it here. For subdirectories this saves both a redundant
@@ -642,8 +642,8 @@ fn du_regular(
 
                         // Check symlink depth limit
                         if current_symlink_depth > MAX_SYMLINK_DEPTH {
-                            print_tx.send(Err(std::io::Error::new(
-                                std::io::ErrorKind::InvalidData,
+                            print_tx.send(Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
                                 "Too many levels of symbolic links",
                             ).map_err_context(
                                 || translate!("du-error-cannot-access", "path" => entry_path.quote()),
@@ -925,15 +925,15 @@ impl StatPrinter {
 }
 
 /// Read file paths from the specified file, separated by null characters
-fn read_files_from(file_name: &OsStr) -> Result<Vec<PathBuf>, std::io::Error> {
+fn read_files_from(file_name: &OsStr) -> io::Result<Vec<PathBuf>> {
     let reader: Box<dyn BufRead> = if file_name == "-" {
         // Read from standard input
-        Box::new(BufReader::new(std::io::stdin()))
+        Box::new(BufReader::new(io::stdin()))
     } else {
         // First, check if the file_name is a directory
         let path = PathBuf::from(file_name);
         if path.is_dir() {
-            return Err(std::io::Error::other(
+            return Err(io::Error::other(
                 translate!("du-error-read-error-is-directory", "file" => file_name.maybe_quote()),
             ));
         }
@@ -941,8 +941,8 @@ fn read_files_from(file_name: &OsStr) -> Result<Vec<PathBuf>, std::io::Error> {
         // Attempt to open the file and handle the error if it does not exist
         match File::open(file_name) {
             Ok(file) => Box::new(BufReader::new(file)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(std::io::Error::other(
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(io::Error::other(
                     translate!("du-error-cannot-open-for-reading", "file" => file_name.quote()),
                 ));
             }
@@ -991,7 +991,7 @@ fn parse_block_size_arg_or_default_fallback(matches: &ArgMatches) -> UResult<Siz
     let block_size_str = matches.get_one::<String>(options::BLOCK_SIZE);
     let block_size = read_block_size(block_size_str.map(AsRef::as_ref))?;
     if block_size == 0 {
-        return Err(std::io::Error::other(translate!("du-error-invalid-block-size-argument", "option" => options::BLOCK_SIZE, "value" => block_size_str.map_or("???BUG", |v| v).quote()))
+        return Err(io::Error::other(translate!("du-error-invalid-block-size-argument", "option" => options::BLOCK_SIZE, "value" => block_size_str.map_or("???BUG", |v| v).quote()))
         .into());
     }
     Ok(SizeFormat::BlockSize(block_size))
@@ -1052,15 +1052,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let files = if let Some(file_from) = matches.get_one::<OsString>(options::FILES0_FROM) {
         if file_from == "-" && matches.get_one::<OsString>(options::FILE).is_some() {
-            return Err(std::io::Error::other(
-                translate!("du-error-extra-operand-with-files0-from",
+            return Err(
+                io::Error::other(translate!("du-error-extra-operand-with-files0-from",
                     "file" => matches
                         .get_one::<OsString>(options::FILE)
                         .unwrap()
                         .quote()
-                ),
-            )
-            .into());
+                ))
+                .into(),
+            );
         }
 
         read_files_from(file_from)?

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -11,7 +11,7 @@ use memchr::{Memchr3, memchr_iter, memmem::Finder};
 use std::cmp::Ordering;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Split, Stdin, Write, stdin, stdout};
+use std::io::{self, BufRead, BufReader, BufWriter, Split, Stdin, Write, stdin, stdout};
 use std::num::IntErrorKind;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -27,7 +27,7 @@ use uucore::{format_usage, show_error, translate};
 #[derive(Debug, Error)]
 enum JoinError {
     #[error("{}", translate!("join-error-io", "error" => .0))]
-    IOError(#[from] std::io::Error),
+    IOError(#[from] io::Error),
 
     #[error("{0}")]
     UnorderedInput(String),
@@ -233,21 +233,12 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
     }
 
     /// Write the field or the empty filler if the field is empty or not set.
-    fn write_field(
-        &self,
-        writer: &mut impl Write,
-        field: Option<&[u8]>,
-    ) -> Result<(), std::io::Error> {
+    fn write_field(&self, writer: &mut impl Write, field: Option<&[u8]>) -> io::Result<()> {
         writer.write_all(self.field_or_empty(field))
     }
 
     /// Write each field except the one at the index.
-    fn write_fields(
-        &self,
-        writer: &mut impl Write,
-        line: &Line,
-        index: usize,
-    ) -> Result<(), std::io::Error> {
+    fn write_fields(&self, writer: &mut impl Write, line: &Line, index: usize) -> io::Result<()> {
         for i in 0..line.field_ranges.len() {
             if i != index {
                 writer.write_all(self.separator.output_separator())?;
@@ -258,7 +249,7 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
     }
 
     /// Write each field or the empty filler if the field is empty or not set.
-    fn write_format<F>(&self, writer: &mut impl Write, f: F) -> Result<(), std::io::Error>
+    fn write_format<F>(&self, writer: &mut impl Write, f: F) -> io::Result<()>
     where
         F: Fn(&Spec) -> Option<&'a [u8]>,
     {
@@ -272,7 +263,7 @@ impl<'a, Sep: Separator> Repr<'a, Sep> {
         Ok(())
     }
 
-    fn write_line_ending(&self, writer: &mut impl Write) -> Result<(), std::io::Error> {
+    fn write_line_ending(&self, writer: &mut impl Write) -> io::Result<()> {
         writer.write_all(&[self.line_ending as u8])
     }
 }
@@ -499,7 +490,7 @@ impl<'a> State<'a> {
         writer: &mut impl Write,
         other: &State,
         repr: &Repr<'a, Sep>,
-    ) -> Result<(), std::io::Error> {
+    ) -> io::Result<()> {
         if self.has_line() {
             if other.has_line() {
                 self.combine(writer, other, repr)?;
@@ -519,7 +510,7 @@ impl<'a> State<'a> {
         writer: &mut impl Write,
         other: &State,
         repr: &Repr<'a, Sep>,
-    ) -> Result<(), std::io::Error> {
+    ) -> io::Result<()> {
         let key = self.get_current_key();
 
         for line1 in &self.seq {
@@ -561,10 +552,7 @@ impl<'a> State<'a> {
         }
     }
 
-    fn reset_read_line<Sep: Separator>(
-        &mut self,
-        input: &Input<Sep>,
-    ) -> Result<(), std::io::Error> {
+    fn reset_read_line<Sep: Separator>(&mut self, input: &Input<Sep>) -> io::Result<()> {
         let line = self.read_line(&input.separator)?;
         self.reset(line);
         Ok(())
@@ -584,7 +572,7 @@ impl<'a> State<'a> {
         &mut self,
         read_sep: &Sep,
         autoformat: bool,
-    ) -> std::io::Result<usize> {
+    ) -> io::Result<usize> {
         if let Some(line) = self.read_line(read_sep)? {
             self.seq.push(line);
 
@@ -620,7 +608,7 @@ impl<'a> State<'a> {
     }
 
     /// Get the next line without the order check.
-    fn read_line<Sep: Separator>(&mut self, sep: &Sep) -> Result<Option<Line>, std::io::Error> {
+    fn read_line<Sep: Separator>(&mut self, sep: &Sep) -> io::Result<Option<Line>> {
         match self.lines.next() {
             Some(value) => {
                 self.line_num += 1;
@@ -672,7 +660,7 @@ impl<'a> State<'a> {
         writer: &mut impl Write,
         line: &Line,
         repr: &Repr<'a, Sep>,
-    ) -> Result<(), std::io::Error> {
+    ) -> io::Result<()> {
         if repr.uses_format() {
             repr.write_format(writer, |spec| match *spec {
                 Spec::Key => line.get_field(self.key),
@@ -696,7 +684,7 @@ impl<'a> State<'a> {
         &self,
         writer: &mut impl Write,
         repr: &Repr<'a, Sep>,
-    ) -> Result<(), std::io::Error> {
+    ) -> io::Result<()> {
         self.write_line(writer, &self.seq[0], repr)
     }
 }

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::ffi::OsStr;
 use std::fs::metadata;
-use std::io::{Read, Write, stderr, stdin, stdout};
+use std::io::{self, Read, Write, stderr, stdin, stdout};
 use std::num::IntErrorKind;
 use std::path::PathBuf;
 use std::str::Utf8Error;
@@ -186,16 +186,13 @@ enum PrError {
     EncounteredErrors { msg: String },
 
     #[error("pr: {}", strip_errno(.0))]
-    Read(std::io::Error),
+    Read(io::Error),
 
     #[error("pr: {}", strip_errno(.0))]
-    Write(std::io::Error),
+    Write(io::Error),
 
     #[error("pr: {path}: {}", strip_errno(error))]
-    ReadPath {
-        path: PathBuf,
-        error: std::io::Error,
-    },
+    ReadPath { path: PathBuf, error: io::Error },
 }
 
 pub fn uu_app() -> Command {
@@ -1320,7 +1317,7 @@ fn write_page(
     lines: &[FileLine],
     options: &OutputOptions,
     page: usize,
-) -> Result<(), std::io::Error> {
+) -> io::Result<()> {
     let line_separator = options.line_separator.as_bytes();
     let page_separator = options.page_separator_char.as_bytes();
 
@@ -1417,7 +1414,7 @@ fn to_table_short_file(
 
 /// Write `n` space characters to `out` in fixed-size chunks, so the indent is
 /// streamed rather than allocated up front.
-fn write_offset_spaces(out: &mut impl Write, mut n: usize) -> Result<(), std::io::Error> {
+fn write_offset_spaces(out: &mut impl Write, mut n: usize) -> io::Result<()> {
     const SPACES: [u8; 256] = [b' '; 256];
     while n > 0 {
         let chunk = n.min(SPACES.len());
@@ -1432,7 +1429,7 @@ fn write_columns(
     writer: &mut impl Write,
     lines: &[FileLine],
     options: &OutputOptions,
-) -> Result<(), std::io::Error> {
+) -> io::Result<()> {
     let line_separator = options.content_line_separator.as_bytes();
 
     let content_lines_per_page = if options.double_space {

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -25,7 +25,7 @@ use std::borrow::Cow;
 use std::cell::OnceCell;
 use std::ffi::{OsStr, OsString};
 use std::fs::{FileType, Metadata};
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
 use std::{env, fs};
@@ -130,7 +130,7 @@ fn write_padded_bytes<W: Write>(
     left: bool,
     width: usize,
     precision: Precision,
-) -> Result<(), std::io::Error> {
+) -> io::Result<()> {
     let display_bytes = match precision {
         Precision::Number(p) if p < bytes.len() => &bytes[..p],
         _ => bytes,
@@ -159,7 +159,7 @@ fn write_padded_bytes<W: Write>(
 /// write padding based on a writer W and n size
 /// writer is genric to be any buffer like: `std::io::stdout`
 /// n is the calculated padding size
-fn write_padding<W: Write>(writer: &mut W, n: usize) -> Result<(), std::io::Error> {
+fn write_padding<W: Write>(writer: &mut W, n: usize) -> io::Result<()> {
     for _ in 0..n {
         writer.write_all(b" ")?;
     }
@@ -430,7 +430,7 @@ fn print_os_str(s: &OsString, flags: Flags, width: usize, precision: Precision) 
 
         let bytes = s.as_bytes();
 
-        if write_padded_bytes(std::io::stdout(), bytes, flags.left, width, precision).is_err() {
+        if write_padded_bytes(io::stdout(), bytes, flags.left, width, precision).is_err() {
             // if an error occurred while trying to print bytes fall back to normal lossy string so it can be printed
             let fallback_string = s.to_string_lossy();
             print_str(&fallback_string, flags, width, precision);
@@ -723,7 +723,7 @@ fn print_unsigned_hex(
 }
 
 fn print_raw_byte(byte: u8) {
-    std::io::stdout().write_all(&[byte]).unwrap();
+    io::stdout().write_all(&[byte]).unwrap();
 }
 
 impl Stater {
@@ -1065,7 +1065,7 @@ impl Stater {
     ) -> Result<(), i32> {
         match *t {
             Token::Byte(byte) => print_raw_byte(byte),
-            Token::Char(c) => std::io::stdout()
+            Token::Char(c) => io::stdout()
                 .write_all(c.to_string().as_bytes())
                 .map_err(|_| 1)?,
 

--- a/src/uucore/src/lib/features/perms.rs
+++ b/src/uucore/src/lib/features/perms.rs
@@ -276,7 +276,7 @@ fn is_root(path: &Path, would_traverse_symlink: bool) -> bool {
     false
 }
 
-pub fn get_metadata(file: &Path, follow: bool) -> Result<Metadata, std::io::Error> {
+pub fn get_metadata(file: &Path, follow: bool) -> std::io::Result<Metadata> {
     if follow {
         file.metadata()
     } else {


### PR DESCRIPTION
for simplicity and consistency.