### PR TITLE
printf: omit errno from write errors

### DIFF
--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -42,7 +42,10 @@ use crate::extendedbigdecimal::ExtendedBigDecimal;
 pub use argument::{FormatArgument, FormatArguments};
 
 use self::{escape::parse_escape_code, num_format::Formatter};
-use crate::{NonUtf8OsStrError, error::UError};
+use crate::{
+    NonUtf8OsStrError,
+    error::{UError, strip_errno},
+};
 pub use spec::Spec;
 use std::{
     error::Error,
@@ -113,7 +116,7 @@ impl Display for FormatError {
             Self::InvalidPrecision(precision) => write!(f, "invalid precision: '{precision}'"),
             // TODO: Error message below needs some work
             Self::WrongSpecType => write!(f, "wrong % directive type was given"),
-            Self::IoError(e) => write!(f, "write error: {e}"),
+            Self::IoError(e) => write!(f, "write error: {}", strip_errno(e)),
             Self::NoMoreArguments => write!(f, "no more arguments"),
             Self::InvalidArgument(_) => write!(f, "invalid argument"),
             Self::MissingHex => write!(f, "missing hexadecimal number in escape"),

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1507,6 +1507,18 @@ fn test_emoji_formatting() {
         .stdout_only("Status: Success 🚀 🎯 Count: 42\n");
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_write_error_omits_errno() {
+    let dev_full = std::fs::File::create("/dev/full").expect("failed to open /dev/full");
+
+    new_ucmd!()
+        .arg("\n")
+        .set_stdout(dev_full)
+        .fails_with_code(1)
+        .stderr_only("printf: write error: No space left on device\n");
+}
+
 #[test]
 fn test_large_width_format() {
     // Test that extremely large width specifications fail gracefully with an error


### PR DESCRIPTION
## Summary

- strip Rust's trailing errno annotation from format write errors using the existing uucore helper
- add a Linux regression that writes printf output to /dev/full and checks the exact diagnostic and exit status

## Validation

- cargo test --locked -p uucore --features format
- cargo test --locked --features printf --no-default-features --test tests test_printf::
- Linux Rust 1.88: 131 printf tests passed, 1 ignored
- cargo clippy --locked --features printf --no-default-features --test tests -- -D warnings
- cargo fmt --all -- --check

Closes #13851