### PR TITLE
pr: make -n/--number-lines argument optional to match GNU

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -238,6 +238,8 @@ pub fn uu_app() -> Command {
                 .long(options::NUMBER_LINES)
                 .help(translate!("pr-help-number-lines"))
                 .allow_hyphen_values(true)
+                // GNU pr makes -n optional (defaults to width 5, tab).
+                .num_args(0..=1)
                 .value_name("[char][width]"),
         )
         .arg(

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -82,6 +82,18 @@ fn test_number_lines_empty_value_is_rejected() {
 }
 
 #[test]
+fn test_number_lines_without_value_numbers_lines() {
+    // A bare -n/--number-lines numbers lines with the default 5-wide, tab format.
+    for arg in ["-n", "--number-lines"] {
+        new_ucmd!()
+            .args(&["-t", arg])
+            .pipe_in("a\nb\n")
+            .succeeds()
+            .stdout_is("    1\ta\n    2\tb\n");
+    }
+}
+
+#[test]
 fn test_without_any_options() {
     let test_file_path = "test_one_page.log";
     let expected_test_file_path = "test_one_page.log.expected";


### PR DESCRIPTION
## Problem

GNU `pr` treats the `-n`/`--number-lines` argument as optional. uutils required
a value, so a bare flag failed:

```
$ printf 'a\nb\n' | pr -t -n
error: a value is required for '--number-lines <[char][width]>' but none was supplied
```

## Fix

Add `num_args(0..=1)` to the argument. When no value is given, the existing
`.or_else(NumberingMode::default())` fallback already supplies the default
(width 5, tab separator), so no further change is needed.

## Verification

Compared against GNU coreutils `pr` over `-n`, `--number-lines`, `-n5`, `-n:3`,
`-nx3`, and `-n FILE`; all match byte for byte.

```
$ printf 'a\nb\n' | pr -t -n
    1	a
    2	b
```

`--number-lines=` (explicit empty value) is still rejected. Added a regression
test; the full `test_pr` suite (239 tests) passes and `cargo fmt` / `cargo
clippy` are clean.
