### PR TITLE
ls: only track listed directories when recursing

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1236,11 +1236,15 @@ pub fn list_with_output<O: LsOutput>(
             output.write_dir_header(path_data, config, is_first)?;
         }
 
+        // Only recursion can revisit a directory, so only then is it worth a
+        // stat to remember this one; without -R the set is never consulted.
         let mut listed_ancestors = FxHashSet::default();
-        listed_ancestors.insert(FileInformation::from_path(
-            path_data.path(),
-            path_data.must_dereference,
-        )?);
+        if config.recursive {
+            listed_ancestors.insert(FileInformation::from_path(
+                path_data.path(),
+                path_data.must_dereference,
+            )?);
+        }
         enter_directory(
             path_data,
             read_dir,

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7679,3 +7679,36 @@ fn test_long_options_detached() {
     new_ucmd!().arg("--time").arg("mtime").succeeds();
     new_ucmd!().arg("--block-size").arg("512").succeeds();
 }
+
+// Without -R a directory can never be revisited, so ls should not spend a stat
+// recording it for the loop detection that only recursion consults.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_no_extra_stat_without_recursion() {
+    use std::process::Command;
+
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.mkdir("some-dir");
+
+    let stats_of_some_dir = |args: &[&str]| -> Option<usize> {
+        let output = Command::new("strace")
+            .args(["-qq", "-e", "trace=stat,statx,lstat,newfstatat"])
+            .arg(&scene.bin_path)
+            .arg(scene.util_name.as_str())
+            .args(args)
+            .current_dir(scene.fixtures.as_string())
+            .output()
+            .ok()?;
+        let trace = String::from_utf8_lossy(&output.stderr);
+        // No syscalls traced at all means strace could not do its job here.
+        if !trace.contains("(") {
+            return None;
+        }
+        Some(trace.lines().filter(|l| l.contains("\"some-dir\"")).count())
+    };
+
+    let Some(count) = stats_of_some_dir(&["-F", "--color=always", "some-dir"]) else {
+        return; // strace unavailable, e.g. restricted ptrace in a container
+    };
+    assert_eq!(count, 1, "expected a single stat of the directory operand");
+}

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7701,7 +7701,7 @@ fn test_no_extra_stat_without_recursion() {
             .ok()?;
         let trace = String::from_utf8_lossy(&output.stderr);
         // No syscalls traced at all means strace could not do its job here.
-        if !trace.contains("(") {
+        if !trace.contains('(') {
             return None;
         }
         Some(trace.lines().filter(|l| l.contains("\"some-dir\"")).count())


### PR DESCRIPTION
Should make test ls/stat-free-symlinks.sh pass