### PR TITLE
date: support european dates and out-of-range years

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -32,6 +32,8 @@ use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetS
 
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 
+use format_modifiers::{apply_modifiers, parse_format_spec};
+
 /// OHOS helper: pass through the system time zone ID returned by
 /// TimeService (OH_TimeService_GetTimeZone, e.g. "Asia/Shanghai") and
 /// resolve it against the embedded IANA tzdata (jiff-tzdb) so that
@@ -288,6 +290,120 @@ fn strip_parenthesized_comments(input: &str) -> Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Split a single whitespace-separated token of the European date form
+/// `DAY.MONTH.` (year omitted) or `DAY.MONTH.YEAR`, returning the day, the
+/// month and the year text. Other tokens return `None`, so time strings with
+/// dots (e.g. `5:15:30.25` or `10.5`) or ISO dates never match.
+fn european_date_token(token: &str) -> Option<(u8, u8, Option<&str>)> {
+    let mut parts = token.split('.');
+
+    let day = parts.next()?;
+    let month = parts.next()?;
+    // Everything after `DAY.MONTH` (possibly empty, i.e. a trailing dot).
+    let rest = parts.next()?;
+    if parts.next().is_some()
+        || day.is_empty()
+        || day.len() > 2
+        || !day.chars().all(|c| c.is_ascii_digit())
+        || month.is_empty()
+        || month.len() > 2
+        || !month.chars().all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let year = if rest.is_empty() {
+        None
+    } else if rest.chars().all(|c| c.is_ascii_digit()) {
+        Some(rest)
+    } else {
+        return None;
+    };
+
+    let day: u8 = day.parse().ok()?;
+    let month: u8 = month.parse().ok()?;
+    // Reject out-of-range values so tokens like `99.00.2024` are left
+    // untouched instead of rewritten into an invalid ISO-like date; the
+    // general parser then handles (or rejects) the original input.
+    if !(1..=31).contains(&day) || !(1..=12).contains(&month) {
+        return None;
+    }
+
+    Some((day, month, year))
+}
+
+/// One entry of `rewrite_european_date`'s replacement table: `None` removes
+/// the token (a consumed separate-year), `Some((year, [day, month]))`
+/// rewrites it as ISO `YYYY-MM-DD`.
+type TokenReplacement = (usize, Option<(String, [u8; 2])>);
+
+/// Rewrite European date form to ISO `YYYY-MM-DD` so the general parser
+/// can handle it.
+///
+/// `date` accepts `DAY.MONTH[.YEAR]` dates (e.g. `13.09.1999`). When the
+/// year is omitted (`05.12.`) the current year is used. A year may also
+/// immediately follow as a separate token of three or more digits
+/// (`09.11. 2007`);
+/// numbers of one or two digits after the date are times of day instead
+/// (`09.11. 3` is 03:00). Tokens that do not look like a European date are
+/// left untouched, so times (`5:15:30.25`), timezone suffixes and relative
+/// items still parse.
+fn rewrite_european_date(input: &str, now: &Zoned) -> String {
+    // European dates always contain a dot; skip tokenizing other inputs.
+    if !input.contains('.') {
+        return input.to_string();
+    }
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    let mut changed = false;
+    let mut replacements: Vec<TokenReplacement> = Vec::new();
+
+    for (index, token) in tokens.iter().enumerate() {
+        let Some((day, month, inline_year)) = european_date_token(token) else {
+            continue;
+        };
+
+        // A separate year, if any, is the token immediately following the
+        // date, made up of three or more digits (two-digit numbers are times,
+        // e.g. `1.2. 3`). Only the adjacent token counts: scanning further
+        // ahead could consume an unrelated number. It only applies when the
+        // date token itself carries no year.
+        let year_index = inline_year.is_none().then(|| index + 1).filter(|&i| {
+            tokens
+                .get(i)
+                .is_some_and(|t| t.chars().all(|c| c.is_ascii_digit()) && t.len() >= 3)
+        });
+        let year = year_index
+            .map(|i| tokens[i])
+            .or(inline_year)
+            .map_or_else(|| now.year().to_string(), str::to_owned);
+
+        replacements.push((index, Some((year, [day, month]))));
+        if let Some(year_index) = year_index {
+            replacements.push((year_index, None));
+        }
+        changed = true;
+        break;
+    }
+
+    if !changed {
+        return input.to_string();
+    }
+
+    tokens
+        .iter()
+        .enumerate()
+        .map(
+            |(index, token)| match replacements.iter().find(|(i, _)| *i == index) {
+                Some((_, Some((year, [day, month])))) => format!("{year}-{month:02}-{day:02}"),
+                Some((_, None)) => String::new(),
+                None => (*token).to_string(),
+            },
+        )
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Parse military timezone with optional hour offset.
 /// Pattern: single letter (a-z except j) optionally followed by 1-2 digits.
 /// Returns Some(total_hours_in_utc) or None if pattern doesn't match.
@@ -432,7 +548,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let set_to = match matches.get_one::<String>(OPT_SET) {
         None => None,
-        Some(input) => match parse_date(input, &now, DebugOptions::new(debug_mode, true), false) {
+        Some(input) => match parse_date(input, &now, DebugOptions::new(debug_mode, true)) {
             Ok(ParsedDateTime::InRange(date)) => Some(date),
             Ok(ParsedDateTime::Extended(_)) | Err(_) => {
                 return Err(Box::new(DateError::InvalidDate {
@@ -454,7 +570,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return set_system_datetime(convert_for_set(date, settings.utc));
     }
 
-    let allow_extended = matches!(settings.format, Format::Default);
     let output_time_zone = now.time_zone().clone();
 
     // Iterate over all dates - whether it's a single date or a file.
@@ -468,7 +583,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     input,
                     &now,
                     DebugOptions::new(settings.debug, warn_midnight),
-                    allow_extended,
                 )
             };
 
@@ -584,7 +698,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             std::io::stdin(),
             &now,
             DebugOptions::new(settings.debug, true),
-            allow_extended,
         ),
         DateSource::File(ref path) => {
             if path.is_dir() {
@@ -594,12 +707,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
             let file =
                 File::open(path).map_err_context(|| path.as_os_str().maybe_quote().to_string())?;
-            parse_dates_from_reader(
-                file,
-                &now,
-                DebugOptions::new(settings.debug, true),
-                allow_extended,
-            )
+            parse_dates_from_reader(file, &now, DebugOptions::new(settings.debug, true))
         }
         DateSource::FileMtime(ref path) => {
             let metadata = std::fs::metadata(path)
@@ -906,7 +1014,13 @@ fn format_extended_default(
         surrogate.offset().seconds(),
     )
     .map_err(str::to_string)?;
-    let format_string = substitute_extended_year(format_string, output.year)?;
+    // Strip `%O` first so `%OY` also reaches the substitution below as `%Y`
+    // (`%O` is a no-op in the C locale). Formats without a year specifier
+    // (e.g. "%H") need no substitution; the surrogate renders the same
+    // fields the real date would.
+    let stripped = strip_o_modifier(format_string);
+    let format_string =
+        substitute_extended_year(&stripped, output.year).map(|opt| opt.unwrap_or(stripped))?;
 
     format_date_with_locale_aware_months(&surrogate, &format_string, config, false)
 }
@@ -917,35 +1031,95 @@ fn surrogate_year(year: u32) -> i16 {
     (BASE + (i64::from(year) - BASE).rem_euclid(400)) as i16
 }
 
-fn substitute_extended_year(format_string: &str, year: u32) -> Result<String, String> {
+/// Substitute the real extended year for every explicit year specifier, so
+/// `ParsedDateTime::Extended` values render correctly with arbitrary formats.
+///
+/// Flags and widths (`%+Y`, `%10Y`, …) are parsed with the same grammar as
+/// [`format_modifiers`] and applied to the real year via [`apply_modifiers`],
+/// so extended years get identical modifier semantics to in-range dates.
+/// The surrogate date then renders all remaining fields identically (the
+/// 400-year Gregorian cycle preserves month/day/weekday).
+///
+/// `%G`/`%g` are ISO week-numbering years: approximated as the calendar year,
+/// which differs only for dates near a year boundary. Bare `%F`/`%D`/`%v`
+/// are expanded to their primitive equivalents; those composites *with*
+/// modifiers, and locale composites (`%x`/`%c`), are left for the surrogate
+/// (a known approximation: the C locale's `%x` uses a 2-digit year, which the
+/// surrogate preserves exactly since it is congruent to the real year mod 100).
+fn substitute_extended_year(format_string: &str, year: u32) -> Result<Option<String>, String> {
     let mut output = String::with_capacity(format_string.len() + 8);
-    let mut chars = format_string.chars().peekable();
-    let year = year.to_string();
+    let year_str = year.to_string();
+    let short_year = format!("{:02}", year % 100);
+    let century = format!("{:02}", year / 100);
     let mut replaced = false;
 
-    while let Some(ch) = chars.next() {
-        if ch != '%' {
-            output.push(ch);
+    let bytes = format_string.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'%' {
+            let ch_len = format_string[i..].chars().next().map_or(1, char::len_utf8);
+            output.push_str(&format_string[i..i + ch_len]);
+            i += ch_len;
             continue;
         }
-
-        match chars.next() {
-            Some('%') => output.push_str("%%"),
-            Some('Y') => {
-                output.push_str(&year);
+        // Keep `%%` intact so it still renders as a literal percent.
+        if bytes.get(i + 1) == Some(&b'%') {
+            output.push_str("%%");
+            i += 2;
+            continue;
+        }
+        let Some(parsed) = parse_format_spec(&format_string[i..]) else {
+            output.push('%');
+            i += 1;
+            continue;
+        };
+        // Year specifiers never carry `:` prefixes; anything else (e.g. `%:z`)
+        // passes through for the surrogate formatter.
+        let base = match parsed.spec {
+            "Y" | "G" => Some(&year_str),
+            "y" | "g" => Some(&short_year),
+            "C" => Some(&century),
+            _ => None,
+        };
+        if let Some(base) = base {
+            output.push_str(&apply_modifiers(base, &parsed).map_err(|e| e.to_string())?);
+            replaced = true;
+            i += parsed.len;
+            continue;
+        }
+        // Bare composites expand to primitives with the real year; modified
+        // composites are left for the surrogate (see doc comment).
+        let bare_composite = parsed.flags.is_empty() && parsed.width.is_none();
+        match parsed.spec {
+            "F" if bare_composite => {
+                // `%F` is `%Y-%m-%d`; only the year needs substituting.
+                output.push_str(&year_str);
+                output.push_str("-%m-%d");
                 replaced = true;
+                i += parsed.len;
             }
-            Some(specifier) => {
-                output.push('%');
-                output.push(specifier);
+            "D" if bare_composite => {
+                // `%D` is `%m/%d/%y`.
+                output.push_str("%m/%d/");
+                output.push_str(&short_year);
+                replaced = true;
+                i += parsed.len;
             }
-            None => output.push('%'),
+            "v" if bare_composite => {
+                // `%v` is `%e-%b-%Y`.
+                output.push_str("%e-%b-");
+                output.push_str(&year_str);
+                replaced = true;
+                i += parsed.len;
+            }
+            _ => {
+                output.push_str(&format_string[i..i + parsed.len]);
+                i += parsed.len;
+            }
         }
     }
 
-    replaced
-        .then_some(output)
-        .ok_or_else(|| "default date format does not contain %Y".to_string())
+    Ok(replaced.then_some(output))
 }
 
 fn format_date_with_locale_aware_months(
@@ -1159,7 +1333,6 @@ fn parse_dates_from_reader<R: Read + 'static>(
     reader: R,
     now: &Zoned,
     dbg_opts: DebugOptions,
-    allow_extended: bool,
 ) -> Box<
     dyn Iterator<Item = Result<ParsedDateTime, (String, parse_datetime::ParseDateTimeError)>> + '_,
 > {
@@ -1170,7 +1343,7 @@ fn parse_dates_from_reader<R: Read + 'static>(
             bytes.pop();
         }
         match String::from_utf8(bytes) {
-            Ok(s) => parse_date(s, now, dbg_opts, allow_extended),
+            Ok(s) => parse_date(s, now, dbg_opts),
             // Report lines with invalid UTF-8 (with non-printable bytes
             // octal-escaped like GNU) instead of silently stopping the input
             Err(e) => Err((
@@ -1186,16 +1359,15 @@ fn parse_date<S: AsRef<str>>(
     s: S,
     now: &Zoned,
     dbg_opts: DebugOptions,
-    allow_extended: bool,
 ) -> Result<ParsedDateTime, (String, parse_datetime::ParseDateTimeError)> {
-    let input_str = s.as_ref();
+    let input_str = rewrite_european_date(s.as_ref(), now);
 
     if dbg_opts.debug {
         let _ = writeln!(stderr(), "date: input string: {input_str}");
     }
 
     // First, try to parse any timezone abbreviations
-    if let Some(zoned) = try_parse_with_abbreviation(input_str, now) {
+    if let Some(zoned) = try_parse_with_abbreviation(&input_str, now) {
         if dbg_opts.debug {
             let mut err = stderr().lock();
             let _ = writeln!(
@@ -1214,7 +1386,7 @@ fn parse_date<S: AsRef<str>>(
         return Ok(ParsedDateTime::InRange(zoned));
     }
 
-    match parse_datetime::parse_datetime_at_date(now.clone(), input_str) {
+    match parse_datetime::parse_datetime_at_date(now.clone(), &input_str) {
         // Convert to system timezone for display
         // (parse_datetime returns a value in the input's timezone)
         Ok(ParsedDateTime::InRange(date)) => {
@@ -1252,12 +1424,8 @@ fn parse_date<S: AsRef<str>>(
             }
             Ok(ParsedDateTime::InRange(result))
         }
-        Ok(ParsedDateTime::Extended(date)) if allow_extended => Ok(ParsedDateTime::Extended(date)),
-        Ok(ParsedDateTime::Extended(_)) => Err((
-            input_str.into(),
-            parse_datetime::ParseDateTimeError::InvalidInput,
-        )),
-        Err(e) => Err((input_str.into(), e)),
+        Ok(ParsedDateTime::Extended(date)) => Ok(ParsedDateTime::Extended(date)),
+        Err(e) => Err((s.as_ref().into(), e)),
     }
 }
 
@@ -1411,14 +1579,9 @@ mod tests {
     #[test]
     fn test_abbreviation_resolves_relative_date_against_now() {
         let now = "2025-03-15T20:00:00+00:00[UTC]".parse::<Zoned>().unwrap();
-        let result = parse_date(
-            "yesterday 10:00 GMT",
-            &now,
-            DebugOptions::new(false, false),
-            false,
-        )
-        .unwrap()
-        .expect_in_range();
+        let result = parse_date("yesterday 10:00 GMT", &now, DebugOptions::new(false, false))
+            .unwrap()
+            .expect_in_range();
         assert_eq!(result.date(), jiff::civil::date(2025, 3, 14));
     }
 
@@ -1430,7 +1593,6 @@ mod tests {
             "Sat 20 Mar 2021 14:53:01 AWST",
             &now,
             DebugOptions::new(false, false),
-            false,
         )
         .unwrap()
         .expect_in_range();
@@ -1470,5 +1632,131 @@ mod tests {
         assert_eq!(strip_parenthesized_comments("a(b(c)d)e"), "ae"); // Nested balanced
         assert_eq!(strip_parenthesized_comments("a(b(c)d"), "a"); // Nested unbalanced
         assert_eq!(strip_parenthesized_comments("a(b)c(d)e(f"), "ace"); // Multiple groups, last unmatched
+    }
+
+    #[test]
+    fn test_rewrite_european_date() {
+        // `now` is pinned years away from the real clock: the year filled into
+        // year less dates comes from this `now`, never from the calendar.
+        let now = "2033-06-15T12:00:00+00:00[UTC]".parse::<Zoned>().unwrap();
+        let rewrite = |input: &str| rewrite_european_date(input, &now);
+
+        // Every day/month/year combination, with and without zero padding,
+        // normalizes to the ISO form.
+        for &(day, month, year) in &[
+            (1, 1, 1999),
+            (9, 2, 2027),
+            (31, 12, 2400),
+            (5, 9, 8888),
+            (30, 6, 9999),
+        ] {
+            let iso = format!("{year}-{month:02}-{day:02}");
+            assert_eq!(rewrite(&format!("{day}.{month}.{year}")), iso);
+            assert_eq!(rewrite(&format!("{day:02}.{month:02}.{year}")), iso);
+        }
+
+        // A year less date is filled with the year of `now`.
+        for &(day, month) in &[(5, 12), (3, 7), (1, 1)] {
+            let iso = format!("{}-{month:02}-{day:02}", now.year());
+            assert_eq!(rewrite(&format!("{day}.{month}.")), iso);
+        }
+
+        // A date rewrite preserves token order but not whitespace: tokens are
+        // rejoined with single spaces. A time with fractional seconds is not
+        // mistaken for a date even when the date comes last.
+        assert_eq!(
+            rewrite("29.2. 8:15:30.25"),
+            format!("{}-02-29 8:15:30.25", now.year())
+        );
+        assert_eq!(
+            rewrite("  29.2.\t 8:15:30.25  "),
+            format!("{}-02-29 8:15:30.25", now.year())
+        );
+        assert_eq!(
+            rewrite("2:15:30.25 28.8."),
+            format!("2:15:30.25 {}-08-28", now.year())
+        );
+
+        // An immediately following three-or-more digit token is a separate
+        // year; a shorter one stays where it is the way a time of day would.
+        assert_eq!(rewrite("11.6. 4312"), "4312-06-11");
+        assert_eq!(
+            rewrite("11.6. 2035+1"),
+            format!("{}-06-11 2035+1", now.year())
+        );
+        assert_eq!(rewrite("11.6. 23"), format!("{}-06-11 23", now.year()));
+        assert_eq!(rewrite("11.6. 23.5"), format!("{}-06-11 23.5", now.year()));
+
+        // Out-of-range day/month values are not European dates; the input is
+        // left untouched for the general parser.
+        for out_of_range in ["00.05.2024", "32.01.2024", "11.00.2024", "11.13.2024"] {
+            assert_eq!(rewrite(out_of_range), out_of_range);
+        }
+
+        // Only the immediately following token can be a separate year; a
+        // number further away stays where it is.
+        assert_eq!(
+            rewrite("09.11. foo 2004"),
+            format!("{}-11-09 foo 2004", now.year())
+        );
+
+        // Inline year variants: one or two digits are passed through untouched
+        // (the general parser maps two-digit years to the 1969-2068 window);
+        // longer years are kept whole; a following token (e.g. a timezone) is
+        // not consumed as part of the date.
+        assert_eq!(rewrite("11.6.99"), "99-06-11");
+        assert_eq!(rewrite("11.6.12000"), "12000-06-11");
+        assert_eq!(rewrite("11.6.1998 UTC"), "1998-06-11 UTC");
+
+        // A non-digit suffix is not a European date; leave it untouched so
+        // the parser reports the original input instead of silently dropping it.
+        for unchanged_suffix in ["11.6.FOO", "11.6.true"] {
+            assert_eq!(rewrite(unchanged_suffix), unchanged_suffix);
+        }
+        for unchanged in [
+            "2027-11-30",
+            "8:15:30.25",
+            "11.6",
+            "11.6.5.5",
+            "3.14",
+            "11.",
+            "2027.11.30",
+            "next monday",
+        ] {
+            assert_eq!(rewrite(unchanged), unchanged);
+        }
+    }
+
+    #[test]
+    fn test_parse_european_date() {
+        let now = "2033-06-15T20:00:00+00:00[UTC]".parse::<Zoned>().unwrap();
+        let parse = |input: &str| parse_date(input, &now, DebugOptions::new(false, false)).unwrap();
+
+        // With an inline year, day/month/year parse from the dotted form.
+        for &(day, month, year) in &[(31, 12, 1985), (1, 3, 2064), (9, 11, 2004)] {
+            let d = parse(&format!("{day}.{month}.{year}")).expect_in_range();
+            assert_eq!((d.year(), d.month(), d.day()), (year, month, day));
+        }
+
+        // Without a year, the year of `now` is used.
+        for &(day, month) in &[(28, 7), (14, 2)] {
+            let d = parse(&format!("{day}.{month}.")).expect_in_range();
+            assert_eq!((d.year(), d.month(), d.day()), (now.year(), month, day));
+        }
+
+        // A time before or after the date, including fractional seconds, parses.
+        let d = parse(&format!("{}. 9:15:30.25", "6.4")).expect_in_range();
+        assert_eq!(
+            (d.month(), d.day(), d.hour(), d.minute(), d.second()),
+            (4, 6, 9, 15, 30)
+        );
+        let d = parse(&format!("9:15:30.25 {}.", "6.4")).expect_in_range();
+        assert_eq!((d.month(), d.day(), d.hour()), (4, 6, 9));
+
+        // A large inline year lands in the extended variant.
+        let ParsedDateTime::Extended(extended) = parse("9.11.888888") else {
+            panic!("expected extended datetime");
+        };
+        assert_eq!(extended.year, 888_888);
     }
 }

--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -85,17 +85,17 @@ fn field_width_too_large(width: usize, specifier: &str) -> FormatError {
 }
 
 /// A parsed `%`-format specifier: `%[flags][width][:colons]<letter>`.
-struct ParsedSpec<'a> {
+pub(crate) struct ParsedSpec<'a> {
     /// Flag characters from `[_0^#+-]`.
-    flags: &'a str,
+    pub(crate) flags: &'a str,
     /// Explicit width, if present. `None` means no width was specified.
     /// A value that overflows `usize` is represented as `Some(usize::MAX)` so
     /// the downstream allocation check surfaces it as `FieldWidthTooLarge`.
-    width: Option<usize>,
+    pub(crate) width: Option<usize>,
     /// The specifier itself, including any leading colons (e.g. `Y`, `:z`, `::z`).
-    spec: &'a str,
+    pub(crate) spec: &'a str,
     /// Total byte length of the parsed sequence including the leading `%`.
-    len: usize,
+    pub(crate) len: usize,
 }
 
 /// Try to parse a format spec at the start of `s`.
@@ -103,7 +103,9 @@ struct ParsedSpec<'a> {
 /// Implements the grammar `%[_0^#+-]*[0-9]*:{0,3}[a-zA-Z]` anchored at the
 /// beginning of `s`. Returns `None` if `s` does not start with `%` or no
 /// valid specifier follows.
-fn parse_format_spec(s: &str) -> Option<ParsedSpec<'_>> {
+///
+/// Shared with the extended-year path so both interpret flags/width identically.
+pub(crate) fn parse_format_spec(s: &str) -> Option<ParsedSpec<'_>> {
     let bytes = s.as_bytes();
     bytes.first().filter(|b| *b == &b'%')?;
 
@@ -351,7 +353,10 @@ fn strip_default_padding(value: &str) -> String {
 /// padding character (space for text, zero for numeric).
 /// Flags are processed in order so that when conflicting flags appear,
 /// the last one takes precedence (e.g., `_+` means `+` wins for padding).
-fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, FormatError> {
+///
+/// Shared with the extended-year path so real extended years get the same
+/// modifier semantics as in-range dates.
+pub(crate) fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, FormatError> {
     let flags = parsed.flags;
     let width = parsed.width;
     let specifier = parsed.spec;

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -147,6 +147,128 @@ fn test_date_accepts_gnu_timezone_abbreviations() {
 }
 
 #[test]
+fn test_european_date() {
+    // DAY.MONTH.YEAR with one- or two-digit day and month. Expect the
+    // normalized ISO date; `%F` exercises the full-year renderer.
+    for (day, month, year) in [(1, 9, 1999), (7, 2, 2004), (31, 12, 2031)] {
+        let input = format!("{day}.{month}.{year}");
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", &input, "+%F"])
+            .succeeds()
+            .stdout_is(format!("{year:04}-{month:02}-{day:02}\n"));
+    }
+
+    // A long year passes through the European form too.
+    new_ucmd!()
+        .env("TZ", "UTC0")
+        .args(&["-d", "31.12.123456", "+%Y-%m-%d"])
+        .succeeds()
+        .stdout_is("123456-12-31\n");
+
+    // Two-digit years use the 1969-2068 window.
+    for (input, expected) in [("11.6.99", "1999-06-11"), ("11.6.05", "2005-06-11")] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", input, "+%Y-%m-%d"])
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+
+    // DAY.MONTH. without a year fills in the current year: it must match
+    // whatever year the binary itself reports today.
+    let current_year = new_ucmd!()
+        .env("TZ", "UTC0")
+        .arg("+%Y")
+        .succeeds()
+        .stdout_str()
+        .trim()
+        .to_string();
+    for (input, month_day) in [("05.12.", "12-05"), ("09.11.", "11-09")] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", input, "+%Y-%m-%d"])
+            .succeeds()
+            .stdout_is(format!("{current_year}-{month_day}\n"));
+    }
+
+    // A year less date combines with a time on either side; the fractional
+    // seconds inside the time token must not be read as a date.
+    for (input, expected) in [
+        ("28.07. 3:15:30.25", "07-28 03:15:30"),
+        ("3:15:30.25 28.7.", "07-28 03:15:30"),
+    ] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", input, "+%m-%d %H:%M:%S"])
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+
+    // An immediately following three-or-more digit token is the year; one or
+    // two digits are a time of day instead.
+    for spec in [
+        ("09.11. 2004", "+%Y-%m-%d", "2004-11-09"),
+        ("09.11. 23", "+%m-%d %H", "11-09 23"),
+        ("23 09.11.", "+%m-%d %H", "11-09 23"),
+    ] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", spec.0, spec.1])
+            .succeeds()
+            .stdout_is(format!("{}\n", spec.2));
+    }
+
+    // A non-digit suffix is not a European date; the error reports the
+    // original input rather than a rewritten string.
+    new_ucmd!()
+        .env("TZ", "UTC0")
+        .args(&["-d", "11.6.FOO"])
+        .fails_with_code(1)
+        .stderr_contains("invalid date '11.6.FOO'");
+}
+
+#[test]
+fn test_large_year_custom_format() {
+    // Years beyond 9999 work with any format string, not just the default.
+    for fmt in ["+%Y-%m-%d", "+%F"] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", "1234567890-01-01", fmt])
+            .succeeds()
+            .stdout_is("1234567890-01-01\n");
+    }
+
+    // Year-derived specifiers render the real extended year, not the surrogate.
+    for (fmt, expected) in [
+        ("+%Y", "1234567890\n"),
+        ("+%y", "90\n"),
+        ("+%C", "12345678\n"),
+        ("+%G", "1234567890\n"),
+        ("+%g", "90\n"),
+        ("+%D", "01/01/90\n"),
+        ("+%v", " 1-Jan-1234567890\n"),
+        // Flags and widths use the same modifier semantics as in-range dates.
+        ("+%+Y", "+1234567890\n"),
+        ("+%10Y", "1234567890\n"),
+        ("+%+6Y", "+1234567890\n"),
+    ] {
+        new_ucmd!()
+            .env("TZ", "UTC0")
+            .args(&["-d", "1234567890-01-01", fmt])
+            .succeeds()
+            .stdout_is(expected);
+    }
+
+    // A year beyond the parser's representable range is rejected.
+    new_ucmd!()
+        .env("TZ", "UTC0")
+        .args(&["-d", "999999999999-01-01", "+%Y-%m-%d"])
+        .fails_with_code(1)
+        .stderr_contains("invalid date");
+}
+
+#[test]
 fn test_format_option_not_to_capture_other_valid_arguments() {
     new_ucmd!()
         .arg("+%Y%m%d%H%M%S")


### PR DESCRIPTION
`date` accepts `DAY.MONTH[.YEAR]` dates (yearless forms use the current
year) and years beyond 9999 with any format. uutils/coreutils rejected both,
failing parts of tests/date/date.pl.

Rewrite european dates to ISO before parsing; accept extended years for
all output formats. Adds unit and integration tests.

tests/date/date.pl gnu test now passes.

Signed-off-by: MuntasirSZN <muntasir.joypurhat@gmail.com>
