### PR TITLE
printf: avoid panic on %s/%c field width above u16::MAX

### DIFF
--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -550,12 +550,29 @@ fn write_padded(
 
     if left {
         writer.write_all(text)?;
-        write!(writer, "{: <padlen$}", "")
+        write_spaces(&mut writer, padlen)
     } else {
-        write!(writer, "{: >padlen$}", "")?;
+        write_spaces(&mut writer, padlen)?;
         writer.write_all(text)
     }
     .map_err(FormatError::IoError)
+}
+
+/// Write `n` space bytes directly to `writer`.
+///
+/// Unlike `write!(writer, "{: <n$}", "")`, this does not feed `n` into Rust's
+/// dynamic-width formatting, which panics with "Formatting argument out of
+/// range" once the width exceeds `u16::MAX`. A `%s`/`%c` field width above that
+/// bound is valid input for `printf`, so it must not panic (#12593, #12900).
+fn write_spaces(mut writer: impl Write, n: usize) -> std::io::Result<()> {
+    const SPACES: [u8; 64] = [b' '; 64];
+    let mut remaining = n;
+    while remaining > 0 {
+        let chunk = remaining.min(SPACES.len());
+        writer.write_all(&SPACES[..chunk])?;
+        remaining -= chunk;
+    }
+    Ok(())
 }
 
 /// Check for a number ending with a '$'

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -440,6 +440,19 @@ fn sub_min_width_negative() {
 }
 
 #[test]
+fn sub_string_char_width_above_u16_max_no_panic() {
+    // A %s/%c field width above u16::MAX must not panic (#12593, #12900).
+    new_ucmd!()
+        .args(&["%100000c", "A"])
+        .succeeds()
+        .stdout_only(format!("{}A", " ".repeat(99999)));
+    new_ucmd!()
+        .args(&["%-100000s", "hi"])
+        .succeeds()
+        .stdout_only(format!("hi{}", " ".repeat(99998)));
+}
+
+#[test]
 fn sub_str_max_chars_input() {
     new_ucmd!()
         .args(&["hello %7.2s", "world"])


### PR DESCRIPTION
## Summary

`printf` panics on a `%s` or `%c` field width above `u16::MAX`:

```
$ printf '%111111c' A
thread 'main' panicked at .../num_format or spec.rs: Formatting argument out of range
$ printf '%-101727s' hi
thread 'main' panicked at ...: Formatting argument out of range
```

## Root cause

`write_padded` (in `src/uucore/src/lib/features/format/spec.rs`) pads with Rust's
dynamic-width formatting (`write!(writer, "{: <padlen$}", "")`). The standard formatter
caps a dynamic width at `u16::MAX`, so any padding above 65535 panics. The existing
`// TODO: We need to not use Rust's formatting for aligning the output, so that we can just
write bytes to stdout without panicking.` in the `%s` arm points at exactly this.

## Fix

Write the padding spaces directly as bytes via a small `write_spaces` helper (in 64-byte
chunks) instead of going through `write!`. This lets `%s`/`%c` field widths up to the
existing `MAX_FORMAT_WIDTH` work without panicking; the `check_width` guard is unchanged, so
widths above that still return a clean error. Fixes both `%c` and `%s`.

## Verification

```
$ printf '%111111c' A | wc -c      # 111111, no panic
$ printf '%-101727s' hi | wc -c    # 101727, no panic
$ printf '[%5s][%-5s][%3c]' hi hi X   # "[   hi][hi   ][  X]"  (unchanged)
$ cargo test -p coreutils --test tests sub_string_char_width_above   # ok
$ cargo fmt -p uucore -- --check ; cargo clippy -p uucore --features format   # clean
```

Adds a regression test `sub_string_char_width_above_u16_max_no_panic`.

Fixes #12593. Fixes #12900.
