### PR TITLE
tail: avoid a double allocation per reverse chunk

### DIFF
--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -84,14 +84,12 @@ impl Iterator for ReverseChunks<'_> {
 
         // Seek backwards by the next chunk, read the full chunk into
         // `buf`, and then seek back to the start of the chunk again.
-        let mut buf = vec![0; BLOCK_SIZE as usize];
+        let mut buf = vec![0; block_size as usize];
         let pos = self
             .file
             .seek(SeekFrom::Current(-(block_size as i64)))
             .unwrap();
-        self.file
-            .read_exact(&mut buf[0..(block_size as usize)])
-            .unwrap();
+        self.file.read_exact(&mut buf).unwrap();
         let pos2 = self
             .file
             .seek(SeekFrom::Current(-(block_size as i64)))
@@ -100,7 +98,7 @@ impl Iterator for ReverseChunks<'_> {
 
         self.block_idx += 1;
 
-        Some(buf[0..(block_size as usize)].to_vec())
+        Some(buf)
     }
 }
 


### PR DESCRIPTION
I hope you don't mind multiple PRs (separated by concern).  

Couple of things I found with this one.  Always allocating BLOCK_SIZE, results in an over allocation on the last block (probably not a huge deal there), but was able to squeeze an allocation out, and a almost insignificiant improvement in binary size.  

cargo fmt, clippy and test ran.

LLM Generated below:
---
`tail -n N` / `tail -c N` on a seekable regular file reads the tail backwards
via `ReverseChunks` in 64 KiB blocks. Each `next()` allocated a 64 KiB buffer,
read `block_size` bytes into a slice of it, then produced the returned chunk
with `buf[0..block_size].to_vec()` — a second allocation plus a full copy of
the block, after which the original buffer was dropped. The rewrite sizes the
buffer exactly to `block_size` and hands it out directly:

```rust
let mut buf = vec![0; block_size as usize];   // sized to what we read
self.file.read_exact(&mut buf).unwrap();
// ...
Some(buf)                                     // no second alloc, no copy
```

Per block this removes one heap allocation and one full-block `memcpy`, and
avoids over-allocating 64 KiB for the final (remainder) block. The bytes
returned are identical.

## Benchmark

Standalone `tail` binary, `tail -n 10` on a 184 MB / 4M-line file.

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Binary size (standalone `tail`) | 1,944,808 B | 1,944,680 B | −128 B (−0.0066%) |
| Runtime (ms/run, 3 runs) | 47/32/55 | 47/43/41 | ~none (I/O-bound; alloc hidden under syscalls) |
| Correctness | baseline reference | byte-identical | pass (`diff` vs GNU `tail -n`, `-c`, file + stdin) |

Correctness: output compared byte-for-byte against GNU `tail` for `-n 5`,
`-n 200`, `-c 7`, and piped stdin (lines and bytes) — identical. 38 unit tests
pass. The change reduces allocator churn and memory-bandwidth work per block;
wall-clock is unchanged because `tail` is dominated by `seek`/`read` syscalls.