### PR TITLE
nl: hoist the per-line blank-line prefix allocation

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -391,6 +391,8 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
     let mut writer = BufWriter::new(stdout());
     let mut current_numbering_style = &settings.body_numbering;
     let mut line = Vec::new();
+    // Written before every unnumbered line; hoisted so it is not reallocated per line.
+    let blank_prefix = vec![b' '; settings.number_width + 1];
 
     loop {
         line.clear();
@@ -464,9 +466,8 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                     .map_err_context(|| translate!("nl-error-could-not-write"))?;
                 stats.line_number = line_number.checked_add(settings.line_increment);
             } else {
-                let prefix = " ".repeat(settings.number_width + 1);
                 writer
-                    .write_all(prefix.as_bytes())
+                    .write_all(&blank_prefix)
                     .map_err_context(|| translate!("nl-error-could-not-write"))?;
             }
             write_line(&mut writer, &line)


### PR DESCRIPTION
Another avoiding heap allocation PR.  Last one for now. 
Instead of one allocation perline, now we're doing one in total.  Performs significantly better and saves ~1KB off binary size.

cargo fmt, clippy and test ran.

LLM Generated:
---

`nl` wrote a `" ".repeat(number_width + 1)` prefix before every *unnumbered*
line (blank lines, or lines skipped by `NumberingStyle::NonEmpty`/`None` or a
regex). That constructed a fresh heap `String` on every such line, even though
the prefix is loop-invariant. The rewrite hoists it out of the loop into a
single `Vec<u8>` allocated once:

```rust
let blank_prefix = vec![b' '; settings.number_width + 1];  // before the loop
// ...
} else {
    writer.write_all(&blank_prefix)?;                       // per unnumbered line
}
```

The output bytes are identical; only the per-line allocation is gone.

## Benchmark

Standalone `nl` binary, `nl` on a 2,000,000-line input of all-blank lines.

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Binary size (standalone `nl`) | 2,985,352 B | 2,983,888 B | −1,464 B (−0.049%) |
| Runtime (ms/run, 5 runs) | 122/122/177/158/162 | 102/95/108/110/130 | ~−32% (median 158 → 108 ms) |
| Correctness | baseline reference | byte-identical | pass (`diff` vs GNU `nl -w3`, `nl -ba`) |

Correctness: output compared byte-for-byte against GNU `nl` with blank lines,
`-w3`, and `-ba` — identical.