### PR TITLE
Revert "ci: trust preinstalled Homebrew taps on macOS"

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -395,10 +395,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
-    - name: Trust preinstalled Homebrew taps
-      run: brew trust aws/tap
-      if: runner.os == 'macOS'
     - name: Avoid no space left on device
       shell: bash
       run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android &
@@ -724,10 +720,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
-    - name: Trust preinstalled Homebrew taps
-      run: brew trust aws/tap
-      if: runner.os == 'macOS'
     - uses: taiki-e/install-action@v2
       with:
         tool: nextest,grcov@0.8.24

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -37,10 +37,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
-    - name: Trust preinstalled Homebrew taps
-      run: brew trust aws/tap
-      if: runner.os == 'macOS'
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
@@ -414,10 +410,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
-    - name: Trust preinstalled Homebrew taps
-      run: brew trust aws/tap
-      if: runner.os == 'macOS'
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       id: sccache-setup
@@ -571,10 +563,6 @@ jobs:
     - uses: actions/checkout@v7.0.1
       with:
         persist-credentials: false
-    # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
-    - name: Trust preinstalled Homebrew taps
-      run: brew trust aws/tap
-      if: runner.os == 'macOS'
     - uses: Swatinem/rust-cache@v2
     - name: Run sccache-cache
       id: sccache-setup


### PR DESCRIPTION
This reverts commit c63f02e4153a8edd708bb705c484fd4c04c698cc.

https://github.com/actions/runner-images/pull/14543 was completed upstream.