### PR TITLE
cp: reject --attributes-only self-copies (#13161)

### DIFF
--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2606,6 +2606,23 @@ fn copy_file(
         }
     }
 
+    // `--attributes-only` skips `handle_existing_dest` above, so its
+    // same-file check never runs; GNU cp refuses self-copies in this
+    // mode too.
+    if initial_dest_metadata.is_some()
+        && options.attributes_only
+        && !matches!(
+            options.overwrite,
+            OverwriteMode::Clobber(ClobberMode::RemoveDestination)
+        )
+        && is_forbidden_to_copy_to_same_file(source, dest, options, source_in_command_line)
+    {
+        return Err(translate!("cp-error-same-file",
+                       "source" => source.quote(),
+                       "dest" => dest.quote())
+        .into());
+    }
+
     if options.attributes_only
         && source_is_symlink
         && !matches!(

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -4807,6 +4807,34 @@ fn test_cp_cannot_create_regular_file_attributes_only() {
 }
 
 #[test]
+fn test_cp_attributes_only_same_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "a";
+
+    at.touch(file);
+
+    ucmd.arg("--attributes-only")
+        .arg(file)
+        .arg(file)
+        .fails_with_code(1)
+        .stderr_contains(format!("'{file}' and '{file}' are the same file"));
+}
+
+#[test]
+fn test_cp_attributes_only_same_file_dot_path() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "a";
+
+    at.touch(file);
+
+    ucmd.arg("--attributes-only")
+        .arg(file)
+        .arg("./a")
+        .fails_with_code(1)
+        .stderr_contains(format!("'{file}' and './{file}' are the same file"));
+}
+
+#[test]
 fn test_cp_seen_file() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;


### PR DESCRIPTION
Fixes the first point of #13161.

The guard from #6051 skips handle_existing_dest for --attributes-only,
which also skipped the same-file check, so `cp --attributes-only a a`
silently succeeded (GNU rejects it with "'a' and 'a' are the same file").

Add an explicit check on the attributes-only path reusing
is_forbidden_to_copy_to_same_file, so the --force --backup allowance
keeps working exactly like the regular path.

Two tests cover `a a` and `a ./a`.

Note: the second point of the issue (chmod by path instead of fd, a
TOCTOU window on the normal attributes-only copy to a *different* file)
is intentionally left out of this PR as a follow-up.
