### PR TITLE
nl: reject line number width above INT_MAX instead of aborting

### DIFF
--- a/src/uu/nl/src/helper.rs
+++ b/src/uu/nl/src/helper.rs
@@ -67,9 +67,11 @@ pub fn parse_options(settings: &mut crate::Settings, opts: &clap::ArgMatches) ->
         Some(Ok(style)) => settings.footer_numbering = style,
         Some(Err(message)) => errs.push(message),
     }
-    match opts.get_one::<usize>(options::NUMBER_WIDTH) {
+    // The upper bound is enforced by clap (see the argument definition); only
+    // the zero case is reported here, to match GNU's message for it.
+    match opts.get_one::<u64>(options::NUMBER_WIDTH) {
         None => {}
-        Some(num) if *num > 0 => settings.number_width = *num,
+        Some(num) if *num > 0 => settings.number_width = *num as usize,
         Some(_) => errs.push(translate!("nl-error-invalid-line-width", "value" => "0")),
     }
     if let Some(num) = opts.get_one::<u64>(options::JOIN_BLANK_LINES) {

--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -376,7 +376,10 @@ pub fn uu_app() -> Command {
                 .long(options::NUMBER_WIDTH)
                 .help(translate!("nl-help-number-width"))
                 .value_name("NUMBER")
-                .value_parser(clap::value_parser!(usize)),
+                // Bound the width to a C int like GNU. This rejects a huge width
+                // up front instead of letting a later `" ".repeat(width + 1)`
+                // abort with a capacity overflow (#13347).
+                .value_parser(clap::value_parser!(u64).range(..=i32::MAX as u64)),
         )
 }
 

--- a/tests/by-util/test_nl.rs
+++ b/tests/by-util/test_nl.rs
@@ -188,6 +188,17 @@ fn test_number_width_zero() {
 }
 
 #[test]
+fn test_number_width_above_int_max_is_rejected() {
+    // A field width above i32::MAX is rejected up front by clap, matching GNU's
+    // C-int bound, instead of aborting with a capacity overflow (#13347).
+    new_ucmd!()
+        .args(&["-w", "2147483648"])
+        .pipe_in("x\n")
+        .fails()
+        .stderr_contains("is not in 0..=2147483647");
+}
+
+#[test]
 fn test_invalid_number_width() {
     for arg in ["-winvalid", "--number-width=invalid"] {
         new_ucmd!()


### PR DESCRIPTION
## Summary

`nl -w N` accepts an arbitrarily large line-number field width and aborts with a
capacity overflow for very large values:

```
$ printf '\n' | nl -w 9223372036854775807
thread 'main' panicked at library/alloc/src/slice.rs: capacity overflow
Aborted (core dumped)
$ echo $?
134
```

## Root cause

The width is only checked for `> 0`. A large width then reaches
`" ".repeat(number_width + 1)`, which aborts when the requested capacity exceeds
`isize::MAX`.

## Fix

Match GNU, which bounds `-w` to a C `int` (`[1, INT_MAX]`): reject a width above
`i32::MAX` up front with the existing "invalid line number field width" error
(exit 1) instead of aborting. Widths up to `i32::MAX` are still accepted, as in
GNU. Adds a regression test.

```
$ printf '\n' | nl -w 2147483648   # INT_MAX + 1
nl: Invalid line number field width: '2147483648': Numerical result out of range
$ echo $?
1
```

Fixes #13347.
