### PR TITLE
tail: do not abort on a -c +N offset past the end of the file

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -480,7 +480,9 @@ fn bounded_tail(file: &mut File, settings: &Settings) -> UResult<()> {
         FilterMode::Bytes(Signum::Positive(count)) if count > &1 => {
             // GNU `tail` seems to index bytes and lines starting at 1, not
             // at 0. It seems to treat `+0` and `+1` as the same thing.
-            file.seek(SeekFrom::Start(*count - 1)).unwrap();
+            // A seek past EOF may fail; fall back to the end so nothing prints.
+            file.seek(SeekFrom::Start(*count - 1))
+                .or_else(|_| file.seek(SeekFrom::End(0)))?;
         }
         _ => {}
     }

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1118,6 +1118,16 @@ fn test_positive_zero_bytes() {
         .no_output();
 }
 
+/// A `-c +N` offset past the end of a seekable file must not abort.
+#[test]
+fn test_positive_bytes_past_end_of_file_does_not_panic() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f", &"a".repeat(1_000_000));
+    ucmd.args(&["-c", "+18446744073709551615", "f"])
+        .succeeds()
+        .no_output();
+}
+
 /// Test for reading all but the first NUM lines: `tail -n +3`.
 #[test]
 fn test_positive_lines() {


### PR DESCRIPTION
Closes #13887.

## Problem

```
$ yes | head -c 8192 > big
$ tail -c +18446744073709551615 big
thread 'main' panicked ... called `Result::unwrap()` on an `Err` value ...
$ echo $?
134
```

`bounded_tail` does `file.seek(SeekFrom::Start(*count - 1)).unwrap()` for a
positive byte offset. When the offset is past the end of the file and not
seekable (here it exceeds `i64::MAX`), the seek returns an error and the unwrap
aborts. GNU `tail` prints nothing for a start offset past end of file and exits
0.

## Fix

Mirror the existing negative-bytes arm: if the forward seek fails, fall back to
`SeekFrom::End(0)` so the following copy reads nothing, instead of unwrapping.

## Verification

```
$ tail -c +18446744073709551615 big ; echo $?   # was 134 (abort), now 0, no output
0
```

Compared against GNU `tail` over offsets `+18446744073709551615`,
`+17592186040322`, `+8193`, `+100`: exit codes and byte counts match. Added a
regression test; the full `test_tail` suite (122 tests) passes and `cargo fmt`
/ `cargo clippy` are clean.
