### PR TITLE
truncate: reject a size above i64::MAX instead of creating the file

### DIFF
--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -282,6 +282,20 @@ fn file_truncate(
             }
         })?;
 
+    // Reject a size above i64::MAX up front like GNU.
+    if truncate_size > i64::MAX as u64 {
+        let error = match size_argument {
+            None => translate!("truncate-error-value-too-large"),
+            Some(arg) => {
+                translate!("truncate-error-value-too-large-arg", "arg" => arg.quote())
+            }
+        };
+        return Err(USimpleError::new(
+            1,
+            translate!("truncate-error-invalid-number", "error" => error),
+        ));
+    }
+
     do_file_truncate(path, !no_create, truncate_size)
 }
 

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -39,6 +39,16 @@ fn test_increase_file_size_kb() {
 }
 
 #[test]
+fn test_size_above_i64_max_is_rejected_without_creating_file() {
+    // A size above i64::MAX is rejected up front and the file is not created.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-s", "9223372036854775808", "new-file"])
+        .fails_with_code(1)
+        .stderr_contains("Value too large for defined data type");
+    assert!(!at.file_exists("new-file"));
+}
+
+#[test]
 fn test_reference() {
     let expected = 5 * 1000;
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
## Problem

An absolute size in the range `(i64::MAX, u64::MAX]` was accepted by the size
calculation and only failed later when opening the file, with a misleading
message, after the file had already been created:

```
$ truncate -s 8E newfile
truncate: cannot open 'newfile' for writing: out of range integral type conversion attempted
$ ls newfile      # created anyway
newfile
```

GNU truncate rejects it up front and creates nothing:

```
$ truncate -s 8E newfile
truncate: Invalid number: '8E': Value too large to be stored in data type
```

## Fix

A file size must fit the signed file offset (`i64`). Check `truncate_size >
i64::MAX` right after the size is computed and return the existing "invalid
number / value too large" error, before the file is opened.

## Verification

Compared against GNU truncate over `8E`, `9223372036854775808` (i64::MAX + 1),
`9223372036854775807` (i64::MAX), `1E`, and `100`: exit codes and whether the
file is created now match GNU in every case. Added a regression test; the full
`test_truncate` suite (49 tests) passes and `cargo fmt` / `cargo clippy` are
clean.
