### PR TITLE
printf: avoid panic on i64::MIN dynamic field width

### DIFF
--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -511,7 +511,10 @@ fn resolve_asterisk_width(
         Some(CanAsterisk::Asterisk(loc)) => {
             let nb = args.next_i64(loc);
             if nb < 0 {
-                Some((usize::try_from(-(nb as isize)).ok().unwrap_or(0), true))
+                // A negative width means left alignment; its magnitude is the
+                // width. Use unsigned_abs so that i64::MIN (which has no positive
+                // counterpart as an i64) does not overflow when negated.
+                Some((usize::try_from(nb.unsigned_abs()).ok().unwrap_or(0), true))
             } else {
                 Some((usize::try_from(nb).ok().unwrap_or(0), false))
             }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -440,6 +440,17 @@ fn sub_min_width_negative() {
 }
 
 #[test]
+fn sub_asterisk_width_i64_min_no_panic() {
+    // A dynamic width of i64::MIN must not panic with "attempt to negate with
+    // overflow" (#13766). Its magnitude exceeds the maximum width, so printf
+    // fails cleanly with exit code 1 rather than aborting (which would be 134).
+    new_ucmd!()
+        .args(&["%*d", "-9223372036854775808", "1"])
+        .fails_with_code(1)
+        .stderr_contains("width too large");
+}
+
+#[test]
 fn sub_str_max_chars_input() {
     new_ucmd!()
         .args(&["hello %7.2s", "world"])


### PR DESCRIPTION
## Summary

`printf`'s `%*d` dynamic field width panics when the width argument is `i64::MIN`:

```
$ printf '%*d' -9223372036854775808 1
thread 'main' panicked at .../spec.rs: attempt to negate with overflow
$ echo $?
134
```

(under `-C overflow-checks`).

## Root cause

For a negative width, `resolve_asterisk_width` computes the magnitude as
`-(nb as isize)`. When `nb` is `i64::MIN` there is no positive counterpart as an
`i64`/`isize`, so the negation overflows.

## Fix

Use `nb.unsigned_abs()` to obtain the magnitude, which is defined for `i64::MIN`.
The resulting width exceeds `MAX_FORMAT_WIDTH`, so `printf` now fails cleanly with
"formatting width too large" (exit 1) instead of aborting. Normal `%*d` widths,
including negative (left-aligned) ones, are unchanged. Adds a regression test.

Fixes #13766.
