### PR TITLE
numfmt: reject a leading + and scientific notation to match GNU

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -206,6 +206,14 @@ fn parse_number_part(s: &str, input: &str) -> Result<ParsedNumber> {
         return Err(translate!("numfmt-error-invalid-number", "input" => input.quote()));
     }
 
+    // GNU rejects a leading '+' and scientific notation, which Rust's parsers accept.
+    if s.starts_with('+') {
+        return Err(translate!("numfmt-error-invalid-number", "input" => input.quote()));
+    }
+    if s.bytes().any(|b| b == b'e' || b == b'E') {
+        return Err(translate!("numfmt-error-invalid-suffix", "input" => input.quote()));
+    }
+
     if let Ok(n) = s.parse::<i128>() {
         return Ok(ParsedNumber::ExactInt(n));
     }

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -186,6 +186,26 @@ fn test_header_error_if_negative() {
 }
 
 #[test]
+fn test_reject_leading_plus_and_scientific_notation() {
+    // GNU numfmt rejects a leading '+' as an invalid number and rejects scientific
+    // notation as an invalid suffix; Rust's parsers accept both, so guard against it.
+    for input in ["+5", "+5K", "+1e-3"] {
+        new_ucmd!()
+            .arg("--from=auto")
+            .pipe_in(format!("{input}\n"))
+            .fails_with_code(2)
+            .stderr_is(format!("numfmt: invalid number: '{input}'\n"));
+    }
+    for input in ["1e-3", "1e+3", "5e-5", "1.0e-2", "-1e-5"] {
+        new_ucmd!()
+            .arg("--from=auto")
+            .pipe_in(format!("{input}\n"))
+            .fails_with_code(2)
+            .stderr_is(format!("numfmt: invalid suffix in input: '{input}'\n"));
+    }
+}
+
+#[test]
 fn test_negative() {
     new_ucmd!()
         .args(&["--from=si"])


### PR DESCRIPTION
## Problem

`numfmt` silently accepts inputs that GNU rejects, and prints a wrong value:

```
$ printf '1e-3\n' | numfmt --from=auto   # prints "1"  (GNU: invalid suffix in input)
$ printf '1e+3\n' | numfmt --from=auto   # prints "1000"
$ printf '+5\n'   | numfmt --from=auto   # prints "5"   (GNU: invalid number)
```

Rust's `i128`/`f64` parsers accept a leading `+` and scientific notation, so
these slip through `parse_number_part`. The `E` (Exa) suffix is not affected,
because the suffix is stripped before the number is parsed.

## Fix

In `parse_number_part`, reject a leading `+` and any `e`/`E` in the number part,
using GNU's two distinct messages (`invalid number` for the sign, `invalid
suffix in input` for the exponent).

## Verification

Compared against GNU coreutils (`gnumfmt`) over a matrix of 20 inputs: every
previously-wrong case now matches GNU's exit code (2) and message, and valid
inputs (`1K`, `2.5M`, `100Ki`, `1P`, `3.5G`, `-42`, ...) are unchanged.

```
$ printf '1e-3\n' | numfmt --from=auto
numfmt: invalid suffix in input: '1e-3'
$ printf '+5\n' | numfmt --from=auto
numfmt: invalid number: '+5'
```

Added a regression test; the full `test_numfmt` suite passes and `cargo fmt` /
`cargo clippy` are clean.
