### PR TITLE
uniq: accept a repeated -D/--all-repeated, last one wins

### DIFF
--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -723,7 +723,9 @@ pub fn uu_app() -> Command {
                 .value_name("delimit-method")
                 .num_args(0..=1)
                 .default_missing_value("none")
-                .require_equals(true),
+                .require_equals(true)
+                // GNU accepts a repeated -D/--all-repeated and uses the last one.
+                .overrides_with(options::ALL_REPEATED),
         )
         .arg(
             Arg::new(options::GROUP)

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -163,6 +163,22 @@ fn test_stdin_all_repeated() {
 }
 
 #[test]
+fn test_all_repeated_repeated_last_wins() {
+    // GNU uniq accepts a repeated -D/--all-repeated and uses the last occurrence,
+    // instead of rejecting the second one.
+    new_ucmd!()
+        .args(&["-D", "--all-repeated=separate"])
+        .pipe_in("a\na\nb\nb\nc\n")
+        .succeeds()
+        .stdout_is("a\na\n\nb\nb\n");
+    new_ucmd!()
+        .args(&["-D", "-D"])
+        .pipe_in("a\na\n")
+        .succeeds()
+        .stdout_is("a\na\n");
+}
+
+#[test]
 fn test_all_repeated_followed_by_filename() {
     let filename = "test.txt";
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
## Problem

Passing `-D`/`--all-repeated` more than once fails:

```
$ printf 'a\na\nb\nb\nc\n' | uniq -D --all-repeated=separate
error: the argument '--all-repeated[=<delimit-method>]' cannot be used multiple times
```

`-D` and `--all-repeated` are the same option, and clap rejects the repeat. GNU
`uniq` accepts a repeated option and uses the last occurrence, so a script that
mixes the short and long form works there but fails here.

## Fix

Add `.overrides_with(options::ALL_REPEATED)` so a later occurrence overrides an
earlier one, matching GNU.

## Verification

```
$ printf 'a\na\nb\nb\nc\n' | uniq -D --all-repeated=separate
a
a

b
b
```

Output matches GNU coreutils (`guniq`) exactly. Added a regression test; the
full `test_uniq` suite passes and `cargo fmt` / `cargo clippy` are clean.
