### PR TITLE
uucore: locate diagnostic operands by argument, not by text

### DIFF
--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -71,23 +71,46 @@ mod options {
 /// These can currently not be handled by clap.
 /// Therefore it might be possible that a pseudo MODE is inserted to pass clap parsing.
 /// The pseudo MODE is later replaced by the extracted (and joined) negative modes.
-fn extract_negative_modes(mut args: impl uucore::Args) -> (Option<String>, Vec<OsString>) {
+fn extract_negative_modes(args: impl uucore::Args) -> (Option<String>, Vec<OsString>, Vec<usize>) {
+    let is_negative_mode = |arg: &OsString| {
+        let Some(arg) = arg.to_str() else {
+            return false;
+        };
+        arg.len() >= 2
+            && arg.starts_with('-')
+            && matches!(
+                arg.chars().nth(1).unwrap(),
+                'r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7'
+            )
+    };
+
     // we look up the args until "--" is found
     // "-mode" will be extracted into parsed_cmode_vec
-    let (parsed_cmode_vec, pre_double_hyphen_args): (Vec<OsString>, Vec<OsString>) =
-        args.by_ref().take_while(|a| a != "--").partition(|arg| {
-            let arg = if let Some(arg) = arg.to_str() {
-                arg.to_string()
-            } else {
-                return false;
-            };
-            arg.len() >= 2
-                && arg.starts_with('-')
-                && matches!(
-                    arg.chars().nth(1).unwrap(),
-                    'r' | 'w' | 'x' | 'X' | 's' | 't' | 'u' | 'g' | 'o' | '0'..='7'
-                )
-        });
+    let mut args = args.enumerate();
+    let mut parsed_cmode_vec: Vec<OsString> = Vec::new();
+    // Where each extracted mode sat in the original argument list, so that a
+    // diagnostic can point back at it.
+    let mut mode_indices = Vec::new();
+    let mut pre_double_hyphen_args = Vec::new();
+    let mut tail = Vec::new();
+    while let Some((index, arg)) = args.next() {
+        if arg == "--" {
+            if let Some((_, next)) = args.next() {
+                // as there is still something left in the iterator, we previously consumed the "--"
+                // -> add it to the args again
+                tail.push(OsString::from("--"));
+                tail.push(next);
+                tail.extend(args.map(|(_, arg)| arg));
+            }
+            break;
+        }
+        if is_negative_mode(&arg) {
+            mode_indices.push(index);
+            parsed_cmode_vec.push(arg);
+        } else {
+            pre_double_hyphen_args.push(arg);
+        }
+    }
 
     let mut clean_args = Vec::new();
     if !parsed_cmode_vec.is_empty() {
@@ -96,14 +119,7 @@ fn extract_negative_modes(mut args: impl uucore::Args) -> (Option<String>, Vec<O
         clean_args.push("w".into());
     }
     clean_args.extend(pre_double_hyphen_args);
-
-    if let Some(arg) = args.next() {
-        // as there is still something left in the iterator, we previously consumed the "--"
-        // -> add it to the args again
-        clean_args.push("--".into());
-        clean_args.push(arg);
-    }
-    clean_args.extend(args);
+    clean_args.extend(tail);
 
     let parsed_cmode = Some(
         parsed_cmode_vec
@@ -113,7 +129,7 @@ fn extract_negative_modes(mut args: impl uucore::Args) -> (Option<String>, Vec<O
             .join(","),
     )
     .filter(|s| !s.is_empty());
-    (parsed_cmode, clean_args)
+    (parsed_cmode, clean_args, mode_indices)
 }
 
 #[uucore::main]
@@ -121,8 +137,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<OsString> = args.skip(1).collect(); // skip binary name
     // Kept for the caret in mode diagnostics, which needs the mode as typed,
     // before `extract_negative_modes` replaces a negative mode by a pseudo one.
-    let mode_args = uucore::diagnostics::enabled().then(|| args.clone());
-    let (parsed_cmode, args) = extract_negative_modes(args.into_iter());
+    let mode_args = uucore::diagnostics::capture(&args);
+    let (parsed_cmode, args, mode_indices) = extract_negative_modes(args.into_iter());
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let changes = matches.get_flag(options::CHANGES);
@@ -185,6 +201,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         traverse_symlinks,
         dereference,
         args: mode_args,
+        mode_indices,
     };
 
     chmoder.chmod(&files)
@@ -289,6 +306,9 @@ struct Chmoder {
     dereference: bool,
     /// The arguments as typed, kept only when a diagnostic may be rendered.
     args: Option<Vec<OsString>>,
+    /// Where each extracted negative mode sat in `args`, in the order they
+    /// were joined into `cmode`. Empty unless `option_like_mode` is set.
+    mode_indices: Vec<usize>,
 }
 
 impl Chmoder {
@@ -331,12 +351,9 @@ impl Chmoder {
                             return Err(ExitCode::new(1));
                         }
                         if let Some(args) = &self.args
-                            && error.render(
-                                args,
-                                &cmode_unwrapped,
-                                clause_start,
-                                &error.to_string(),
-                            )
+                            && let Some((index, operand, offset)) =
+                                self.locate_clause(args, &cmode_unwrapped, clause_start)
+                            && error.render_at(args, index, &operand, offset, &error.to_string())
                         {
                             // The diagnostic is already on stderr; exit quietly.
                             return Err(ExitCode::new(1));
@@ -347,6 +364,36 @@ impl Chmoder {
             }
             Ok((new_mode, naively_expected_new_mode))
         }
+    }
+
+    /// Map `clause_start` — an offset into `cmode`, the joined mode string —
+    /// back to the argument the failing clause came from.
+    ///
+    /// Returns the argument's index in `args`, the mode text that argument
+    /// carries, and the clause's offset inside that text. A mode given as a
+    /// plain positional is its own argument; extracted negative modes
+    /// (`chmod -w -x f`) were joined with commas, so the offset is walked back
+    /// through the recorded [`Chmoder::mode_indices`].
+    fn locate_clause(
+        &self,
+        args: &[OsString],
+        cmode: &str,
+        clause_start: usize,
+    ) -> Option<(usize, String, usize)> {
+        if !self.option_like_mode {
+            let index = args.iter().position(|arg| arg == cmode)?;
+            return Some((index, cmode.to_string(), clause_start));
+        }
+        let mut start = 0;
+        for &index in &self.mode_indices {
+            let element = args.get(index)?.to_str()?;
+            // The `+ 1` is the comma the join put after this element.
+            if clause_start < start + element.len() + 1 {
+                return Some((index, element.to_string(), clause_start - start));
+            }
+            start += element.len() + 1;
+        }
+        None
     }
 
     /// Report permission changes based on verbose and changes flags
@@ -904,25 +951,29 @@ mod tests {
     fn test_extract_negative_modes() {
         // "chmod -w -r file" becomes "chmod -w,-r file". clap does not accept "-w,-r" as MODE.
         // Therefore, "w" is added as pseudo mode to pass clap.
-        let (c, a) = extract_negative_modes(["-w", "-r", "file"].iter().map(OsString::from));
+        let (c, a, i) = extract_negative_modes(["-w", "-r", "file"].iter().map(OsString::from));
         assert_eq!(c, Some("-w,-r".to_string()));
         assert_eq!(a, ["w", "file"]);
+        assert_eq!(i, [0, 1]);
 
         // "chmod -w file -r" becomes "chmod -w,-r file". clap does not accept "-w,-r" as MODE.
         // Therefore, "w" is added as pseudo mode to pass clap.
-        let (c, a) = extract_negative_modes(["-w", "file", "-r"].iter().map(OsString::from));
+        let (c, a, i) = extract_negative_modes(["-w", "file", "-r"].iter().map(OsString::from));
         assert_eq!(c, Some("-w,-r".to_string()));
         assert_eq!(a, ["w", "file"]);
+        assert_eq!(i, [0, 2]);
 
         // "chmod -w -- -r file" becomes "chmod -w -r file", where "-r" is interpreted as file.
         // Again, "w" is needed as pseudo mode.
-        let (c, a) = extract_negative_modes(["-w", "--", "-r", "f"].iter().map(OsString::from));
+        let (c, a, i) = extract_negative_modes(["-w", "--", "-r", "f"].iter().map(OsString::from));
         assert_eq!(c, Some("-w".to_string()));
         assert_eq!(a, ["w", "--", "-r", "f"]);
+        assert_eq!(i, [0]);
 
         // "chmod -- -r file" becomes "chmod -r file".
-        let (c, a) = extract_negative_modes(["--", "-r", "file"].iter().map(OsString::from));
+        let (c, a, i) = extract_negative_modes(["--", "-r", "file"].iter().map(OsString::from));
         assert_eq!(c, None);
         assert_eq!(a, ["--", "-r", "file"]);
+        assert!(i.is_empty());
     }
 }

--- a/src/uu/expr/src/diagnostics.rs
+++ b/src/uu/expr/src/diagnostics.rs
@@ -9,7 +9,7 @@
 use uucore::diagnostics::Snapshot;
 use uucore::translate;
 
-use crate::ExprError;
+use crate::{ExprError, FailurePoint};
 
 /// What to point at: the argument index, the text for the caret, and optional
 /// advice.
@@ -21,13 +21,13 @@ struct Located {
 
 /// Render `err` against `args`.
 ///
-/// `stopped_at` is the number of arguments the parser had consumed, and is
-/// `None` for errors raised once the expression was already parsed. Returns
-/// `false` when the error cannot be tied to an argument, in which case the
-/// caller should fall back to the plain one-line message.
-pub fn render(args: &[Vec<u8>], err: &ExprError, stopped_at: Option<usize>) -> bool {
+/// `at` says where the expression failed: how many arguments the parser had
+/// consumed, or which argument evaluation blames. Returns `false` when the
+/// error cannot be tied to an argument, in which case the caller should fall
+/// back to the plain one-line message.
+pub fn render(args: &[Vec<u8>], err: &ExprError, at: &FailurePoint) -> bool {
     let snapshot = Snapshot::from_bytes(args);
-    let Some(located) = locate(&snapshot, err, stopped_at) else {
+    let Some(located) = locate(&snapshot, err, at) else {
         return false;
     };
     snapshot.render(
@@ -38,11 +38,15 @@ pub fn render(args: &[Vec<u8>], err: &ExprError, stopped_at: Option<usize>) -> b
     )
 }
 
-fn locate(snapshot: &Snapshot, err: &ExprError, stopped_at: Option<usize>) -> Option<Located> {
+fn locate(snapshot: &Snapshot, err: &ExprError, at: &FailurePoint) -> Option<Located> {
     if snapshot.is_empty() {
         return None;
     }
 
+    let stopped_at = match at {
+        FailurePoint::Parse(index) => Some(*index),
+        FailurePoint::Eval(_) => None,
+    };
     // The parser ran out of arguments, so the culprit is the last one it did
     // consume: the operator or parenthesis left dangling.
     let previous = || stopped_at.map(|index| index.saturating_sub(1));
@@ -69,11 +73,14 @@ fn locate(snapshot: &Snapshot, err: &ExprError, stopped_at: Option<usize>) -> Op
             "expr-diag-label-expected-closing-brace-instead-of",
             None,
         ),
-        // Raised while evaluating, so the position is recovered from the value.
-        // An operand computed by a subexpression will not be found, and the
-        // error falls back to its plain form.
-        ExprError::NonIntegerArgument(operand) => (
-            snapshot.index_of_bytes(operand),
+        // Raised while evaluating; the evaluator says which argument it
+        // blames. An operand computed by a subexpression has no argument of
+        // its own, and the error falls back to its plain form.
+        ExprError::NonIntegerArgument(_) => (
+            match at {
+                FailurePoint::Eval(index) => *index,
+                FailurePoint::Parse(_) => None,
+            },
             "expr-diag-label-non-integer-argument",
             Some("expr-diag-help-non-integer-argument"),
         ),

--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -103,13 +103,20 @@ pub fn uu_app() -> Command {
         )
 }
 
+/// Where an expression failed, in terms a diagnostic can point at.
+pub enum FailurePoint {
+    /// The parser failed after consuming this many arguments.
+    Parse(usize),
+    /// Evaluation failed, at this argument when one is to blame.
+    Eval(Option<usize>),
+}
+
 /// Parse and evaluate the expression.
-///
-/// On failure the second half of the error reports how many arguments the
-/// parser had consumed, which is `None` once parsing has succeeded.
-fn evaluate(args: &[Vec<u8>]) -> Result<Vec<u8>, (ExprError, Option<usize>)> {
-    let ast = AstNode::parse_located(args).map_err(|(e, at)| (e, Some(at)))?;
-    let value = ast.eval().map_err(|e| (e, None))?;
+fn evaluate(args: &[Vec<u8>]) -> Result<Vec<u8>, (ExprError, FailurePoint)> {
+    let ast = AstNode::parse_located(args).map_err(|(e, at)| (e, FailurePoint::Parse(at)))?;
+    let value = ast
+        .eval_located()
+        .map_err(|(e, at)| (e, FailurePoint::Eval(at)))?;
     Ok(value.eval_as_string())
 }
 
@@ -136,12 +143,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         let res = match evaluate(args) {
             Ok(res) => res,
-            Err((e, stopped_at)) => {
-                if uucore::diagnostics::enabled() && diagnostics::render(args, &e, stopped_at) {
-                    // The diagnostic is already on stderr; exit quietly.
-                    return Err(uucore::error::ExitCode::new(e.code()));
-                }
-                return Err(e.into());
+            Err((e, at)) => {
+                let reported = uucore::diagnostics::enabled() && diagnostics::render(args, &e, &at);
+                return Err(uucore::error::quiet_if_reported(reported, e));
             }
         };
         let _ = stdout().write_all(&res);

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -616,12 +616,14 @@ pub struct AstNode {
     inner: AstNodeInner,
 }
 
-// We derive Eq and PartialEq only for tests because we want to ignore the id field.
+// Eq and PartialEq are implemented only for tests, ignoring the id and
+// position fields.
 #[derive(Debug, Clone)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
 pub enum AstNodeInner {
     Leaf {
         value: MaybeNonUtf8String,
+        /// Index of the argument the value came from, for diagnostics.
+        position: usize,
     },
     BinOp {
         op_type: BinOp,
@@ -656,13 +658,23 @@ impl AstNode {
         parser.parse().map_err(|e| (e, parser.index))
     }
 
+    /// [`AstNode::eval_located`] without the location, for tests that only
+    /// care about the value.
+    #[cfg(test)]
     pub fn eval(&self) -> ExprResult<NumOrStr> {
+        self.eval_located().map_err(|(error, _)| error)
+    }
+
+    /// Evaluate, reporting on failure the index of the argument the error is
+    /// about, when there is one single argument to blame.
+    pub fn eval_located(&self) -> Result<NumOrStr, (ExprError, Option<usize>)> {
         // This function implements a recursive tree-walking algorithm, but uses an explicit
         // stack approach instead of native recursion to avoid potential stack overflow
         // on deeply nested expressions.
 
         let mut stack = vec![self];
-        let mut result_stack = BTreeMap::new();
+        let mut result_stack: BTreeMap<u32, Result<NumOrStr, (ExprError, Option<usize>)>> =
+            BTreeMap::new();
 
         while let Some(node) = stack.pop() {
             match &node.inner {
@@ -674,7 +686,7 @@ impl AstNode {
                     left,
                     right,
                 } => {
-                    let (Some(right), Some(left)) = (
+                    let (Some(right_result), Some(left_result)) = (
                         result_stack.remove(&right.id),
                         result_stack.remove(&left.id),
                     ) else {
@@ -684,7 +696,23 @@ impl AstNode {
                         continue;
                     };
 
-                    let result = op_type.eval(left, right);
+                    // The operator takes plain results — some, like `|`,
+                    // swallow their children's errors — so the positions are
+                    // held back and re-attached if an error comes out.
+                    let (left_result, left_position) = split(left_result);
+                    let (right_result, right_position) = split(right_result);
+                    let result = op_type.eval(left_result, right_result).map_err(|error| {
+                        let position = match &error {
+                            // Born here from a leaf operand, unless a child
+                            // already located it deeper in the expression.
+                            ExprError::NonIntegerArgument(value) => left_position
+                                .or(right_position)
+                                .or_else(|| leaf_position(left, value))
+                                .or_else(|| leaf_position(right, value)),
+                            _ => left_position.or(right_position),
+                        };
+                        (error, position)
+                    });
                     result_stack.insert(node.id, result);
                 }
                 AstNodeInner::Substr {
@@ -751,13 +779,39 @@ impl AstNode {
     }
 }
 
+/// Take the position out of a located result, leaving the plain result the
+/// operator evaluators work on.
+fn split(
+    result: Result<NumOrStr, (ExprError, Option<usize>)>,
+) -> (ExprResult<NumOrStr>, Option<usize>) {
+    match result {
+        Ok(value) => (Ok(value), None),
+        Err((error, position)) => (Err(error), position),
+    }
+}
+
+/// The position of `node`, when it is a leaf holding exactly `value`.
+fn leaf_position(node: &AstNode, value: &MaybeNonUtf8Str) -> Option<usize> {
+    match &node.inner {
+        AstNodeInner::Leaf {
+            value: leaf,
+            position,
+        } if leaf == value => Some(*position),
+        _ => None,
+    }
+}
+
 impl Drop for AstNode {
     // This is a tree-walking algorithm, so like `eval` it uses an explicit
     // stack instead of native recursion to avoid a stack overflow when
     // dropping a deeply nested AST.
     fn drop(&mut self) {
         fn detach_children(inner: &mut AstNodeInner, stack: &mut Vec<AstNode>) {
-            match std::mem::replace(inner, AstNodeInner::Leaf { value: Vec::new() }) {
+            let empty = AstNodeInner::Leaf {
+                value: Vec::new(),
+                position: 0,
+            };
+            match std::mem::replace(inner, empty) {
                 AstNodeInner::Leaf { .. } => {}
                 AstNodeInner::BinOp { left, right, .. } => {
                     stack.push(*left);
@@ -979,12 +1033,16 @@ impl<'a, S: AsRef<MaybeNonUtf8Str>> Parser<'a, S> {
                     }
                     b"+" => ParseState::Value(AstNode::new(AstNodeInner::Leaf {
                         value: self.next()?.into(),
+                        position: self.index - 1,
                     })),
                     b"(" => {
                         stack.push(ParseFrame::CloseParen);
                         ParseState::Expression { min_prec: 0 }
                     }
-                    s => ParseState::Value(AstNode::new(AstNodeInner::Leaf { value: s.into() })),
+                    s => ParseState::Value(AstNode::new(AstNodeInner::Leaf {
+                        value: s.into(),
+                        position: self.index - 1,
+                    })),
                 },
                 ParseState::Value(value) => match stack.pop() {
                     None => return Ok(value),
@@ -1087,12 +1145,51 @@ mod test {
 
     impl Eq for AstNode {}
 
+    // Hand-built expectations cannot know real argument positions, so
+    // equality ignores them, like it ignores ids.
+    impl PartialEq for AstNodeInner {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (Self::Leaf { value: a, .. }, Self::Leaf { value: b, .. }) => a == b,
+                (
+                    Self::BinOp {
+                        op_type: a_op,
+                        left: a_left,
+                        right: a_right,
+                    },
+                    Self::BinOp {
+                        op_type: b_op,
+                        left: b_left,
+                        right: b_right,
+                    },
+                ) => a_op == b_op && a_left == b_left && a_right == b_right,
+                (
+                    Self::Substr {
+                        string: a_string,
+                        pos: a_pos,
+                        length: a_length,
+                    },
+                    Self::Substr {
+                        string: b_string,
+                        pos: b_pos,
+                        length: b_length,
+                    },
+                ) => a_string == b_string && a_pos == b_pos && a_length == b_length,
+                (Self::Length { string: a }, Self::Length { string: b }) => a == b,
+                _ => false,
+            }
+        }
+    }
+
+    impl Eq for AstNodeInner {}
+
     impl From<&str> for AstNode {
         fn from(value: &str) -> Self {
             Self {
                 id: get_next_id(),
                 inner: AstNodeInner::Leaf {
                     value: value.into(),
+                    position: 0,
                 },
             }
         }

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -377,7 +377,7 @@ fn behavior(matches: &ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Beh
         Some(uucore::mode::parse(x, considering_dir, 0).map_err(|err| {
             let message = translate!("install-error-invalid-mode", "error" => err.to_string());
             // When the diagnostic is rendered it is already on stderr; exit quietly.
-            if !diag_args.is_some_and(|args| err.render(args, x, 0, &message)) {
+            if !diag_args.is_some_and(|args| err.render_mode_value(args, x, 0, &message)) {
                 show_error!("{message}");
             }
             1

--- a/src/uu/mkdir/src/mkdir.rs
+++ b/src/uu/mkdir/src/mkdir.rs
@@ -70,7 +70,7 @@ fn get_mode(matches: &ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Opt
     mode::parse_chmod(DEFAULT_PERM, m, true, mode::get_umask())
         .map(Some)
         .map_err(|err| {
-            if diag_args.is_some_and(|args| err.render(args, m, 0, &err.to_string())) {
+            if diag_args.is_some_and(|args| err.render_mode_value(args, m, 0, &err.to_string())) {
                 // The diagnostic is already on stderr; exit quietly.
                 ExitCode::new(1)
             } else {

--- a/src/uu/mkfifo/src/mkfifo.rs
+++ b/src/uu/mkfifo/src/mkfifo.rs
@@ -31,7 +31,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let message = translate!("mkfifo-error-invalid-mode", "error" => err.to_string());
         if let Some(args) = &diag_args
             && let Some(mode) = matches.get_one::<String>(options::MODE)
-            && err.render(args, mode, 0, &message)
+            && err.render_mode_value(args, mode, 0, &message)
         {
             // The diagnostic is already on stderr; exit quietly.
             return ExitCode::new(1);

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -158,7 +158,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     let message =
                         translate!("mknod-error-invalid-mode", "error" => err.to_string());
                     if let Some(args) = &diag_args
-                        && err.render(args, str_mode, 0, &message)
+                        && err.render_mode_value(args, str_mode, 0, &message)
                     {
                         // The diagnostic is already on stderr; exit quietly.
                         return ExitCode::new(1);

--- a/src/uu/numfmt/src/diagnostics.rs
+++ b/src/uu/numfmt/src/diagnostics.rs
@@ -13,7 +13,8 @@ use uucore::translate;
 
 use crate::options::{FormatError, FormatErrorKind};
 
-/// Render `err`, raised while parsing `format`, against `args`.
+/// Render `err`, raised while parsing `format`, against `args` — the whole
+/// argument list, program name included.
 ///
 /// Returns `false` when the format cannot be found among the arguments, in
 /// which case the caller should fall back to the plain one-line message.
@@ -25,7 +26,12 @@ pub fn render(args: &[OsString], format: &str, err: &FormatError) -> bool {
         FormatErrorKind::StrayPercent => "numfmt-diag-label-stray-percent",
     };
 
-    Snapshot::new(args).render_inside(
+    let snapshot = Snapshot::with_program(args);
+    let Some(index) = snapshot.index_of_value(format, None, Some("format")) else {
+        return false;
+    };
+    snapshot.render_inside_at(
+        index,
         format,
         err.span.clone(),
         &err.message,

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -9,8 +9,8 @@ use crate::format::{escape_line, write_formatted_with_delimiter, write_formatted
 use crate::options::{
     DEBUG, DELIMITER, FIELD, FIELD_DEFAULT, FORMAT, FROM, FROM_DEFAULT, FROM_UNIT,
     FROM_UNIT_DEFAULT, FormatOptions, GROUPING, HEADER, HEADER_DEFAULT, INVALID, InvalidModes,
-    NUMBER, NumfmtOptions, PADDING, ROUND, RoundMethod, SUFFIX, TO, TO_DEFAULT, TO_UNIT,
-    TO_UNIT_DEFAULT, TransformOptions, UNIT_SEPARATOR, ZERO_TERMINATED,
+    NUMBER, NumfmtOptions, PADDING, ParseError, ROUND, RoundMethod, SUFFIX, TO, TO_DEFAULT,
+    TO_UNIT, TO_UNIT_DEFAULT, TransformOptions, UNIT_SEPARATOR, ZERO_TERMINATED,
 };
 use crate::units::{Result, Unit};
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser, parser::ValueSource};
@@ -19,7 +19,7 @@ use std::io::{BufRead, Write as _, stderr};
 use std::str::FromStr;
 
 use uucore::display::Quotable;
-use uucore::error::{ExitCode, UResult};
+use uucore::error::{UResult, quiet_if_reported};
 use uucore::i18n::decimal::locale_grouping_separator;
 use uucore::parser::parse_size::{IEC_BASES, SI_BASES};
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
@@ -245,7 +245,7 @@ fn parse_delimiter(arg: &OsString) -> Result<Vec<u8>> {
     }
 }
 
-fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
+fn parse_options(args: &ArgMatches) -> std::result::Result<NumfmtOptions, ParseError> {
     let from = parse_unit(args.get_one::<String>(FROM).unwrap(), FROM)?;
     let to = parse_unit(args.get_one::<String>(TO).unwrap(), TO)?;
     let from_unit = parse_unit_size(args.get_one::<String>(FROM_UNIT).unwrap())?;
@@ -303,17 +303,13 @@ fn parse_options(args: &ArgMatches) -> Result<NumfmtOptions> {
     };
 
     if grouping && args.contains_id(FORMAT) {
-        return Err(translate!(
-            "numfmt-error-grouping-cannot-be-combined-with-format"
-        ));
+        return Err(translate!("numfmt-error-grouping-cannot-be-combined-with-format").into());
     }
 
     let grouping = grouping || format.grouping;
 
     if grouping && to != Unit::None {
-        return Err(translate!(
-            "numfmt-error-grouping-cannot-be-combined-with-to"
-        ));
+        return Err(translate!("numfmt-error-grouping-cannot-be-combined-with-to").into());
     }
 
     let delimiter = args
@@ -398,18 +394,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
     let options = match parse_options(&matches) {
         Ok(options) => options,
-        Err(message) => {
-            // Only the format is worth a caret, and only when it is the very
-            // error that was reported: other options are checked first.
-            if let Some(args) = &format_args
-                && let Some(format) = matches.get_one::<String>(FORMAT)
-                && let Err(error) = format.parse::<FormatOptions>()
-                && error.message == message
-                && diagnostics::render(args, format, &error)
-            {
-                // The diagnostic is already on stderr; exit quietly.
-                return Err(ExitCode::new(1));
-            }
+        // A format error still knows where in the format string it happened,
+        // so it is the one error worth a caret.
+        Err(ParseError::Format(error)) => {
+            let reported = format_args
+                .as_ref()
+                .zip(matches.get_one::<String>(FORMAT))
+                .is_some_and(|(args, format)| diagnostics::render(args, format, &error));
+            return Err(quiet_if_reported(
+                reported,
+                NumfmtError::IllegalArgument(error.message),
+            ));
+        }
+        Err(ParseError::Other(message)) => {
             return Err(NumfmtError::IllegalArgument(message).into());
         }
     };

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -151,9 +151,23 @@ impl Display for FormatError {
     }
 }
 
-impl From<FormatError> for String {
+/// Why option parsing failed: a format error that still knows where in the
+/// format string it happened, or a plain message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    Format(FormatError),
+    Other(String),
+}
+
+impl From<FormatError> for ParseError {
     fn from(error: FormatError) -> Self {
-        error.message
+        Self::Format(error)
+    }
+}
+
+impl From<String> for ParseError {
+    fn from(message: String) -> Self {
+        Self::Other(message)
     }
 }
 

--- a/src/uu/sort/locales/en-US.ftl
+++ b/src/uu/sort/locales/en-US.ftl
@@ -31,7 +31,6 @@ sort-failed-parse-field-index = failed to parse field index {$field} {$error}
 sort-field-index-cannot-be-zero = field index can not be 0
 sort-failed-parse-char-index = failed to parse character index {$char}: {$error}
 sort-invalid-option = invalid option: '{$option}'
-sort-invalid-char-index-zero-start = invalid character index 0 for the start position of a field
 sort-invalid-field-spec = {$msg}: invalid field specification {$spec}
 sort-invalid-count-at-start-of = invalid count at start of {$string}
 sort-invalid-number-at-field-start = invalid number at field start

--- a/src/uu/sort/locales/fr-FR.ftl
+++ b/src/uu/sort/locales/fr-FR.ftl
@@ -31,7 +31,6 @@ sort-failed-parse-field-index = échec d'analyse de l'index de champ {$field} {$
 sort-field-index-cannot-be-zero = l'index de champ ne peut pas être 0
 sort-failed-parse-char-index = échec d'analyse de l'index de caractère {$char} : {$error}
 sort-invalid-option = option invalide : '{$option}'
-sort-invalid-char-index-zero-start = index de caractère 0 invalide pour la position de début d'un champ
 sort-invalid-field-spec = {$msg} : spécification de champ invalide {$spec}
 sort-invalid-count-at-start-of = nombre invalide au début de {$string}
 sort-invalid-number-at-field-start = nombre invalide au début du champ

--- a/src/uu/sort/src/diagnostics.rs
+++ b/src/uu/sort/src/diagnostics.rs
@@ -13,7 +13,8 @@ use uucore::translate;
 
 use crate::{KeyError, KeyErrorKind};
 
-/// Render `err`, raised while parsing `key`, against `args`.
+/// Render `err`, raised while parsing `key`, against `args` — the whole
+/// argument list, program name included.
 ///
 /// Returns `false` when the key cannot be found among the arguments, in which
 /// case the caller should fall back to the plain one-line message.
@@ -25,7 +26,12 @@ pub fn render(args: &[OsString], key: &str, err: &KeyError) -> bool {
         KeyErrorKind::IncompatibleOptions => ("sort-diag-label-incompatible-options", false),
     };
 
-    Snapshot::new(args).render_inside(
+    let snapshot = Snapshot::with_program(args);
+    let Some(index) = snapshot.index_of_value(key, Some('k'), Some("key")) else {
+        return false;
+    };
+    snapshot.render_inside_at(
+        index,
         key,
         err.span.clone(),
         &err.message,

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2102,13 +2102,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ..Default::default()
     };
 
+    // Kept for the caret in `-k` diagnostics, which echoes the command line:
+    // taken before the legacy rewrite, so that a `-k` error in a command that
+    // also used `+POS` shows what was typed rather than the `-k` the rewrite
+    // synthesized.
+    let args: Vec<OsString> = args.collect();
+    let key_args = uucore::diagnostics::capture(&args);
+
     let (processed_args, mut legacy_warnings) = preprocess_legacy_args(args);
     if !legacy_warnings.is_empty() {
         index_legacy_warnings(&processed_args, &mut legacy_warnings);
     }
-    // Kept for the caret in `-k` diagnostics, which needs the arguments as they
-    // reached the parser.
-    let key_args = uucore::diagnostics::capture(&processed_args);
     let matches =
         uucore::clap_localization::handle_clap_result_with_exit_code(uu_app(), processed_args, 2)?;
 

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -1285,33 +1285,23 @@ impl FieldSelector {
             char: from_char,
             ignore_blanks: from_ignore_blanks,
         };
-        Self::new(from, to, settings).map_err(|message| KeyError {
-            message,
-            span: 0..key.len(),
-            kind: KeyErrorKind::ZeroCount,
-        })
+        Ok(Self::new(from, to, settings))
     }
 
-    fn new(
-        from: KeyPosition,
-        to: Option<KeyPosition>,
-        settings: KeySettings,
-    ) -> Result<Self, String> {
-        if from.char == 0 {
-            Err(translate!("sort-invalid-char-index-zero-start"))
-        } else {
-            Ok(Self {
-                needs_selection: (from.field != 1
-                    || from.char != 1
-                    || to.is_some()
-                    || matches!(settings.mode, SortMode::Numeric | SortMode::HumanNumeric)
-                    || from.ignore_blanks)
-                    && !matches!(settings.mode, SortMode::GeneralNumeric),
-                needs_tokens: from.field != 1 || from.char == 0 || to.is_some(),
-                from,
-                to,
-                settings,
-            })
+    fn new(from: KeyPosition, to: Option<KeyPosition>, settings: KeySettings) -> Self {
+        // A zero start position is rejected by `parse` before getting here.
+        debug_assert_ne!(from.char, 0);
+        Self {
+            needs_selection: (from.field != 1
+                || from.char != 1
+                || to.is_some()
+                || matches!(settings.mode, SortMode::Numeric | SortMode::HumanNumeric)
+                || from.ignore_blanks)
+                && !matches!(settings.mode, SortMode::GeneralNumeric),
+            needs_tokens: from.field != 1 || to.is_some(),
+            from,
+            to,
+            settings,
         }
     }
 
@@ -2399,18 +2389,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if !matches.contains_id(options::KEY) {
         // add a default selector matching the whole line
         let key_settings = KeySettings::from(&settings);
-        settings.selectors.push(
-            FieldSelector::new(
-                KeyPosition {
-                    field: 1,
-                    char: 1,
-                    ignore_blanks: key_settings.ignore_blanks,
-                },
-                None,
-                key_settings,
-            )
-            .unwrap(),
-        );
+        settings.selectors.push(FieldSelector::new(
+            KeyPosition {
+                field: 1,
+                char: 1,
+                ignore_blanks: key_settings.ignore_blanks,
+            },
+            None,
+            key_settings,
+        ));
     }
 
     let needs_random = settings.mode == SortMode::Random

--- a/src/uu/tr/locales/en-US.ftl
+++ b/src/uu/tr/locales/en-US.ftl
@@ -55,7 +55,6 @@ tr-diag-label-class-except-lower-upper-in-set2 = only [:lower:] and [:upper:] ma
 tr-diag-label-class-in-set2-not-matched = no class at the matching position in SET1
 tr-diag-label-set1-longer-set2-ends-in-class = this set is longer than SET2
 tr-diag-label-complement-more-than-one-unique = only one character may be complemented to
-tr-diag-label-empty-set2 = this set is empty
 tr-diag-help-char-class = classes are alnum, alpha, blank, cntrl, digit, graph, lower, print, punct, space, upper and xdigit
 tr-diag-help-equivalence = [=c=] stands for every character equivalent to c
 tr-diag-help-repeat = [c*N] repeats c N times, [c*] pads SET2 to the length of SET1

--- a/src/uu/tr/locales/fr-FR.ftl
+++ b/src/uu/tr/locales/fr-FR.ftl
@@ -56,7 +56,6 @@ tr-diag-label-class-except-lower-upper-in-set2 = seules [:lower:] et [:upper:] p
 tr-diag-label-class-in-set2-not-matched = aucune classe à la position correspondante dans SET1
 tr-diag-label-set1-longer-set2-ends-in-class = cet ensemble est plus long que SET2
 tr-diag-label-complement-more-than-one-unique = un seul caractère peut être la cible du complément
-tr-diag-label-empty-set2 = cet ensemble est vide
 tr-diag-help-char-class = les classes sont alnum, alpha, blank, cntrl, digit, graph, lower, print, punct, space, upper et xdigit
 tr-diag-help-equivalence = [=c=] désigne tout caractère équivalent à c
 tr-diag-help-repeat = [c*N] répète c N fois, [c*] complète SET2 à la longueur de SET1

--- a/src/uu/tr/src/diagnostics.rs
+++ b/src/uu/tr/src/diagnostics.rs
@@ -13,7 +13,8 @@ use uucore::translate;
 
 use crate::operation::{BadSequence, SequenceError};
 
-/// Render `err` against `args`, where `sets` are the set operands as typed.
+/// Render `err` against `args` — the whole argument list, program name
+/// included — where `sets` are the set operands as typed.
 ///
 /// Returns `false` when the set cannot be found among the arguments, in which
 /// case the caller should fall back to the plain one-line message.
@@ -27,11 +28,20 @@ pub fn render(args: &[OsString], sets: &[OsString], err: &SequenceError) -> bool
         return false;
     };
 
-    let (label, help) = describe(&err.error);
+    let Some((label, help)) = describe(&err.error) else {
+        return false;
+    };
     // No span means the set as a whole is the problem, so underline all of it.
     let span = err.span.clone().unwrap_or(0..set.len());
 
-    Snapshot::new(args).render_inside(
+    // The sets are positional operands, numbered as they appear; this holds
+    // because none of tr's options takes a separate value.
+    let snapshot = Snapshot::with_program(args);
+    let Some(index) = snapshot.index_of_positional(usize::from(err.set) - 1) else {
+        return false;
+    };
+    snapshot.render_inside_at(
+        index,
         set,
         span,
         &err.to_string(),
@@ -40,54 +50,55 @@ pub fn render(args: &[OsString], sets: &[OsString], err: &SequenceError) -> bool
     )
 }
 
-/// The caret label for `error`, and the advice that goes under it.
-fn describe(error: &BadSequence) -> (&'static str, Option<&'static str>) {
+/// The caret label for `error`, and the advice that goes under it, or `None`
+/// for an error that a caret cannot be placed for.
+fn describe(error: &BadSequence) -> Option<(&'static str, Option<&'static str>)> {
     match error {
-        BadSequence::MissingCharClassName => (
+        BadSequence::MissingCharClassName => Some((
             "tr-diag-label-missing-char-class-name",
             Some("tr-diag-help-char-class"),
-        ),
-        BadSequence::InvalidCharClass(_) => (
+        )),
+        BadSequence::InvalidCharClass(_) => Some((
             "tr-diag-label-invalid-char-class",
             Some("tr-diag-help-char-class"),
-        ),
-        BadSequence::MissingEquivalentClassChar => (
+        )),
+        BadSequence::MissingEquivalentClassChar => Some((
             "tr-diag-label-missing-equivalence-char",
             Some("tr-diag-help-equivalence"),
-        ),
-        BadSequence::MultipleCharInEquivalence(_) => (
+        )),
+        BadSequence::MultipleCharInEquivalence(_) => Some((
             "tr-diag-label-multiple-char-in-equivalence",
             Some("tr-diag-help-equivalence"),
-        ),
-        BadSequence::InvalidRepeatCount(_) => (
+        )),
+        BadSequence::InvalidRepeatCount(_) => Some((
             "tr-diag-label-invalid-repeat-count",
             Some("tr-diag-help-repeat"),
-        ),
-        BadSequence::BackwardsRange { .. } => (
+        )),
+        BadSequence::BackwardsRange { .. } => Some((
             "tr-diag-label-backwards-range",
             Some("tr-diag-help-backwards-range"),
-        ),
-        BadSequence::CharRepeatInSet1 => (
+        )),
+        BadSequence::CharRepeatInSet1 => Some((
             "tr-diag-label-char-repeat-in-set1",
             Some("tr-diag-help-repeat"),
-        ),
+        )),
         BadSequence::MultipleCharRepeatInSet2 => {
-            ("tr-diag-label-multiple-char-repeat-in-set2", None)
+            Some(("tr-diag-label-multiple-char-repeat-in-set2", None))
         }
         BadSequence::ClassExceptLowerUpperInSet2 => {
-            ("tr-diag-label-class-except-lower-upper-in-set2", None)
+            Some(("tr-diag-label-class-except-lower-upper-in-set2", None))
         }
         BadSequence::ClassInSet2NotMatchedBySet1 => {
-            ("tr-diag-label-class-in-set2-not-matched", None)
+            Some(("tr-diag-label-class-in-set2-not-matched", None))
         }
         BadSequence::Set1LongerSet2EndsInClass => {
-            ("tr-diag-label-set1-longer-set2-ends-in-class", None)
+            Some(("tr-diag-label-set1-longer-set2-ends-in-class", None))
         }
         BadSequence::ComplementMoreThanOneUniqueInSet2 => {
-            ("tr-diag-label-complement-more-than-one-unique", None)
+            Some(("tr-diag-label-complement-more-than-one-unique", None))
         }
-        // Raised against the solved sets, so it never carries a location and is
-        // filtered out before reaching here.
-        BadSequence::EmptySet2WhenNotTruncatingSet1 => ("tr-diag-label-empty-set2", None),
+        // Raised against the solved sets rather than what was typed, so there
+        // is nothing to point a caret at.
+        BadSequence::EmptySet2WhenNotTruncatingSet1 => None,
     }
 }

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (strings) anychar combinator Alnum Punct Xdigit alnum punct xdigit cntrl
+// spell-checker:ignore (strings) anychar combinator Alnum Punct Xdigit alnum punct xdigit cntrl alpah
 
 use crate::unicode_table;
 use nom::{
@@ -419,9 +419,12 @@ impl Sequence {
     ///
     /// The alternatives are tried in the same order as before; the loop only
     /// replaces `many0` so that how much each sequence consumed is still known
-    /// once it turns out to be wrong.
+    /// once it turns out to be wrong. Like `many0`, it consumes the whole set
+    /// even past a bad sequence: parsing the tail emits the warnings — an
+    /// ambiguous octal escape, invalid UTF-8 — that it always has.
     fn parse_set(input: &[u8]) -> Result<Vec<Self>, (BadSequence, Range<usize>)> {
         let mut result = Vec::new();
+        let mut first_error = None;
         let mut rest = input;
         while !rest.is_empty() {
             let start = input.len() - rest.len();
@@ -440,11 +443,25 @@ impl Sequence {
             // The last alternative accepts any single byte, so this only
             // happens on input the loop has already run out of.
             let Ok((next, sequence)) = parsed else { break };
+            // `many0` refuses an alternative that matched nothing rather than
+            // loop on it forever; none of the ones above can, but the loop is
+            // no place to find out if one ever does.
+            if next.len() == rest.len() {
+                break;
+            }
             let end = input.len() - next.len();
-            result.push(sequence.map_err(|error| (error, start..end))?);
+            match sequence {
+                Ok(sequence) => result.push(sequence),
+                Err(error) => {
+                    first_error.get_or_insert((error, start..end));
+                }
+            }
             rest = next;
         }
-        Ok(result)
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(result),
+        }
     }
 
     fn parse_octal(input: &[u8]) -> IResult<&[u8], u8> {

--- a/src/uucore/src/lib/features/diagnostics.rs
+++ b/src/uucore/src/lib/features/diagnostics.rs
@@ -98,6 +98,8 @@ pub struct Snapshot {
     verbatim: Vec<bool>,
     /// The arguments themselves, for [`Snapshot::index_of`].
     args: Vec<OsString>,
+    /// Index of the first operand: 1 when argument 0 is the program name.
+    first_operand: usize,
 }
 
 impl Snapshot {
@@ -112,6 +114,22 @@ impl Snapshot {
         for arg in args {
             snapshot.push(arg.as_ref().to_os_string());
         }
+        snapshot
+    }
+
+    /// Build a snapshot of an argument list whose first argument is the
+    /// program name.
+    ///
+    /// The program name is shown in the source line — the command reads as it
+    /// was typed — but it is never matched by any locator, so an operand that
+    /// happens to share its text cannot be mistaken for it.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The whole argument list, `argv[0]` included.
+    pub fn with_program<S: AsRef<OsStr>>(args: &[S]) -> Self {
+        let mut snapshot = Self::new(args);
+        snapshot.first_operand = args.len().min(1);
         snapshot
     }
 
@@ -140,6 +158,7 @@ impl Snapshot {
             spans: Vec::with_capacity(len),
             verbatim: Vec::with_capacity(len),
             args: Vec::with_capacity(len),
+            first_operand: 0,
         }
     }
 
@@ -185,10 +204,16 @@ impl Snapshot {
     ///
     /// # Returns
     ///
-    /// The index of the first argument equal to `arg`, or `None` if there is
-    /// none. A repeated value resolves to its first occurrence.
+    /// The index of the first operand equal to `arg`, or `None` if there is
+    /// none. A repeated value resolves to its first occurrence, and the
+    /// program name is never matched.
     pub fn index_of(&self, arg: &OsStr) -> Option<usize> {
-        self.args.iter().position(|candidate| candidate == arg)
+        self.args
+            .iter()
+            .enumerate()
+            .skip(self.first_operand)
+            .find(|(_, candidate)| *candidate == arg)
+            .map(|(index, _)| index)
     }
 
     /// Index of the first argument equal to `arg`, held as raw bytes.
@@ -204,6 +229,122 @@ impl Snapshot {
     /// platform.
     pub fn index_of_bytes(&self, arg: &[u8]) -> Option<usize> {
         self.index_of(&crate::os_str_from_bytes(arg).ok()?)
+    }
+
+    /// Index of the argument carrying `operand` as the value of an option.
+    ///
+    /// An option's value can be spelled many ways — `-k 2.3q`, `-k2.3q`,
+    /// `-rk2.3q`, `--key 2.3q`, `--key=2.3q` — and a text search cannot tell
+    /// the value apart from a file or another option that happens to end with
+    /// the same characters. This walks the arguments and matches only the
+    /// shapes an option value can actually take.
+    ///
+    /// # Arguments
+    ///
+    /// * `operand` - The value at fault, as the parser received it.
+    /// * `short` - The option's short name (`'k'` for `-k`), if it has one.
+    /// * `long` - The option's long name (`"key"` for `--key`), if it has one.
+    ///
+    /// # Returns
+    ///
+    /// The index of the first argument carrying `operand` — the argument
+    /// itself for a detached value, the combined argument for a glued one —
+    /// or `None` if no argument does. First match is the right one for
+    /// repeatable options, since parsing stops at the first failing value.
+    pub fn index_of_value(
+        &self,
+        operand: &str,
+        short: Option<char>,
+        long: Option<&str>,
+    ) -> Option<usize> {
+        // A run of short options the wanted one ends, as in `-r…k`.
+        let ends_cluster = |arg: &str| {
+            let Some(short) = short else { return false };
+            arg.strip_prefix('-').is_some_and(|cluster| {
+                cluster.ends_with(short) && cluster.chars().all(char::is_alphanumeric)
+            })
+        };
+        // `-k` or `--key`, or a cluster of short options ending in `-…k`.
+        let is_flag = |arg: &str| {
+            if let Some(rest) = arg.strip_prefix("--") {
+                return long == Some(rest);
+            }
+            ends_cluster(arg)
+        };
+        // `--key=<operand>`.
+        let is_attached_long = |arg: &str| {
+            let Some(long) = long else { return false };
+            arg.strip_prefix("--")
+                .and_then(|rest| rest.strip_prefix(long))
+                .and_then(|rest| rest.strip_prefix('='))
+                == Some(operand)
+        };
+        // `-k<operand>`, or glued to a cluster as `-r…k<operand>`. An empty
+        // value cannot be glued: `-k` alone is the flag, not the flag carrying
+        // nothing, and taking it for the value would point the caret at the
+        // option instead of the empty argument that follows it.
+        let is_attached_short = |arg: &str| {
+            if operand.is_empty() {
+                return false;
+            }
+            let Some(prefix) = arg
+                .len()
+                .checked_sub(operand.len())
+                .and_then(|end| arg.get(..end))
+            else {
+                return false;
+            };
+            arg.ends_with(operand) && ends_cluster(prefix)
+        };
+
+        let args = self.args.iter().map(|arg| arg.to_str()).enumerate();
+        let mut previous: Option<&str> = None;
+        for (index, arg) in args.skip(self.first_operand) {
+            let Some(arg) = arg else {
+                previous = None;
+                continue;
+            };
+            // Everything after a bare `--` is positional, never an option or
+            // its value.
+            if arg == "--" {
+                break;
+            }
+            if is_attached_long(arg)
+                || is_attached_short(arg)
+                || (arg == operand && previous.is_some_and(is_flag))
+            {
+                return Some(index);
+            }
+            previous = Some(arg);
+        }
+        None
+    }
+
+    /// Index of the `n`-th positional argument, counting from zero.
+    ///
+    /// An argument is taken as positional when it follows a bare `--` or does
+    /// not start with `-`; a lone `-` counts as positional. This only holds
+    /// for utilities none of whose options take a *separate* value — an
+    /// option's detached value would be miscounted as a positional.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Zero-based rank among the positional arguments.
+    ///
+    /// # Returns
+    ///
+    /// The index of that positional, or `None` if there are not that many.
+    pub fn index_of_positional(&self, n: usize) -> Option<usize> {
+        let mut options_ended = false;
+        let mut positionals = (self.first_operand..self.args.len()).filter(|&index| {
+            let bytes = self.args[index].as_encoded_bytes();
+            if !options_ended && bytes == b"--" {
+                options_ended = true;
+                return false;
+            }
+            options_ended || !bytes.starts_with(b"-") || bytes == b"-"
+        });
+        positionals.nth(n)
     }
 
     /// Byte range of the argument at `index`.
@@ -273,6 +414,59 @@ impl Snapshot {
         self.report(span, message, label, help)
     }
 
+    /// Write a report pointing at `range`, a byte range *inside* `operand`,
+    /// where `operand` is the tail (or the whole) of the argument at `index`.
+    ///
+    /// Like [`Snapshot::render_inside`], but the argument is named rather than
+    /// searched for: the caller has located it with [`Snapshot::index_of`],
+    /// [`Snapshot::index_of_value`] or [`Snapshot::index_of_positional`], or
+    /// tracked it itself, so an unrelated argument sharing the operand's text
+    /// cannot draw the caret away.
+    ///
+    /// Falls back to underlining the whole argument when the operand is not
+    /// its tail, or when quoting means an offset inside `operand` no longer
+    /// lines up with what is printed.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - Position of the argument carrying `operand`.
+    /// * `operand` - The operand at fault, as it was parsed.
+    /// * `range` - Byte range inside `operand` to point at. An empty range
+    ///   marks the character it starts at.
+    /// * `message` - The error message, already localized.
+    /// * `label` - Text placed under the caret, already localized.
+    /// * `help` - An optional line of advice, already localized.
+    ///
+    /// # Returns
+    ///
+    /// `false` if nothing could be rendered, in which case the caller should
+    /// fall back to a plain one-line message.
+    pub fn render_inside_at(
+        &self,
+        index: usize,
+        operand: &str,
+        range: Range<usize>,
+        message: &str,
+        label: &str,
+        help: Option<&str>,
+    ) -> bool {
+        let Some(span) = self.locate_at(index, operand, range) else {
+            return false;
+        };
+        self.report(span, message, label, help)
+    }
+
+    /// Byte range covered by `range` — an offset inside `operand` — within the
+    /// argument at `index`.
+    fn locate_at(&self, index: usize, operand: &str, range: Range<usize>) -> Option<Range<usize>> {
+        let arg = self.args.get(index)?;
+        let whole = self.spans[index].clone();
+        if !self.verbatim[index] || !arg.as_encoded_bytes().ends_with(operand.as_bytes()) {
+            return Some(whole);
+        }
+        Some(self.locate_tail(whole, operand, range))
+    }
+
     /// Byte range covered by `range` — an offset inside `operand` — once
     /// `operand` has been found among the arguments.
     fn locate(&self, operand: &str, range: Range<usize>) -> Option<Range<usize>> {
@@ -284,21 +478,26 @@ impl Snapshot {
         if !self.verbatim[index] {
             return Some(whole);
         }
+        Some(self.locate_tail(whole, operand, range))
+    }
 
+    /// Byte range covered by `range` — an offset inside `operand` — where
+    /// `operand` is the tail of the argument spanning `whole`.
+    fn locate_tail(&self, whole: Range<usize>, operand: &str, range: Range<usize>) -> Range<usize> {
         let base = whole.end - operand.len();
         // Offsets come from someone else's parser, so they are only trusted as
         // far as the text agrees with them.
         let start = self.floor_boundary(base + range.start.min(operand.len()));
         let end = self.floor_boundary(base + range.end.clamp(range.start, operand.len()));
         if start < end {
-            return Some(start..end);
+            return start..end;
         }
         // An empty range means something is missing rather than wrong; give the
         // caret the character it stopped at, or the whole argument if the
         // operand ran out.
         match self.text[start..].chars().next() {
-            Some(c) if start < whole.end => Some(start..start + c.len_utf8()),
-            _ => Some(whole),
+            Some(c) if start < whole.end => start..start + c.len_utf8(),
+            _ => whole,
         }
     }
 
@@ -471,5 +670,132 @@ mod tests {
         let snap = snapshot(&["dup", "-ef", "dup"]);
         assert_eq!(snap.index_of(OsStr::new("dup")), Some(0));
         assert_eq!(snap.index_of(OsStr::new("absent")), None);
+    }
+
+    #[test]
+    fn the_program_name_is_never_the_argument_looked_for() {
+        // `printf printf` prints its own name; the operand is the second one.
+        let snap = Snapshot::with_program(&["printf", "printf"]);
+        assert_eq!(snap.index_of(OsStr::new("printf")), Some(1));
+    }
+
+    #[test]
+    fn an_operand_starting_with_a_dash_is_still_found() {
+        // What `index_of_positional` cannot do: printf takes hyphen values, so
+        // `-%y` is the format rather than an option.
+        let snap = Snapshot::with_program(&["printf", "-%y", "arg"]);
+        assert_eq!(snap.index_of(OsStr::new("-%y")), Some(1));
+        assert_eq!(snap.index_of_positional(0), Some(2));
+    }
+
+    #[test]
+    fn a_value_is_found_in_every_spelling_of_its_option() {
+        for (args, expected) in [
+            (&["-k", "2.3q", "f"][..], 1),
+            (&["-k2.3q", "f"][..], 0),
+            (&["-rk2.3q", "f"][..], 0),
+            (&["--key", "2.3q", "f"][..], 1),
+            (&["--key=2.3q", "f"][..], 0),
+        ] {
+            let snap = snapshot(args);
+            assert_eq!(
+                snap.index_of_value("2.3q", Some('k'), Some("key")),
+                Some(expected),
+                "in {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_program_name_is_never_an_option_value() {
+        let snap = Snapshot::with_program(&["sort", "-k", "sort"]);
+        assert_eq!(snap.index_of_value("sort", Some('k'), Some("key")), Some(2));
+    }
+
+    #[test]
+    fn a_file_sharing_the_value_text_is_not_the_value() {
+        let snap = Snapshot::with_program(&["sort", "data.2.3q", "-k2.3q"]);
+        assert_eq!(snap.index_of_value("2.3q", Some('k'), Some("key")), Some(2));
+    }
+
+    #[test]
+    fn another_option_sharing_the_value_suffix_is_not_the_value() {
+        let snap = Snapshot::with_program(&["numfmt", "--delimiter=%q", "--format=%q", "1000"]);
+        assert_eq!(snap.index_of_value("%q", None, Some("format")), Some(2));
+    }
+
+    #[test]
+    fn a_long_option_is_not_mistaken_for_a_short_cluster() {
+        // `--am=644` ends in `m` + the operand, but it is not a `-m` cluster.
+        let snap = snapshot(&["--am=644", "-m644", "d"]);
+        assert_eq!(snap.index_of_value("644", Some('m'), Some("mode")), Some(1));
+    }
+
+    #[test]
+    fn a_value_after_a_double_dash_is_not_an_option_value() {
+        let snap = snapshot(&["--", "-k", "2.3q"]);
+        assert_eq!(snap.index_of_value("2.3q", Some('k'), Some("key")), None);
+    }
+
+    #[test]
+    fn an_empty_value_is_the_argument_after_the_flag() {
+        // `-k` ends in `k` and in the empty operand, but it is the flag.
+        let snap = snapshot(&["-k", "", "f"]);
+        assert_eq!(snap.index_of_value("", Some('k'), Some("key")), Some(1));
+    }
+
+    #[test]
+    fn a_missing_value_cannot_be_located() {
+        let snap = snapshot(&["-x", "unrelated"]);
+        assert_eq!(snap.index_of_value("2.3q", Some('k'), Some("key")), None);
+    }
+
+    #[test]
+    fn positionals_are_counted_across_options() {
+        let snap = Snapshot::with_program(&["tr", "-c", "ab", "tr"]);
+        assert_eq!(snap.index_of_positional(0), Some(2));
+        assert_eq!(snap.index_of_positional(1), Some(3));
+        assert_eq!(snap.index_of_positional(2), None);
+    }
+
+    #[test]
+    fn a_double_dash_ends_options_for_positionals() {
+        let snap = Snapshot::with_program(&["tr", "--", "-d", "x"]);
+        assert_eq!(snap.index_of_positional(0), Some(2));
+        assert_eq!(snap.index_of_positional(1), Some(3));
+    }
+
+    #[test]
+    fn a_lone_dash_is_a_positional() {
+        let snap = snapshot(&["-c", "-", "x"]);
+        assert_eq!(snap.index_of_positional(0), Some(1));
+    }
+
+    #[test]
+    fn locate_at_points_inside_the_named_argument() {
+        for (args, index) in [(&["-k2.3x", "f"][..], 0), (&["-k", "2.3x", "f"][..], 1)] {
+            let snap = snapshot(args);
+            let span = snap.locate_at(index, "2.3x", 3..4).unwrap();
+            assert_eq!(&snap.text[span], "x", "in {args:?}");
+        }
+    }
+
+    #[test]
+    fn locate_at_ignores_an_earlier_argument_with_the_same_tail() {
+        let snap = snapshot(&["data.2.3q", "-k2.3q"]);
+        let span = snap.locate_at(1, "2.3q", 3..4).unwrap();
+        assert_eq!(span, snap.spans[1].start + 5..snap.spans[1].start + 6);
+    }
+
+    #[test]
+    fn locate_at_underlines_the_whole_argument_when_the_operand_is_not_its_tail() {
+        let snap = snapshot(&["ab", "cd"]);
+        assert_eq!(snap.locate_at(1, "zz", 0..1), Some(3..5));
+    }
+
+    #[test]
+    fn locate_at_past_the_end_cannot_be_located() {
+        let snap = snapshot(&["ab"]);
+        assert_eq!(snap.locate_at(5, "ab", 0..1), None);
     }
 }

--- a/src/uucore/src/lib/features/diagnostics.rs
+++ b/src/uucore/src/lib/features/diagnostics.rs
@@ -216,21 +216,6 @@ impl Snapshot {
             .map(|(index, _)| index)
     }
 
-    /// Index of the first argument equal to `arg`, held as raw bytes.
-    ///
-    /// # Arguments
-    ///
-    /// * `arg` - The argument to look for, as raw bytes.
-    ///
-    /// # Returns
-    ///
-    /// The index of the first argument equal to `arg`, or `None` if there is
-    /// none or the bytes cannot be represented as an [`OsStr`] on this
-    /// platform.
-    pub fn index_of_bytes(&self, arg: &[u8]) -> Option<usize> {
-        self.index_of(&crate::os_str_from_bytes(arg).ok()?)
-    }
-
     /// Index of the argument carrying `operand` as the value of an option.
     ///
     /// An option's value can be spelled many ways — `-k 2.3q`, `-k2.3q`,
@@ -376,52 +361,18 @@ impl Snapshot {
         self.report(span, message, label, help)
     }
 
-    /// Write a report pointing at `range`, a byte range *inside* `operand`.
-    ///
-    /// For utilities whose operands are small languages of their own — a `sort`
-    /// key, a `chmod` mode — the argument as a whole is rarely the answer; the
-    /// caret belongs under the one character that broke the parse. `operand` is
-    /// looked up among the arguments, so a key passed as `-k2.3x` and one passed
-    /// as `-k 2.3x` both point at the same place.
-    ///
-    /// Falls back to underlining the whole argument when quoting means an offset
-    /// inside `operand` no longer lines up with what is printed.
-    ///
-    /// # Arguments
-    ///
-    /// * `operand` - The operand at fault, as it was parsed.
-    /// * `range` - Byte range inside `operand` to point at. An empty range
-    ///   marks the character it starts at.
-    /// * `message` - The error message, already localized.
-    /// * `label` - Text placed under the caret, already localized.
-    /// * `help` - An optional line of advice, already localized.
-    ///
-    /// # Returns
-    ///
-    /// `false` if nothing could be rendered, in which case the caller should
-    /// fall back to a plain one-line message.
-    pub fn render_inside(
-        &self,
-        operand: &str,
-        range: Range<usize>,
-        message: &str,
-        label: &str,
-        help: Option<&str>,
-    ) -> bool {
-        let Some(span) = self.locate(operand, range) else {
-            return false;
-        };
-        self.report(span, message, label, help)
-    }
-
     /// Write a report pointing at `range`, a byte range *inside* `operand`,
     /// where `operand` is the tail (or the whole) of the argument at `index`.
     ///
-    /// Like [`Snapshot::render_inside`], but the argument is named rather than
-    /// searched for: the caller has located it with [`Snapshot::index_of`],
-    /// [`Snapshot::index_of_value`] or [`Snapshot::index_of_positional`], or
-    /// tracked it itself, so an unrelated argument sharing the operand's text
-    /// cannot draw the caret away.
+    /// For utilities whose operands are small languages of their own — a `sort`
+    /// key, a `chmod` mode — the argument as a whole is rarely the answer; the
+    /// caret belongs under the one character that broke the parse. The argument
+    /// is named rather than searched for: the caller has located it with
+    /// [`Snapshot::index_of`], [`Snapshot::index_of_value`] or
+    /// [`Snapshot::index_of_positional`], or tracked it itself, so an unrelated
+    /// argument sharing the operand's text cannot draw the caret away. The
+    /// operand may sit at the tail of a larger argument, so a key passed as
+    /// `-k2.3x` and one passed as `-k 2.3x` both point at the same place.
     ///
     /// Falls back to underlining the whole argument when the operand is not
     /// its tail, or when quoting means an offset inside `operand` no longer
@@ -462,20 +413,6 @@ impl Snapshot {
         let arg = self.args.get(index)?;
         let whole = self.spans[index].clone();
         if !self.verbatim[index] || !arg.as_encoded_bytes().ends_with(operand.as_bytes()) {
-            return Some(whole);
-        }
-        Some(self.locate_tail(whole, operand, range))
-    }
-
-    /// Byte range covered by `range` — an offset inside `operand` — once
-    /// `operand` has been found among the arguments.
-    fn locate(&self, operand: &str, range: Range<usize>) -> Option<Range<usize>> {
-        let index = self
-            .args
-            .iter()
-            .position(|arg| arg.as_encoded_bytes().ends_with(operand.as_bytes()))?;
-        let whole = self.spans[index].clone();
-        if !self.verbatim[index] {
             return Some(whole);
         }
         Some(self.locate_tail(whole, operand, range))
@@ -604,15 +541,17 @@ mod tests {
         let snap = Snapshot::from_bytes(&[b"9", b"+", b"4"]);
         assert_eq!(snap.text, "9 + 4");
         assert_eq!(snap.index_of(OsStr::new("+")), Some(1));
-        assert_eq!(snap.index_of_bytes(b"4"), Some(2));
+        assert_eq!(snap.index_of(OsStr::new("4")), Some(2));
     }
 
     #[cfg(unix)]
     #[test]
     fn invalid_utf8_arguments_can_still_be_found() {
+        use std::os::unix::ffi::OsStrExt;
+
         let snap = Snapshot::from_bytes(&[&b"ba\x80d"[..], b"+", b"1"]);
         // A lossy conversion would not compare equal to the raw argument.
-        assert_eq!(snap.index_of_bytes(b"ba\x80d"), Some(0));
+        assert_eq!(snap.index_of(OsStr::from_bytes(b"ba\x80d")), Some(0));
     }
 
     #[test]
@@ -622,46 +561,31 @@ mod tests {
     }
 
     #[test]
-    fn a_range_inside_an_operand_is_found_whether_it_is_glued_to_the_option() {
-        for args in [&["-k2.3x", "f"][..], &["-k", "2.3x", "f"][..]] {
-            let snap = snapshot(args);
-            let span = snap.locate("2.3x", 3..4).unwrap();
-            assert_eq!(&snap.text[span], "x");
-        }
-    }
-
-    #[test]
     fn an_empty_range_still_gets_one_character() {
         let snap = snapshot(&["u+rwx,g"]);
-        let span = snap.locate("u+rwx,g", 6..6).unwrap();
+        let span = snap.locate_at(0, "u+rwx,g", 6..6).unwrap();
         assert_eq!(&snap.text[span], "g");
     }
 
     #[test]
     fn a_range_at_the_end_of_an_operand_falls_back_to_the_argument() {
         let snap = snapshot(&["-k1,"]);
-        assert_eq!(snap.locate("1,", 2..2), Some(0..4));
+        assert_eq!(snap.locate_at(0, "1,", 2..2), Some(0..4));
     }
 
     #[test]
     fn a_quoted_operand_falls_back_to_the_whole_argument() {
         let snap = snapshot(&["a b", "-k1"]);
         // Offsets inside `a b` would land on the quotes that were added.
-        assert_eq!(snap.locate("a b", 1..2), Some(0..5));
-        assert_eq!(&snap.text[snap.locate("a b", 1..2).unwrap()], "'a b'");
-    }
-
-    #[test]
-    fn an_operand_that_is_not_an_argument_cannot_be_located() {
-        let snap = snapshot(&["-k1"]);
-        assert_eq!(snap.locate("2.3", 0..1), None);
+        assert_eq!(snap.locate_at(0, "a b", 1..2), Some(0..5));
+        assert_eq!(&snap.text[snap.locate_at(0, "a b", 1..2).unwrap()], "'a b'");
     }
 
     #[test]
     fn offsets_inside_a_multibyte_operand_stay_on_character_boundaries() {
         let snap = snapshot(&["--from=éx"]);
         // Mid-character offset, walked back rather than slicing a code point.
-        let span = snap.locate("éx", 1..3).unwrap();
+        let span = snap.locate_at(0, "éx", 1..3).unwrap();
         assert_eq!(&snap.text[span], "éx");
     }
 

--- a/src/uucore/src/lib/features/mode.rs
+++ b/src/uucore/src/lib/features/mode.rs
@@ -56,12 +56,14 @@ impl ModeError {
         }
     }
 
-    /// Render this error against `args`, with a caret under the part of the
-    /// mode that is at fault.
+    /// Render this error against `args`, where the mode is the value of the
+    /// `-m`/`--mode` option.
     ///
     /// # Arguments
     ///
-    /// * `args` - The argument list the mode came from.
+    /// * `args` - The argument list the mode came from, without the program
+    ///   name — as [`crate::diagnostics::operands`] returns it, since the other
+    ///   renderer here takes a positional index into the same list.
     /// * `mode` - The whole mode operand.
     /// * `clause_start` - Where the clause that failed begins inside `mode`,
     ///   since a mode is parsed one comma-separated clause at a time.
@@ -71,9 +73,58 @@ impl ModeError {
     ///
     /// `false` when the mode cannot be found among the arguments, in which case
     /// the caller should fall back to the plain one-line message.
-    pub fn render(
+    pub fn render_mode_value(
         &self,
         args: &[std::ffi::OsString],
+        mode: &str,
+        clause_start: usize,
+        message: &str,
+    ) -> bool {
+        let snapshot = crate::diagnostics::Snapshot::new(args);
+        let Some(index) = snapshot.index_of_value(mode, Some('m'), Some("mode")) else {
+            return false;
+        };
+        self.render_snapshot(&snapshot, index, mode, clause_start, message)
+    }
+
+    /// Render this error against `args`, with the argument carrying the mode
+    /// already located by the caller.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The argument list the mode came from, without the program
+    ///   name.
+    /// * `index` - Position of the argument carrying the mode inside `args`.
+    /// * `mode` - The mode as it appears in that argument.
+    /// * `clause_start` - Where the clause that failed begins inside `mode`,
+    ///   since a mode is parsed one comma-separated clause at a time.
+    /// * `message` - The headline, already localized.
+    ///
+    /// # Returns
+    ///
+    /// `false` when nothing could be rendered, in which case the caller should
+    /// fall back to the plain one-line message.
+    pub fn render_at(
+        &self,
+        args: &[std::ffi::OsString],
+        index: usize,
+        mode: &str,
+        clause_start: usize,
+        message: &str,
+    ) -> bool {
+        self.render_snapshot(
+            &crate::diagnostics::Snapshot::new(args),
+            index,
+            mode,
+            clause_start,
+            message,
+        )
+    }
+
+    fn render_snapshot(
+        &self,
+        snapshot: &crate::diagnostics::Snapshot,
+        index: usize,
         mode: &str,
         clause_start: usize,
         message: &str,
@@ -84,7 +135,8 @@ impl ModeError {
             ModeErrorKind::InvalidNumber => "mode-diag-label-invalid-number",
         };
 
-        crate::diagnostics::Snapshot::new(args).render_inside(
+        snapshot.render_inside_at(
+            index,
             mode,
             clause_start + self.span.start..clause_start + self.span.end,
             message,

--- a/tests/by-util/test_chmod.rs
+++ b/tests/by-util/test_chmod.rs
@@ -1693,14 +1693,6 @@ fn test_chmod_symlink_two_links_same_dir() {
 
 mod diagnostics {
     use super::*;
-    /// Column of the caret in a report header such as `[ chmod:1:5 ]`.
-    #[cfg(unix)]
-    fn caret_column(stderr: &str) -> Option<usize> {
-        let header = stderr.lines().find(|line| line.contains("chmod:1:"))?;
-        let column = header.rsplit(':').next()?;
-        column.trim_end_matches(" ]").parse().ok()
-    }
-
     #[cfg(unix)]
     #[test]
     fn test_snippet_points_at_the_bad_operator() {
@@ -1715,7 +1707,7 @@ mod diagnostics {
 
         assert!(stderr.contains("invalid operator"), "{stderr}");
         // The caret lands on `?`, the fifth character of the mode.
-        assert_eq!(caret_column(stderr), Some(5), "{stderr}");
+        assert_eq!(result.caret_column(), Some(5), "{stderr}");
     }
 
     #[cfg(unix)]
@@ -1732,7 +1724,7 @@ mod diagnostics {
 
         // Clauses are parsed one at a time, but the caret is placed in the
         // whole mode: `!` is its seventh character.
-        assert_eq!(caret_column(stderr), Some(7), "{stderr}");
+        assert_eq!(result.caret_column(), Some(7), "{stderr}");
     }
 
     #[cfg(unix)]
@@ -1748,7 +1740,7 @@ mod diagnostics {
         let stderr = result.stderr_str();
 
         assert!(stderr.contains("invalid mode"), "{stderr}");
-        assert_eq!(caret_column(stderr), Some(1), "{stderr}");
+        assert_eq!(result.caret_column(), Some(1), "{stderr}");
     }
 
     #[cfg(unix)]
@@ -1778,27 +1770,45 @@ mod diagnostics {
         let stderr = result.stderr_str();
 
         assert!(stderr.contains("invalid operator"), "{stderr}");
-        assert_eq!(caret_column(stderr), Some(4), "{stderr}");
+        assert_eq!(result.caret_column(), Some(4), "{stderr}");
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_plain_message_when_negative_modes_are_joined() {
+    fn test_snippet_points_into_the_right_negative_mode() {
         let (at, mut ucmd) = at_and_ucmd!();
         at.touch("probe");
 
-        // Several negative modes are joined into one mode that matches no
-        // single argument, so there is nothing to point at.
+        // Several negative modes are joined into one mode string before being
+        // parsed, but the caret still lands on `%` inside the one argument
+        // that carries the bad clause.
         let result = ucmd
             .terminal_sim_stderr()
             .args(&["-w", "-r%x", "probe"])
             .fails_with_code(1);
+        let stderr = result.stderr_str();
 
-        // The pseudo-terminal turns the newline into CRLF, hence the trim.
-        assert_eq!(
-            result.stderr_str().trim_end(),
-            "chmod: invalid operator (expected +, -, or =, but found %)"
-        );
+        assert!(stderr.contains("invalid operator"), "{stderr}");
+        // Column 6 of `-w -r%x probe` is the `%`.
+        assert_eq!(result.caret_column(), Some(6), "{stderr}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_mode_not_a_file_with_the_same_name() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("g+rw?x");
+
+        // The file is named exactly like the mode; the caret belongs to the
+        // mode operand, the first of the two.
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["g+rw?x", "g+rw?x"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        assert!(stderr.contains("invalid operator"), "{stderr}");
+        assert_eq!(result.caret_column(), Some(5), "{stderr}");
     }
 
     #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -2157,6 +2157,47 @@ expr: syntax error: expecting ')' after '7'
             .stderr_contains("for more information");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_operand_that_failed_not_its_twin() {
+        // Both operands read `a`, but only the right-hand one of `+` failed
+        // arithmetic; the caret must not drift to the first occurrence, a
+        // perfectly valid string operand of `=`.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["a", "=", "2", "+", "a"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+expr: non-integer argument
+   ╭─[ expr:1:9 ]
+   │
+ 1 │ a = 2 + a
+   │         ┬
+   │         ╰── this is not an integer
+   │
+   │ Help: arithmetic operators need integers; use = or != to compare strings instead
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_computed_operand_stays_plain() {
+        // The failing operand is the result of `substr`, not an argument, so
+        // there is nothing to point at and the plain message is kept.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["substr", "abc", "1", "2", "+", "1"])
+            .fails_with_code(2);
+        assert_eq!(
+            result.stderr_str().replace("\r\n", "\n"),
+            "expr: non-integer argument\n"
+        );
+    }
+
     #[test]
     fn test_plain_message_is_the_default() {
         // The test harness pipes stderr, so the report must not appear.

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -3075,13 +3075,6 @@ fn test_install_backup_custom_suffix_refuses() {
 #[cfg(unix)]
 mod diagnostics {
     use super::*;
-    /// Column of the caret in a report header such as `[ install:1:8 ]`.
-    fn caret_column(stderr: &str) -> Option<usize> {
-        let header = stderr.lines().find(|line| line.contains("install:1:"))?;
-        let column = header.rsplit(':').next()?;
-        column.trim_end_matches(" ]").parse().ok()
-    }
-
     #[test]
     fn test_snippet_points_at_the_bad_operator() {
         let (at, mut ucmd) = at_and_ucmd!();
@@ -3095,7 +3088,7 @@ mod diagnostics {
 
         assert!(stderr.contains("invalid operator"), "{stderr}");
         // The caret lands on `?`: three columns of `-m ` and four of mode.
-        assert_eq!(caret_column(stderr), Some(8), "{stderr}");
+        assert_eq!(result.caret_column(), Some(8), "{stderr}");
     }
 
     #[test]

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -1095,13 +1095,6 @@ fn test_mkdir_inside_inexistent_dir() {
 #[cfg(unix)]
 mod diagnostics {
     use super::*;
-    /// Column of the caret in a report header such as `[ mkdir:1:8 ]`.
-    fn caret_column(stderr: &str) -> Option<usize> {
-        let header = stderr.lines().find(|line| line.contains("mkdir:1:"))?;
-        let column = header.rsplit(':').next()?;
-        column.trim_end_matches(" ]").parse().ok()
-    }
-
     #[test]
     fn test_snippet_points_at_the_bad_operator() {
         let result = new_ucmd!()
@@ -1112,7 +1105,7 @@ mod diagnostics {
 
         assert!(stderr.contains("invalid operator"), "{stderr}");
         // The caret lands on `?`: three columns of `-m ` and four of mode.
-        assert_eq!(caret_column(stderr), Some(8), "{stderr}");
+        assert_eq!(result.caret_column(), Some(8), "{stderr}");
     }
 
     #[test]
@@ -1125,7 +1118,7 @@ mod diagnostics {
 
         // Clauses are parsed one at a time, but the caret is placed in the
         // whole mode: `!` is its sixth character, after `-m `.
-        assert_eq!(caret_column(stderr), Some(9), "{stderr}");
+        assert_eq!(result.caret_column(), Some(9), "{stderr}");
     }
 
     #[test]

--- a/tests/by-util/test_mkfifo.rs
+++ b/tests/by-util/test_mkfifo.rs
@@ -254,13 +254,6 @@ fn test_mkfifo_permission_unchanged_when_failed() {
 #[cfg(unix)]
 mod diagnostics {
     use super::*;
-    /// Column of the caret in a report header such as `[ mkfifo:1:7 ]`.
-    fn caret_column(stderr: &str) -> Option<usize> {
-        let header = stderr.lines().find(|line| line.contains("mkfifo:1:"))?;
-        let column = header.rsplit(':').next()?;
-        column.trim_end_matches(" ]").parse().ok()
-    }
-
     #[test]
     fn test_snippet_points_at_the_bad_operator() {
         let result = new_ucmd!()
@@ -271,7 +264,7 @@ mod diagnostics {
 
         assert!(stderr.contains("invalid mode"), "{stderr}");
         // The caret lands on `?`: three columns of `-m ` and four of mode.
-        assert_eq!(caret_column(stderr), Some(7), "{stderr}");
+        assert_eq!(result.caret_column(), Some(7), "{stderr}");
     }
 
     #[test]

--- a/tests/by-util/test_mknod.rs
+++ b/tests/by-util/test_mknod.rs
@@ -275,13 +275,6 @@ fn test_mknod_selinux_invalid_cleanup() {
 #[cfg(unix)]
 mod diagnostics {
     use super::*;
-    /// Column of the caret in a report header such as `[ mknod:1:8 ]`.
-    fn caret_column(stderr: &str) -> Option<usize> {
-        let header = stderr.lines().find(|line| line.contains("mknod:1:"))?;
-        let column = header.rsplit(':').next()?;
-        column.trim_end_matches(" ]").parse().ok()
-    }
-
     #[test]
     fn test_snippet_points_at_the_bad_operator() {
         let result = new_ucmd!()
@@ -292,7 +285,7 @@ mod diagnostics {
 
         assert!(stderr.contains("invalid mode"), "{stderr}");
         // The caret lands on `?`: three columns of `-m ` and four of mode.
-        assert_eq!(caret_column(stderr), Some(8), "{stderr}");
+        assert_eq!(result.caret_column(), Some(8), "{stderr}");
     }
 
     #[test]

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1815,6 +1815,31 @@ numfmt: format 'qwe' has no % directive
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_ignores_another_option_with_the_same_value() {
+        // --delimiter carries the same text as --format; the caret must land
+        // inside --format, not the option that merely shares its suffix.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--delimiter=%q", "--format=%q", "1000"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
+   ╭─[ numfmt:1:33 ]
+   │
+ 1 │ numfmt --delimiter=%q --format=%q 1000
+   │                                 ┬
+   │                                 ╰── not allowed in a directive
+   │
+   │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in \"%'-10.2f\"
+───╯"
+        );
+    }
+
     #[test]
     fn test_plain_message_when_stderr_is_a_pipe() {
         // The test harness pipes stderr, so the report must not appear.

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -3311,6 +3311,59 @@ sort: options '-hV' are incompatible
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_ignores_a_file_that_ends_like_the_key() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("data.2.3q");
+
+        // The input file's name ends with the key's text; the caret must stay
+        // on the `-k` operand, not drift onto the file.
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["data.2.3q", "-k2.3q"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+sort: stray character in field spec: invalid field specification '2.3q'
+   ╭─[ sort:1:21 ]
+   │
+ 1 │ sort data.2.3q -k2.3q
+   │                     ┬
+   │                     ╰── not part of a key
+   │
+   │ Help: a key is FIELD[.CHAR][OPTS][,FIELD[.CHAR][OPTS]], as in -k2.3,4nr
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_ignores_the_program_name_as_a_key() {
+        // A key spelled exactly like the program name must not pull the caret
+        // onto `sort` itself at the start of the line.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-k", "sort", "/dev/null"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+sort: invalid number at field start: invalid count at start of 'sort'
+   ╭─[ sort:1:9 ]
+   │
+ 1 │ sort -k sort /dev/null
+   │         ──┬─
+   │           ╰─── expected a number here
+   │
+   │ Help: a key is FIELD[.CHAR][OPTS][,FIELD[.CHAR][OPTS]], as in -k2.3,4nr
+───╯"
+        );
+    }
+
     #[test]
     fn test_plain_message_when_stderr_is_not_a_terminal() {
         // The test harness pipes stderr, so the report must not appear.

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1794,6 +1794,30 @@ tr: we: equivalence class operand must be a single character
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_ignores_the_program_name_as_a_set() {
+        // The second set reads exactly like the program name; the caret must
+        // stay on the operand, not drift onto `tr` at the start of the line.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-c", "[:alpha:]", "tr"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+tr: when translating with complemented character classes,
+string2 must map all characters in the domain to one
+   ╭─[ tr:1:17 ]
+   │
+ 1 │ tr -c [:alpha:] tr
+   │                 ─┬
+   │                  ╰── only one character may be complemented to
+───╯"
+        );
+    }
+
     #[test]
     fn test_plain_message_when_stderr_is_a_pipe() {
         // The test harness pipes stderr, so the report must not appear.

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -1584,6 +1584,22 @@ fn test_multibyte_octal_sequence() {
 }
 
 #[test]
+fn test_octal_warning_still_fires_after_a_bad_sequence() {
+    // The set fails on the character class, but the ambiguous octal escape
+    // after it must still be warned about: the whole set is parsed even when
+    // an earlier sequence is bad.
+    // No `pipe_in`: the sets are rejected before stdin is ever read, so
+    // handing the child input only races its exit.
+    new_ucmd!()
+        .args(&[r"[:foo:]\400", "y"])
+        .fails()
+        .stderr_is(
+            "tr: warning: the ambiguous octal escape \\400 is being interpreted as the 2-byte sequence \\040, 0\n\
+             tr: invalid character class 'foo'\n",
+        );
+}
+
+#[test]
 fn test_backwards_range() {
     new_ucmd!()
         .args(&["-d", r"\046-\048"])

--- a/tests/uutests/src/lib/util.rs
+++ b/tests/uutests/src/lib/util.rs
@@ -413,6 +413,28 @@ impl CmdResult {
             .join("\n")
     }
 
+    /// Returns the one-based column a caret diagnostic points at.
+    ///
+    /// A report opens with a header naming the utility and the position it
+    /// points at — `╭─[ chmod:1:5 ]` — which is the only place the column is
+    /// written out; the caret row itself is padded and drawn with box
+    /// characters. Asserting on the column keeps a test to the one thing it
+    /// cares about, where matching the block verbatim would break on every
+    /// wording change.
+    ///
+    /// # Returns
+    ///
+    /// `None` when stderr carries no such header: the plain one-line message
+    /// was printed, or the diagnostic pointed at another line.
+    pub fn caret_column(&self) -> Option<usize> {
+        let header = format!("{}:1:", self.util_name.as_ref()?);
+        let line = self
+            .stderr_str()
+            .lines()
+            .find(|line| line.contains(&header))?;
+        line.rsplit(':').next()?.trim_end_matches(" ]").parse().ok()
+    }
+
     /// Returns the program's standard error as a string slice, automatically handling invalid utf8
     pub fn stderr_str_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(&self.stderr)


### PR DESCRIPTION
The first carets found their operand by searching the rendered argument line for
its text, which cannot tell a value apart from a file or another option that
happens to end with the same characters. This replaces that with a locator that
walks the arguments and matches only the shapes an option value can take —
`-k 2.3q`, `-k2.3q`, `-rk2.3q`, `--key 2.3q`, `--key=2.3q` — then moves each
utility over and drops the text search.

- uucore: locate diagnostic operands by argument, not by text
- uucore, chmod, mkdir, mkfifo, mknod, install: anchor mode carets to the mode argument
- sort: anchor -k carets to the key argument
- sort: make FieldSelector::new infallible
- tr: anchor set carets to the set operand
- tr: keep parsing a bad set so octal-escape warnings still fire
- numfmt: return a structured error from parse_options
- expr: remember which argument each leaf came from
- uucore: drop the text-search diagnostic locator

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
