### PR TITLE
use imports instead of absolute path when using strip_errno

### DIFF
--- a/src/uu/false/src/false.rs
+++ b/src/uu/false/src/false.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 use clap::{Arg, ArgAction, Command};
 use std::io::{self, Write as _};
+use uucore::error::strip_errno;
 use uucore::{crate_version, translate};
 
 // uucore::main does not support no-result
@@ -25,7 +26,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
     if let Err(e) = res
         && e.kind() != io::ErrorKind::BrokenPipe
     {
-        let _ = writeln!(io::stderr(), "false: {}", uucore::error::strip_errno(&e));
+        let _ = writeln!(io::stderr(), "false: {}", strip_errno(&e));
     }
     1
 }

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 use uucore::display::{Quotable, print_verbatim};
-use uucore::error::{FromIo, UError, UResult, USimpleError};
+use uucore::error::{FromIo, UError, UResult, USimpleError, strip_errno};
 use uucore::line_ending::LineEnding;
 use uucore::show;
 use uucore::translate;
@@ -165,7 +165,7 @@ impl HeadOptions {
 fn wrap_in_stdout_error(err: io::Error) -> io::Error {
     io::Error::new(
         err.kind(),
-        translate!("head-error-writing-stdout", "err" => uucore::error::strip_errno(&err)),
+        translate!("head-error-writing-stdout", "err" => strip_errno(&err)),
     )
 }
 

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -13,7 +13,7 @@ use std::io::{Write, stdout};
 use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use uucore::error::ExitCode;
-use uucore::error::{UResult, USimpleError};
+use uucore::error::{UResult, USimpleError, strip_errno};
 #[cfg(not(windows))]
 use uucore::mode;
 use uucore::translate;
@@ -374,7 +374,7 @@ fn create_single_dir(path: &Path, is_parent: bool, config: &Config) -> UResult<(
         }
         Err(e) => Err(USimpleError::new(
             1,
-            translate!("mkdir-error-cannot-create-directory", "path" => path.display(), "error" => uucore::error::strip_errno(&e)),
+            translate!("mkdir-error-cannot-create-directory", "path" => path.display(), "error" => strip_errno(&e)),
         )),
     }
 }

--- a/src/uu/split/src/platform/unix.rs
+++ b/src/uu/split/src/platform/unix.rs
@@ -11,7 +11,7 @@ use std::io::{ErrorKind, Write};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use uucore::display::Quotable;
-use uucore::error::USimpleError;
+use uucore::error::{USimpleError, strip_errno};
 use uucore::fs;
 use uucore::fs::FileInformation;
 use uucore::show;
@@ -197,7 +197,7 @@ fn create_or_truncate_output_file(input: &OsStr, filename: &OsStr) -> Result<std
 }
 
 fn open_file_error(filename: &OsStr, e: Error) -> Error {
-    let e = uucore::error::strip_errno(&e);
+    let e = strip_errno(&e);
     Error::other(format!("{}: {e}", filename.quote()))
 }
 

--- a/src/uu/split/src/platform/windows.rs
+++ b/src/uu/split/src/platform/windows.rs
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
 use uucore::display::Quotable;
+use uucore::error::strip_errno;
 use uucore::fs;
 use uucore::translate;
 
@@ -71,7 +72,7 @@ fn create_or_truncate_output_file(input: &OsStr, filename: &OsStr) -> Result<std
 }
 
 fn open_file_error(filename: &OsStr, e: Error) -> Error {
-    let e = uucore::error::strip_errno(&e);
+    let e = strip_errno(&e);
     Error::other(format!("{}: {e}", filename.quote()))
 }
 

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -218,6 +218,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // open with O_NONBLOCK to handle fifo files
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
+            use uucore::error::strip_errno;
             let path = Path::new(f);
             if let Err(e) = rustix::fs::open(
                 path,
@@ -225,7 +226,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 rustix::fs::Mode::empty(),
             ) && (e != rustix::io::Errno::ACCESS || path.is_dir())
             {
-                let msg = translate!("sync-error-opening-file", "file" => f.quote(), "err" => uucore::error::strip_errno(&std::io::Error::from(e)));
+                let msg = translate!("sync-error-opening-file", "file" => f.quote(), "err" => strip_errno(&std::io::Error::from(e)));
                 show_error!("{msg}");
                 set_exit_code(1);
             }

--- a/src/uu/true/src/true.rs
+++ b/src/uu/true/src/true.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 use clap::{Arg, ArgAction, Command};
 use std::io::{self, Write as _};
-use uucore::{crate_version, translate};
+use uucore::{crate_version, error::strip_errno, translate};
 
 // uucore::main does not support no-result
 pub fn uumain(mut args: impl uucore::Args) -> i32 {
@@ -26,7 +26,7 @@ pub fn uumain(mut args: impl uucore::Args) -> i32 {
         && e.kind() != io::ErrorKind::BrokenPipe
     {
         // Try to display this error.
-        let _ = writeln!(io::stderr(), "true: {}", uucore::error::strip_errno(&e));
+        let _ = writeln!(io::stderr(), "true: {}", strip_errno(&e));
         // Mirror GNU options. When failing to print warnings or version flags, then we exit
         // with FAIL. This avoids allocation some error information which may result in yet
         // other types of failure.


### PR DESCRIPTION
that was found with `grep -r "uucore::error::strip_errno(" .`