### PR TITLE
install: strip "(os error N)" from --strip-program failure

### DIFF
--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -1070,7 +1070,7 @@ fn strip_file(to: &Path, b: &Behavior) -> UResult<()> {
         Err(e) => {
             // Follow GNU's behavior: if strip fails, removes the target
             let _ = fs::remove_file(to);
-            return Err(InstallError::StripProgramFailed(e.to_string()).into());
+            return Err(InstallError::StripProgramFailed(strip_errno(&e)).into());
         }
     }
     Ok(())

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -992,7 +992,7 @@ fn test_install_and_strip_with_non_existent_program() {
         .arg(source)
         .arg(STRIP_TARGET_FILE)
         .fails()
-        .stderr_contains("No such file or directory");
+        .stderr_only("install: strip program failed: No such file or directory\n");
     assert!(!at.file_exists(STRIP_TARGET_FILE));
 }
 


### PR DESCRIPTION
Fixes #13863.

When the program passed to `--strip-program` cannot be spawned, the raw `io::Error` was formatted with `to_string()`, which appends the platform errno suffix:

```
$ install --strip-program /root -s a b
install: strip program failed: Permission denied (os error 13)
```

GNU prints only the errno description. This uses `uucore::error::strip_errno`, which the same `InstallError` enum already uses for `BackupFailed`:

```
install: strip program failed: Permission denied
```

The existing `test_install_and_strip_with_non_existent_program` only did a `stderr_contains` check, so it passed despite the leak; it is tightened to an exact `stderr_only` assertion. It fails on `main` and passes with the fix.

### Verification

```
$ cargo test --features install --no-default-features --test tests -- test_install::
test result: ok. 104 passed; 0 failed

$ cargo fmt --check          # clean
$ cargo clippy -p uu_install --all-targets -- -D warnings   # clean
```

Baseline check (test applied, `install.rs` fix stashed):

```
< install: strip program failed: No such file or directory (os error 2)
> install: strip program failed: No such file or directory
```

---
*Written with assistance from Claude Code; reviewed and verified locally by me.*