### PR TITLE
mktemp: strip OS error code from permission-denied message

### DIFF
--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -8,7 +8,7 @@
 use clap::builder::{TypedValueParser, ValueParserFactory};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use uucore::display::{Quotable, println_verbatim};
-use uucore::error::{FromIo, UError, UResult, UUsageError};
+use uucore::error::{FromIo, UError, UResult, UUsageError, strip_errno};
 use uucore::format_usage;
 use uucore::translate;
 
@@ -74,6 +74,9 @@ enum MkTempError {
 
     #[error("{}", translate!("mktemp-error-not-found", "template_type" => .0.clone(), "template" => .1.quote()))]
     NotFound(String, PathBuf),
+
+    #[error("{}", strip_errno(.0))]
+    Io(std::io::Error),
 }
 
 impl UError for MkTempError {
@@ -570,7 +573,7 @@ fn make_temp_dir(dir: &Path, prefix: &str, rand: usize, suffix: &str) -> UResult
             let path = Path::new(dir).join(filename);
             Err(MkTempError::NotFound(translate!("mktemp-template-type-directory"), path).into())
         }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(MkTempError::Io(e).into()),
     }
 }
 
@@ -599,7 +602,7 @@ fn make_temp_file(dir: &Path, prefix: &str, rand: usize, suffix: &str) -> UResul
             let path = Path::new(dir).join(filename);
             Err(MkTempError::NotFound(translate!("mktemp-template-type-file"), path).into())
         }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(MkTempError::Io(e).into()),
     }
 }
 

--- a/tests/by-util/test_mktemp.rs
+++ b/tests/by-util/test_mktemp.rs
@@ -1209,3 +1209,45 @@ fn test_mktemp_hidden_file_single_dot() {
         template_name.len()
     );
 }
+
+/// Creating a temporary file or directory in an unwritable directory must fail
+/// with a clean `Permission denied` message, without leaking the raw
+/// `(os error N)` suffix or the internal `at path ...` detail that the
+/// underlying `tempfile` crate would otherwise embed.
+#[cfg(unix)]
+#[test]
+fn test_permission_denied_clean_message() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use uucore::process::geteuid;
+
+    // chmod 000 does not block root, so the assertion would not hold.
+    if geteuid() == 0 {
+        return;
+    }
+
+    let scene = TestScenario::new(util_name!());
+    let dir = scene.fixtures.plus("noperm");
+    fs::create_dir_all(&dir).unwrap();
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // File case: `mktemp -p <dir>` (default template) creates inside <dir>.
+    scene
+        .ucmd()
+        .arg("-p")
+        .arg(&dir)
+        .fails()
+        .stderr_only("mktemp: Permission denied\n");
+
+    // Directory case: `mktemp -d -p <dir>`.
+    scene
+        .ucmd()
+        .arg("-d")
+        .arg("-p")
+        .arg(&dir)
+        .fails()
+        .stderr_only("mktemp: Permission denied\n");
+
+    // Restore perms so the fixture tempdir cleanup can remove the entry.
+    let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o755));
+}


### PR DESCRIPTION
## What

Creating a temporary file or directory in an unwritable directory leaked the raw `Permission denied (os error 13) at path "..."` text from the underlying `tempfile` crate, instead of the clean `Permission denied` message used elsewhere in uutils:

```
$ coreutils mktemp -p /tmp/noperm   # chmod 000
mktemp: Permission denied (os error 13) at path "/tmp.haKXBI6xNU"
```

## Why

`tempfile` wraps the underlying `io::Error` as `io::Error::new(kind, "{<inner display>} at path {path:?}")`. That wrapper has `raw_os_error() == None`, so `UIoError::Display` skips its kind-match normalization branch and prints `self.inner.to_string()` verbatim — which still contains the `(os error 13)` suffix and the internal `at path "..."` detail.

Routing the error through a dedicated `MkTempError::Io(std::io::Error)` variant rendered with `strip_errno` (as @sylvestre suggested in the issue) drops both the `(os error N)` suffix and the internal path detail, matching how `perms.rs` (`common-write-error`) and `csplit` render io errors:

```
$ coreutils mktemp -p /tmp/noperm
mktemp: Permission denied
$ coreutils mktemp -d -p /tmp/noperm
mktemp: Permission denied
```

## Changes

- `src/uu/mktemp/src/mktemp.rs`: add `MkTempError::Io(std::io::Error)` rendered with `strip_errno`, and route the two catch-all `Err(e) => Err(e.into())` arms in `make_temp_file` / `make_temp_dir` through it.
- `tests/by-util/test_mktemp.rs`: add `test_permission_denied_clean_message` (Unix, skipped under root) asserting the clean message for both the file and directory cases.

Closes #13720.

## Verification

- `cargo build --bin coreutils --no-default-features --features mktemp`
- `cargo test --no-default-features --features mktemp --test tests -- mktemp` → 41 passed
- `cargo fmt --all -- --check` → clean
- `cargo clippy --no-default-features --features mktemp` → clean

## AI disclosure

This change was authored with the assistance of Claude (Anthropic). The diagnosis of the `UIoError::Display` fall-through, the fix design (mirroring `perms.rs` / `csplit`), the test, and the verification were all produced with AI assistance and reviewed by me.

## Note on prior claim

I saw that @AnandajithS mentioned working on this in the issue and @Devel08 followed up. No PR appeared after several days, so I went ahead. Happy to close/defer this if a PR from the original claimant is in flight — let me know.