### PR TITLE
cut: add -F option and --whitespace-delimited=trimmed, fix -s/-n edge cases

### DIFF
--- a/src/uu/cut/locales/en-US.ftl
+++ b/src/uu/cut/locales/en-US.ftl
@@ -97,6 +97,7 @@ cut-help-characters = alias for character mode
 cut-help-delimiter = specify the delimiter character that separates fields in the input source. Defaults to Tab.
 cut-help-whitespace-delimited = Use any number of whitespace (Space, Tab) to separate fields in the input source (FreeBSD extension).
 cut-help-fields = filter field columns from the input source
+cut-help-fields-merged = like -f, but merge adjacent delimiters; the delimiter defaults to whitespace and the output delimiter to a space
 cut-help-complement = invert the filter - instead of displaying only the filtered columns, display all but those columns
 cut-help-only-delimited = in field mode, only print lines which contain the delimiter
 cut-help-zero-terminated = instead of filtering columns based on line, filter columns based on \\0 (NULL character)

--- a/src/uu/cut/locales/fr-FR.ftl
+++ b/src/uu/cut/locales/fr-FR.ftl
@@ -97,6 +97,7 @@ cut-help-characters = alias pour le mode caractère
 cut-help-delimiter = spécifier le caractère délimiteur qui sépare les champs dans la source d'entrée. Par défaut Tab.
 cut-help-whitespace-delimited = Utiliser tout nombre d'espaces (Espace, Tab) pour séparer les champs dans la source d'entrée (extension FreeBSD).
 cut-help-fields = filtrer les colonnes de champs depuis la source d'entrée
+cut-help-fields-merged = comme -f, mais fusionne les délimiteurs adjacents ; le délimiteur par défaut est l'espacement et le délimiteur de sortie une espace
 cut-help-complement = inverser le filtre - au lieu d'afficher seulement les colonnes filtrées, afficher toutes sauf ces colonnes
 cut-help-only-delimited = en mode champ, afficher seulement les lignes qui contiennent le délimiteur
 cut-help-zero-terminated = au lieu de filtrer les colonnes basées sur la ligne, filtrer les colonnes basées sur \\0 (caractère NULL)

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -42,6 +42,8 @@ enum Delimiter<'a> {
 struct FieldOptions<'a> {
     delimiter: Delimiter<'a>,
     only_delimited: bool,
+    /// `--whitespace-delimited=trimmed`: strip leading/trailing blanks per line.
+    whitespace_trimmed: bool,
 }
 
 enum Mode<'a> {
@@ -394,6 +396,80 @@ fn cut_chars<R: Read, W: Write>(
     Ok(())
 }
 
+/// Write the fields of `line` selected by `ranges`, separated by `out_delim`.
+///
+/// `line` may or may not end with `newline_char`; either way the output is
+/// terminated, unless the line has no delimiter and `only_delimited` drops it.
+fn write_fields_line<W: Write, M: Matcher>(
+    line: &[u8],
+    out: &mut W,
+    matcher: &M,
+    ranges: &[Range],
+    only_delimited: bool,
+    newline_char: u8,
+    out_delim: &[u8],
+) -> std::io::Result<()> {
+    let mut fields_pos = 1;
+    let mut low_idx = 0;
+    let mut delim_search = Searcher::new(matcher, line).peekable();
+    let mut print_delim = false;
+
+    if delim_search.peek().is_none() {
+        if !only_delimited {
+            // Always write the entire line, even if it doesn't end with `newline_char`
+            out.write_all(line)?;
+            if line.is_empty() || line[line.len() - 1] != newline_char {
+                out.write_all(&[newline_char])?;
+            }
+        }
+
+        return Ok(());
+    }
+
+    for &Range { low, high } in ranges {
+        if low - fields_pos > 0 {
+            // current field is not in the range, so jump to the field corresponding to the
+            // beginning of the range if any
+            low_idx = match delim_search.nth(low - fields_pos - 1) {
+                Some((_, last)) => last,
+                None => break,
+            };
+        }
+
+        // at this point, current field is the first in the range
+        for _ in 0..=high - low {
+            // skip printing delimiter if this is the first matching field for this line
+            if print_delim {
+                out.write_all(out_delim)?;
+            } else {
+                print_delim = true;
+            }
+
+            if let Some((first, last)) = delim_search.next() {
+                // print the current field up to the next field delim
+                let segment = &line[low_idx..first];
+
+                out.write_all(segment)?;
+
+                low_idx = last;
+                fields_pos = high + 1;
+            } else {
+                // this is the last field in the line, so print the rest
+                let segment = &line[low_idx..];
+
+                out.write_all(segment)?;
+
+                if line[line.len() - 1] == newline_char {
+                    return Ok(());
+                }
+                break;
+            }
+        }
+    }
+
+    out.write_all(&[newline_char])
+}
+
 /// Output delimiter is explicitly specified
 fn cut_fields_explicit_out_delim<R: Read, W: Write, M: Matcher>(
     reader: R,
@@ -407,65 +483,15 @@ fn cut_fields_explicit_out_delim<R: Read, W: Write, M: Matcher>(
     let mut buf_in = BufReader::new(reader);
 
     let result = buf_in.for_byte_record_with_terminator(newline_char, |line| {
-        let mut fields_pos = 1;
-        let mut low_idx = 0;
-        let mut delim_search = Searcher::new(matcher, line).peekable();
-        let mut print_delim = false;
-
-        if delim_search.peek().is_none() {
-            if !only_delimited {
-                // Always write the entire line, even if it doesn't end with `newline_char`
-                out.write_all(line)?;
-                if line.is_empty() || line[line.len() - 1] != newline_char {
-                    out.write_all(&[newline_char])?;
-                }
-            }
-
-            return Ok(true);
-        }
-
-        for &Range { low, high } in ranges {
-            if low - fields_pos > 0 {
-                // current field is not in the range, so jump to the field corresponding to the
-                // beginning of the range if any
-                low_idx = match delim_search.nth(low - fields_pos - 1) {
-                    Some((_, last)) => last,
-                    None => break,
-                };
-            }
-
-            // at this point, current field is the first in the range
-            for _ in 0..=high - low {
-                // skip printing delimiter if this is the first matching field for this line
-                if print_delim {
-                    out.write_all(out_delim)?;
-                } else {
-                    print_delim = true;
-                }
-
-                if let Some((first, last)) = delim_search.next() {
-                    // print the current field up to the next field delim
-                    let segment = &line[low_idx..first];
-
-                    out.write_all(segment)?;
-
-                    low_idx = last;
-                    fields_pos = high + 1;
-                } else {
-                    // this is the last field in the line, so print the rest
-                    let segment = &line[low_idx..];
-
-                    out.write_all(segment)?;
-
-                    if line[line.len() - 1] == newline_char {
-                        return Ok(true);
-                    }
-                    break;
-                }
-            }
-        }
-
-        out.write_all(&[newline_char])?;
+        write_fields_line(
+            line,
+            out,
+            matcher,
+            ranges,
+            only_delimited,
+            newline_char,
+            out_delim,
+        )?;
         Ok(true)
     });
 
@@ -666,8 +692,52 @@ fn cut_fields_newline_char_delim<R: Read, W: Write>(
         current_field_idx += 1;
     }
 
-    if has_data && !suppressed {
+    // With -s, a record that produced no selected field must not emit a line.
+    if has_data && !suppressed && (first_field_printed || !only_delimited) {
         out.write_all(&[newline_char])?;
+    }
+
+    Ok(())
+}
+
+/// `--whitespace-delimited=trimmed`: strip leading/trailing blanks from each
+/// line, then split on runs of blanks. With no internal blank the line is
+/// undelimited (suppressed under `-s`).
+fn cut_fields_whitespace_trimmed<R: Read, W: Write>(
+    reader: R,
+    out: &mut W,
+    ranges: &[Range],
+    only_delimited: bool,
+    newline_char: u8,
+    out_delim: &[u8],
+) -> UResult<()> {
+    let is_blank = |&b: &u8| b == b' ' || b == b'\t';
+    let matcher = WhitespaceMatcher {};
+    let mut buf_in = BufReader::new(reader);
+
+    // Trimming is the only difference from the plain whitespace path: once the
+    // outer blanks are gone, the remaining blank runs are ordinary delimiters.
+    let result = buf_in.for_byte_record(newline_char, |line| {
+        let start = line.iter().position(|b| !is_blank(b)).unwrap_or(line.len());
+        let end = line
+            .iter()
+            .rposition(|b| !is_blank(b))
+            .map_or(start, |p| p + 1);
+
+        write_fields_line(
+            &line[start..end],
+            out,
+            &matcher,
+            ranges,
+            only_delimited,
+            newline_char,
+            out_delim,
+        )?;
+        Ok(true)
+    });
+
+    if let Err(e) = result {
+        return Err(USimpleError::new(1, e.to_string()));
     }
 
     Ok(())
@@ -716,16 +786,28 @@ fn cut_fields<R: Read, W: Write>(
             }
         }
         Delimiter::Whitespace => {
-            let matcher = WhitespaceMatcher {};
-            cut_fields_explicit_out_delim(
-                reader,
-                out,
-                &matcher,
-                ranges,
-                field_opts.only_delimited,
-                newline_char,
-                opts.out_delimiter.unwrap_or(b"\t"),
-            )
+            let out_delim = opts.out_delimiter.unwrap_or(b"\t");
+            if field_opts.whitespace_trimmed {
+                cut_fields_whitespace_trimmed(
+                    reader,
+                    out,
+                    ranges,
+                    field_opts.only_delimited,
+                    newline_char,
+                    out_delim,
+                )
+            } else {
+                let matcher = WhitespaceMatcher {};
+                cut_fields_explicit_out_delim(
+                    reader,
+                    out,
+                    &matcher,
+                    ranges,
+                    field_opts.only_delimited,
+                    newline_char,
+                    out_delim,
+                )
+            }
         }
     }
 }
@@ -794,7 +876,9 @@ where
 /// Get delimiter and output delimiter from `-d`/`--delimiter` and `--output-delimiter` options respectively
 /// Allow either delimiter to have a value that is neither UTF-8 nor ASCII to align with GNU behavior
 fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter<'_>, Option<&[u8]>)> {
-    let whitespace_delimited = matches.get_flag(options::WHITESPACE_DELIMITED);
+    let whitespace_delimited = matches
+        .get_one::<String>(options::WHITESPACE_DELIMITED)
+        .is_some();
     let delim_opt = matches.get_one::<OsString>(options::DELIMITER);
     let delim = match delim_opt {
         Some(_) if whitespace_delimited => {
@@ -848,6 +932,8 @@ mod options {
     pub const CHARACTERS: &str = "characters";
     pub const DELIMITER: &str = "delimiter";
     pub const FIELDS: &str = "fields";
+    // -F: field mode that merges whitespace (or -d) runs, default output is a space.
+    pub const FIELDS_MERGED: &str = "fields-merged";
     pub const ZERO_TERMINATED: &str = "zero-terminated";
     pub const ONLY_DELIMITED: &str = "only-delimited";
     pub const OUTPUT_DELIMITER: &str = "output-delimiter";
@@ -879,13 +965,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let (delimiter, out_delimiter) = get_delimiters(&matches)?;
     let line_ending = LineEnding::from_zero_flag(matches.get_flag(options::ZERO_TERMINATED));
     let suppress_split = matches.get_flag(options::NOTHING);
+    // `--whitespace-delimited[=trimmed]` (`-w`): the optional value selects trimming.
+    let whitespace_trimmed = matches
+        .get_one::<String>(options::WHITESPACE_DELIMITED)
+        .is_some_and(|value| value == "trimmed");
 
     let mode_arg = get_mode_arg(&matches)?;
     let list = matches
         .get_one::<String>(mode_arg)
         .expect("should be ensured by get_mode_arg");
-    let ranges = list_to_ranges(list, complement, mode_arg == options::FIELDS)
-        .map_err(|e| UUsageError::new(1, e))?;
+    let is_field = matches!(mode_arg, options::FIELDS | options::FIELDS_MERGED);
+    let ranges = list_to_ranges(list, complement, is_field).map_err(|e| UUsageError::new(1, e))?;
 
     let mode = match mode_arg {
         options::BYTES => Mode::Bytes(
@@ -914,6 +1004,26 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 field_opts: Some(FieldOptions {
                     delimiter,
                     only_delimited,
+                    whitespace_trimmed,
+                }),
+                suppress_split,
+            },
+        ),
+        // `-F`: like `-f`, but consecutive delimiters merge, the delimiter
+        // defaults to whitespace, and the output delimiter defaults to a space.
+        options::FIELDS_MERGED => Mode::Fields(
+            ranges,
+            Options {
+                out_delimiter: out_delimiter.or(Some(b" ")),
+                line_ending,
+                field_opts: Some(FieldOptions {
+                    delimiter: if matches.contains_id(options::DELIMITER) {
+                        delimiter
+                    } else {
+                        Delimiter::Whitespace
+                    },
+                    only_delimited,
+                    whitespace_trimmed,
                 }),
                 suppress_split,
             },
@@ -930,17 +1040,23 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 }
 
 // Only one, and only one of cutting mode arguments, i.e. `-b`, `-c`, `-f`,
-// is expected.
+// `-F`, is expected.
 //
-// Returns `options::BYTES`, `options::CHARACTERS`, or `options::FIELDS`.
+// Returns `options::BYTES`, `options::CHARACTERS`, `options::FIELDS`, or
+// `options::FIELDS_MERGED`.
 fn get_mode_arg(matches: &ArgMatches) -> UResult<&str> {
-    let mode_args_and_counts: Vec<_> = [options::BYTES, options::CHARACTERS, options::FIELDS]
-        .into_iter()
-        .filter_map(|arg| {
-            let count = matches.indices_of(arg)?.count();
-            (count > 0).then_some((arg, count))
-        })
-        .collect();
+    let mode_args_and_counts: Vec<_> = [
+        options::BYTES,
+        options::CHARACTERS,
+        options::FIELDS,
+        options::FIELDS_MERGED,
+    ]
+    .into_iter()
+    .filter_map(|arg| {
+        let count = matches.indices_of(arg)?.count();
+        (count > 0).then_some((arg, count))
+    })
+    .collect();
 
     let mode_arg = match mode_args_and_counts.as_slice() {
         [(arg, 1)] => *arg,
@@ -966,7 +1082,9 @@ fn get_mode_arg(matches: &ArgMatches) -> UResult<&str> {
             ),
             (
                 // GNU words `-w` as a delimiter too, so it shares the message.
-                matches.get_flag(options::WHITESPACE_DELIMITED),
+                matches
+                    .get_one::<String>(options::WHITESPACE_DELIMITED)
+                    .is_some(),
                 "cut-error-delimiter-only-with-fields",
             ),
             (
@@ -1030,15 +1148,28 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::WHITESPACE_DELIMITED)
                 .short('w')
+                .long(options::WHITESPACE_DELIMITED)
                 .help(translate!("cut-help-whitespace-delimited"))
-                .value_name("WHITESPACE")
-                .action(ArgAction::SetTrue),
+                .value_name("trimmed")
+                .value_parser(["", "trimmed"])
+                .num_args(0..=1)
+                .require_equals(true)
+                .default_missing_value("")
+                .action(ArgAction::Set),
         )
         .arg(
             Arg::new(options::FIELDS)
                 .short('f')
                 .long(options::FIELDS)
                 .help(translate!("cut-help-fields"))
+                .allow_hyphen_values(true)
+                .value_name("LIST")
+                .action(ArgAction::Append),
+        )
+        .arg(
+            Arg::new(options::FIELDS_MERGED)
+                .short('F')
+                .help(translate!("cut-help-fields-merged"))
                 .allow_hyphen_values(true)
                 .value_name("LIST")
                 .action(ArgAction::Append),

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore defg naïve nave närd nøys ntøys nfjärd
+// spell-checker:ignore defg naïve nave närd nøys ntøys nfjärd undelimited xbfw
 
 use uutests::{at_and_ucmd, new_ucmd};
 
@@ -682,6 +682,90 @@ fn test_output_delimiter_with_adjacent_ranges() {
         .pipe_in("abcd\n")
         .succeeds()
         .stdout_only("ab:cd\n");
+}
+
+#[test]
+fn test_fields_merged() {
+    // -F: merge adjacent delimiters, default delimiter whitespace, output a space.
+    new_ucmd!()
+        .args(&["-F", "1,3"])
+        .pipe_in("one\ttwo   three\n")
+        .succeeds()
+        .stdout_only("one three\n");
+    new_ucmd!()
+        .args(&["-F", "1,3", "-O", "+"])
+        .pipe_in("one\ttwo   three\n")
+        .succeeds()
+        .stdout_only("one+three\n");
+    // -F with an explicit delimiter still uses a space as the output delimiter.
+    new_ucmd!()
+        .args(&["-F", "2,4", "-d", ";"])
+        .pipe_in("p;q;r;s\n")
+        .succeeds()
+        .stdout_only("q s\n");
+}
+
+#[test]
+fn test_fields_merged_conflicts_with_fields() {
+    new_ucmd!()
+        .args(&["-f", "3", "-F", "5"])
+        .fails_with_code(1)
+        .stderr_contains("cut: only one list may be specified");
+}
+
+#[test]
+fn test_whitespace_delimited_long_and_trimmed() {
+    // Long form behaves like -w (leading blanks make an empty first field).
+    new_ucmd!()
+        .args(&["--whitespace-delimited", "-f1,2"])
+        .pipe_in("   alpha beta\n")
+        .succeeds()
+        .stdout_only("\talpha\n");
+    // =trimmed strips leading/trailing blanks before splitting.
+    new_ucmd!()
+        .args(&["--whitespace-delimited=trimmed", "-f1,2"])
+        .pipe_in("  hello world  \n")
+        .succeeds()
+        .stdout_only("hello\tworld\n");
+    // With -s a single (undelimited) field is suppressed.
+    new_ucmd!()
+        .args(&["-s", "--whitespace-delimited=trimmed", "-f1"])
+        .pipe_in("   solo   \n")
+        .succeeds()
+        .stdout_only("");
+    // Without -s an undelimited line is printed whole, whatever field is asked
+    // for, while a blank-only line collapses to an empty one.
+    new_ucmd!()
+        .args(&["--whitespace-delimited=trimmed", "-f4"])
+        .pipe_in("  loner\n\t\n one two\n")
+        .succeeds()
+        .stdout_only("loner\n\n\n");
+    // Only `trimmed` is a valid value.
+    new_ucmd!()
+        .args(&["--whitespace-delimited=middle", "-f1"])
+        .fails_with_code(1);
+}
+
+#[test]
+fn test_unset_locale_is_byte_oriented() {
+    // With no locale set the POSIX default is C, so characters are bytes.
+    // "ж" is d0 b6, and -c3 must take just the b6.
+    new_ucmd!()
+        .env("LC_ALL", "")
+        .args(&["-c3"])
+        .pipe_in(&b"p\xd0\xb6t\n"[..])
+        .succeeds()
+        .stdout_only_bytes(b"\xb6\n");
+}
+
+#[test]
+fn test_newline_delim_suppress_missing_field() {
+    // -s with the newline as delimiter must not emit a spurious blank line.
+    new_ucmd!()
+        .args(&["-s", "-d", "\n", "-f3"])
+        .pipe_in("solo\n")
+        .succeeds()
+        .stdout_only("");
 }
 
 #[test]


### PR DESCRIPTION
Add the -F field mode (merge adjacent delimiters, whitespace default, space
output delimiter), accept the long --whitespace-delimited[=trimmed] form,
stop -s from emitting a blank line for a missing newline-delimited field,
and avoid a stray output delimiter for a partial -b -n character.

Should make test tests/cut/cut.pl pass

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>