### PR TITLE
dd: quote invalid status level

### DIFF
--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -101,7 +101,7 @@ dd-error-conv-flag-no-match = invalid conversion: '{ $flag }'
 dd-error-multiplier-parse-failure = invalid number: '{ $input }'
 dd-error-multiplier-overflow = Multiplier string would overflow on current system -> { $input }
 dd-error-block-without-cbs = conv=block or conv=unblock specified without cbs=N
-dd-error-status-not-recognized = invalid status level: '{ $level }'
+dd-error-status-not-recognized = invalid status level: { $level }
 dd-error-unimplemented = feature not implemented on this system -> { $feature }
 dd-error-bs-out-of-range = { $param }=N cannot fit into memory
 dd-error-invalid-number = invalid number: '{ $input }'

--- a/src/uu/dd/locales/fr-FR.ftl
+++ b/src/uu/dd/locales/fr-FR.ftl
@@ -102,7 +102,7 @@ dd-error-conv-flag-no-match = conversion invalide : '{ $flag }'
 dd-error-multiplier-parse-failure = nombre invalide : '{ $input }'
 dd-error-multiplier-overflow = La chaîne de multiplicateur déborderait sur le système actuel -> { $input }
 dd-error-block-without-cbs = conv=block ou conv=unblock spécifié sans cbs=N
-dd-error-status-not-recognized = niveau d'état invalide : '{ $level }'
+dd-error-status-not-recognized = niveau d'état invalide : { $level }
 dd-error-unimplemented = fonctionnalité non implémentée sur ce système -> { $feature }
 dd-error-bs-out-of-range = { $param }=N ne peut pas tenir en mémoire
 dd-error-invalid-number = nombre invalide : '{ $input }'

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -14,8 +14,7 @@ use thiserror::Error;
 use uucore::display::Quotable;
 use uucore::error::UError;
 use uucore::parser::parse_size::{ParseSizeError, Parser as SizeParser};
-use uucore::show_warning;
-use uucore::translate;
+use uucore::{show_warning, translate};
 
 /// Parser Errors describe errors with parser input
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -368,7 +367,9 @@ impl Parser {
             "none" => Ok(StatusLevel::None),
             "noxfer" => Ok(StatusLevel::Noxfer),
             "progress" => Ok(StatusLevel::Progress),
-            _ => Err(ParseError::StatusLevelNotRecognized(val.to_string())),
+            _ => Err(ParseError::StatusLevelNotRecognized(
+                val.quote().to_string(),
+            )),
         }
     }
 

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -2408,3 +2408,19 @@ dd: unrecognized operand 'bsx=1'
             .stderr_does_not_contain("╭─");
     }
 }
+
+#[test]
+fn test_invalid_status_level() {
+    new_ucmd!()
+        .args(&["status=invalid"])
+        .fails()
+        .stderr_contains("dd: invalid status level: 'invalid'");
+}
+
+#[test]
+fn test_invalid_status_level_shell_escaped() {
+    new_ucmd!()
+        .args(&["status=foo bar"])
+        .fails()
+        .stderr_contains("dd: invalid status level: 'foo bar'");
+}


### PR DESCRIPTION
Fixes #13868 

### Summary
Updates the `dd` error message for an unrecognized `status=` value so that the user-provided value is quoted.

**Before**
```console
$ dd status=invalid
dd: status=LEVEL not recognized -> invalid
```
**After**
```console
$ dd status=invalid
dd: invalid status level: ‘invalid’
```
**GNU (Reference)**
```console
$ /bin/dd status=invalid
dd: invalid status level: ‘invalid’
```