### PR TITLE
split: do not overflow on -n l/K when K is larger than the byte count

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1137,7 +1137,9 @@ fn n_chunks_by_line(
         let num_line_bytes = bytes.len() as u64;
         num_bytes_written += num_line_bytes;
         let mut skipped = -1;
-        while num_bytes_should_be_written <= num_bytes_written {
+        // Stop at the last chunk: with more chunks than bytes the increment is 0,
+        // so without this bound the loop spins until chunk_number/skipped overflow.
+        while num_bytes_should_be_written <= num_bytes_written && chunk_number < num_chunks {
             num_bytes_should_be_written +=
                 chunk_size_base + (chunk_size_reminder > chunk_number) as u64;
             chunk_number += 1;

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -254,6 +254,19 @@ fn test_split_num_prefixed_chunks_by_lines() {
 }
 
 #[test]
+fn test_number_of_chunks_by_line_more_chunks_than_bytes() {
+    // More chunks than bytes must not overflow; the trailing chunks are empty.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("in", "ab");
+    ucmd.args(&["-n", "l/5", "in"]).succeeds().no_stderr();
+    assert_eq!(at.read("xaa"), "ab");
+    for name in ["xab", "xac", "xad", "xae"] {
+        assert_eq!(at.read(name), "");
+    }
+    assert!(!at.file_exists("xaf"));
+}
+
+#[test]
 fn test_split_str_prefixed_chunks_by_lines() {
     let (at, mut ucmd) = at_and_ucmd!();
     let name = "split_str_prefixed_chunks_by_lines";


### PR DESCRIPTION
## Problem

```
$ printf 'ab' > tiny
$ split -n l/5 tiny
thread 'main' panicked at src/uu/split/src/split.rs:1144:13: attempt to add with overflow
```

When there are more chunks than bytes, `chunk_size_base = num_bytes / num_chunks`
is 0 and the trailing empty chunks add 0 to `num_bytes_should_be_written`, so the
inner `while num_bytes_should_be_written <= num_bytes_written` loop never advances
and spins until `chunk_number`/`skipped` overflow.

## Fix

Add `chunk_number < num_chunks` to the loop condition so it stops at the last
chunk. There are only `num_chunks` chunks, so this never truncates real output.

## Verification

Compared against GNU `split` for `-n l/5` on `ab`, `-n l/3` on `a`, `-n l/2` on
empty input, `-n l/3` on a 10-byte line, and multi-line inputs: the file set and
contents match exactly (`xaa` gets the data, the rest are empty). Added a
regression test; the full `test_split` suite (129 tests) passes and `cargo fmt`
/ `cargo clippy` are clean.
