### PR TITLE
fix unused_qualifications lint

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1037,7 +1037,7 @@ impl Stater {
 
     fn exec(&self) -> i32 {
         #[cfg(unix)]
-        let stdin_is_fifo = rustix::fs::fstat(std::io::stdin())
+        let stdin_is_fifo = rustix::fs::fstat(io::stdin())
             .is_ok_and(|s| rustix::fs::FileType::from_raw_mode(s.st_mode).is_fifo());
 
         let mut ret = 0;


### PR DESCRIPTION
```console
$ git checkout -q 1d8091faa3c112f0f987b62dbdf456488d0d733c
$ cargo clippy --workspace --all-targets --all-features
warning: unnecessary qualification
    --> src/uu/stat/src/stat.rs:1040:47
     |
1040 |         let stdin_is_fifo = rustix::fs::fstat(std::io::stdin())
     |                                               ^^^^^^^^^^^^^^
     |
     = note: requested on the command line with `-W unused-qualifications`
help: remove the unnecessary path segments
     |
1040 -         let stdin_is_fifo = rustix::fs::fstat(std::io::stdin())
1040 +         let stdin_is_fifo = rustix::fs::fstat(io::stdin())
     |
```