### PR TITLE
diagnostics: localize the format, checksum and advice-line strings

### DIFF
--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -95,3 +95,15 @@ mode-error-invalid-operator = invalid operator (expected +, -, or =, but found {
 mode-diag-label-missing-operator = this clause says who, but not what to change
 mode-diag-label-invalid-number = not an octal mode
 mode-diag-help-syntax = a mode is either octal, as in 644, or clauses such as u+rwx,go-w
+# Format string parsing messages (printf, seq, env, ...)
+format-error-invalid-spec = %{ $spec }: invalid conversion specification
+format-error-too-many-specs = format '{ $format }' has too many % directives
+format-error-no-spec = format '{ $format }' has no % directive
+format-error-ends-with-percent = format { $format } ends in %
+format-error-invalid-precision = invalid precision: '{ $precision }'
+format-error-wrong-spec-type = wrong % directive type was given
+format-error-write = write error: { $error }
+format-error-no-more-arguments = no more arguments
+format-error-invalid-argument = invalid argument
+format-error-missing-hex = missing hexadecimal number in escape
+format-error-invalid-universal-character = invalid universal character name \{ $escape }{ $digits }

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -107,3 +107,6 @@ format-error-no-more-arguments = no more arguments
 format-error-invalid-argument = invalid argument
 format-error-missing-hex = missing hexadecimal number in escape
 format-error-invalid-universal-character = invalid universal character name \{ $escape }{ $digits }
+
+# The word ariadne heads the advice line of a caret report with
+diagnostics-help-label = Help

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -110,3 +110,23 @@ format-error-invalid-universal-character = invalid universal character name \{ $
 
 # The word ariadne heads the advice line of a caret report with
 diagnostics-help-label = Help
+
+# Checksum errors (cksum, md5sum, sha*sum, b2sum)
+checksum-error-raw-multiple-files = the --raw option is not supported with multiple files
+checksum-error-check-only-flag = the --{ $flag } option is meaningful only when verifying checksums
+checksum-error-length-required = --length required for { $algorithm }
+checksum-error-invalid-length = invalid length: { $length }
+checksum-error-length-too-big-for-blake = maximum digest length for { $algorithm } is 512 bits
+checksum-error-length-not-multiple-of-8 = length is not a multiple of 8
+checksum-error-invalid-length-for-sha = digest length for { $algorithm } must be 224, 256, 384, or 512
+checksum-error-length-required-for-sha = --algorithm={ $algorithm } requires specifying --length 224, 256, 384, or 512
+checksum-error-length-only-for-blake2b-sha2-sha3 = --length is only supported with --algorithm blake2b, sha2, or sha3
+checksum-error-binary-text-conflict = the --binary and --text options are meaningless when verifying checksums
+checksum-error-text-without-untagged = --text mode is only supported with --untagged
+checksum-error-tag-check = the --tag option is meaningless when verifying checksums
+checksum-error-text-after-tag = --tag does not support --text mode
+checksum-error-algorithm-not-supported-with-check = --check is not supported with --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
+checksum-error-combine-multiple-algorithms = You cannot combine multiple hash algorithms!
+checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
+    Use --help for more information.
+checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -104,3 +104,23 @@ format-error-invalid-universal-character = nom de caractère universel invalide 
 
 # Le mot en tête de la ligne de conseil d'un rapport avec caret
 diagnostics-help-label = Aide{" "}
+
+# Erreurs de somme de contrôle (cksum, md5sum, sha*sum, b2sum)
+checksum-error-raw-multiple-files = l'option --raw n'est pas prise en charge avec plusieurs fichiers
+checksum-error-check-only-flag = l'option --{ $flag } n'a de sens que lors de la vérification de sommes de contrôle
+checksum-error-length-required = --length est requis pour { $algorithm }
+checksum-error-invalid-length = longueur invalide : { $length }
+checksum-error-length-too-big-for-blake = la longueur maximale d'empreinte pour { $algorithm } est de 512 bits
+checksum-error-length-not-multiple-of-8 = la longueur n'est pas un multiple de 8
+checksum-error-invalid-length-for-sha = la longueur d'empreinte pour { $algorithm } doit être 224, 256, 384 ou 512
+checksum-error-length-required-for-sha = --algorithm={ $algorithm } nécessite de préciser --length 224, 256, 384 ou 512
+checksum-error-length-only-for-blake2b-sha2-sha3 = --length n'est pris en charge qu'avec --algorithm blake2b, sha2 ou sha3
+checksum-error-binary-text-conflict = les options --binary et --text n'ont pas de sens lors de la vérification de sommes de contrôle
+checksum-error-text-without-untagged = le mode --text n'est pris en charge qu'avec --untagged
+checksum-error-tag-check = l'option --tag n'a pas de sens lors de la vérification de sommes de contrôle
+checksum-error-text-after-tag = --tag ne prend pas en charge le mode --text
+checksum-error-algorithm-not-supported-with-check = --check n'est pas pris en charge avec --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
+checksum-error-combine-multiple-algorithms = Vous ne pouvez pas combiner plusieurs algorithmes de hachage !
+checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire.
+    Utilisez --help pour plus d'informations.
+checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -89,3 +89,15 @@ mode-error-invalid-operator = opérateur invalide (+, - ou = attendu, mais { $op
 mode-diag-label-missing-operator = cette clause indique qui, mais pas quoi changer
 mode-diag-label-invalid-number = n'est pas un mode octal
 mode-diag-help-syntax = un mode est soit octal, comme 644, soit des clauses comme u+rwx,go-w
+# Messages d'analyse des chaînes de format (printf, seq, env, ...)
+format-error-invalid-spec = %{ $spec } : spécification de conversion invalide
+format-error-too-many-specs = le format '{ $format }' a trop de directives %
+format-error-no-spec = le format '{ $format }' n'a pas de directive %
+format-error-ends-with-percent = le format { $format } se termine par %
+format-error-invalid-precision = précision invalide : '{ $precision }'
+format-error-wrong-spec-type = type de directive % incorrect
+format-error-write = erreur d'écriture : { $error }
+format-error-no-more-arguments = plus d'arguments
+format-error-invalid-argument = argument invalide
+format-error-missing-hex = nombre hexadécimal manquant dans l'échappement
+format-error-invalid-universal-character = nom de caractère universel invalide \{ $escape }{ $digits }

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -101,3 +101,6 @@ format-error-no-more-arguments = plus d'arguments
 format-error-invalid-argument = argument invalide
 format-error-missing-hex = nombre hexadécimal manquant dans l'échappement
 format-error-invalid-universal-character = nom de caractère universel invalide \{ $escape }{ $digits }
+
+# Le mot en tête de la ligne de conseil d'un rapport avec caret
+diagnostics-help-label = Aide{" "}

--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -17,7 +17,7 @@ use crate::sum::{
     Blake2b, Blake3, Bsd, CRC32B, Crc, Digest, DigestOutput, DigestWriter, Md5, Sha1, Sha3_224,
     Sha3_256, Sha3_384, Sha3_512, Sha224, Sha256, Sha384, Sha512, Shake128, Shake256, Sm3, SysV,
 };
-use crate::{show_error, translate};
+use crate::{show_error, translate, translate_text};
 
 pub mod compute;
 pub mod validate;
@@ -439,43 +439,43 @@ impl SizedAlgoKind {
 
 #[derive(Debug, Error)]
 pub enum ChecksumError {
-    #[error("the --raw option is not supported with multiple files")]
+    #[error("{}", translate!("checksum-error-raw-multiple-files"))]
     RawMultipleFiles,
 
-    #[error("the --{0} option is meaningful only when verifying checksums")]
+    #[error("{}", translate_text!("checksum-error-check-only-flag", "flag" => _0))]
     CheckOnlyFlag(String),
 
     // --length sanitization errors
-    #[error("--length required for {}", .0.quote())]
+    #[error("{}", translate_text!("checksum-error-length-required", "algorithm" => _0.quote()))]
     LengthRequired(String),
-    #[error("invalid length: {}", .0.quote())]
+    #[error("{}", translate_text!("checksum-error-invalid-length", "length" => _0.quote()))]
     InvalidLength(String),
-    #[error("maximum digest length for {} is 512 bits", .0.quote())]
+    #[error("{}", translate_text!("checksum-error-length-too-big-for-blake", "algorithm" => _0.quote()))]
     LengthTooBigForBlake(String),
-    #[error("length is not a multiple of 8")]
+    #[error("{}", translate!("checksum-error-length-not-multiple-of-8"))]
     LengthNotMultipleOf8,
-    #[error("digest length for {} must be 224, 256, 384, or 512", .0.quote())]
+    #[error("{}", translate_text!("checksum-error-invalid-length-for-sha", "algorithm" => _0.quote()))]
     InvalidLengthForSha(String),
-    #[error("--algorithm={0} requires specifying --length 224, 256, 384, or 512")]
+    #[error("{}", translate_text!("checksum-error-length-required-for-sha", "algorithm" => _0))]
     LengthRequiredForSha(String),
-    #[error("--length is only supported with --algorithm blake2b, sha2, or sha3")]
+    #[error("{}", translate!("checksum-error-length-only-for-blake2b-sha2-sha3"))]
     LengthOnlyForBlake2bSha2Sha3,
 
-    #[error("the --binary and --text options are meaningless when verifying checksums")]
+    #[error("{}", translate!("checksum-error-binary-text-conflict"))]
     BinaryTextConflict,
-    #[error("--text mode is only supported with --untagged")]
+    #[error("{}", translate!("checksum-error-text-without-untagged"))]
     TextWithoutUntagged,
-    #[error("the --tag option is meaningless when verifying checksums")]
+    #[error("{}", translate!("checksum-error-tag-check"))]
     TagCheck,
-    #[error("--tag does not support --text mode")]
+    #[error("{}", translate!("checksum-error-text-after-tag"))]
     TextAfterTag,
-    #[error("--check is not supported with --algorithm={{bsd,sysv,crc,crc32b}}")]
+    #[error("{}", translate!("checksum-error-algorithm-not-supported-with-check"))]
     AlgorithmNotSupportedWithCheck,
-    #[error("You cannot combine multiple hash algorithms!")]
+    #[error("{}", translate!("checksum-error-combine-multiple-algorithms"))]
     CombineMultipleAlgorithms,
-    #[error("Needs an algorithm to hash with.\nUse --help for more information.")]
+    #[error("{}", translate!("checksum-error-need-algorithm-to-hash"))]
     NeedAlgorithmToHash,
-    #[error("unknown algorithm: {0}: clap should have prevented this case")]
+    #[error("{}", translate_text!("checksum-error-unknown-algorithm", "algorithm" => _0))]
     UnknownAlgorithm(String),
     #[error("{}: {}", translate!("common-write-error"), strip_errno(.0))]
     Write(io::Error),

--- a/src/uucore/src/lib/features/diagnostics.rs
+++ b/src/uucore/src/lib/features/diagnostics.rs
@@ -33,7 +33,7 @@
 //! ───╯
 //! ```
 
-// spell-checker:ignore étage
+// spell-checker:ignore étage replacen
 
 use std::borrow::Cow;
 use std::env;
@@ -45,6 +45,7 @@ use std::ops::Range;
 use ariadne::{CharSet, Color, Config, IndexType, Label, Report, ReportKind, Source};
 
 use crate::display::Quotable;
+use crate::translate;
 
 /// Whether errors should be rendered against their argument list.
 ///
@@ -462,6 +463,41 @@ impl Snapshot {
             .unwrap_or(0)
     }
 
+    /// Translate the word ariadne heads the advice line with.
+    ///
+    /// The advice itself arrives already localized, but ariadne writes its own
+    /// `Help` in front of it, so a translated report would end on a line half
+    /// in English. The word is replaced where ariadne wrote it — on the first
+    /// row below the label, which is the only place it can be — rather than
+    /// everywhere, since an argument the report echoes is free to contain it
+    /// too.
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - The rendered report, its headline already dropped.
+    /// * `has_help` - Whether an advice line was asked for at all.
+    fn localize_help(body: &str, has_help: bool) -> Cow<'_, str> {
+        let localized = translate!("diagnostics-help-label");
+        if !has_help || localized == "Help" {
+            return Cow::Borrowed(body);
+        }
+        let mut lines: Vec<Cow<'_, str>> = body.lines().map(Cow::Borrowed).collect();
+        // Rows 0..=2 are the header, the gutter and the source line; rows 3
+        // and 4 belong to the label.
+        let Some(row) = lines
+            .iter()
+            .skip(5)
+            .position(|line| line.contains("Help"))
+            .map(|row| row + 5)
+        else {
+            // The report is not shaped the way we assumed; hand it back
+            // untouched rather than rebuilding it around a row we never found.
+            return Cow::Borrowed(body);
+        };
+        lines[row] = Cow::Owned(lines[row].replacen("Help", &localized, 1));
+        Cow::Owned(lines.join("\n") + "\n")
+    }
+
     /// Whether `row` is one of the two rows a single label occupies.
     ///
     /// A report with one label on one source line always has the same shape,
@@ -473,15 +509,25 @@ impl Snapshot {
         (SOURCE + 1..=SOURCE + 2).contains(&row)
     }
 
-    fn report(
+    /// The report ariadne draws for `span`, with its headline dropped.
+    ///
+    /// Both [`Self::localize_help`] and [`Self::is_label_row`] count on the
+    /// rows of what this returns, so it is a step of its own: a test can render
+    /// a known report and check the shape those two assume, rather than only
+    /// the finished output.
+    ///
+    /// # Returns
+    ///
+    /// `None` when ariadne could not render, in which case the caller falls
+    /// back to the plain one-line message.
+    fn render_body(
         &self,
         span: Range<usize>,
-        message: &str,
         label: Option<&str>,
         help: Option<&str>,
-    ) -> bool {
+        color: bool,
+    ) -> Option<String> {
         let id = crate::util_name();
-        let color = env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal();
         let config = Config::default()
             // ariadne counts characters unless told otherwise, which would drift
             // on multi-byte arguments.
@@ -508,14 +554,35 @@ impl Snapshot {
             .write((id, Source::from(self.text.as_str())), &mut rendered)
             .is_err()
         {
-            return false;
+            return None;
         }
 
         // ariadne heads every report with its own line — a hardcoded, untranslated
         // "Error:". Drop it and write the utility name instead, so the first line
         // reads exactly like the plain one-line form.
         let rendered = String::from_utf8_lossy(&rendered);
-        let body = rendered.split_once('\n').map_or("", |(_, rest)| rest);
+        Some(
+            rendered
+                .split_once('\n')
+                .map_or("", |(_, rest)| rest)
+                .into(),
+        )
+    }
+
+    fn report(
+        &self,
+        span: Range<usize>,
+        message: &str,
+        label: Option<&str>,
+        help: Option<&str>,
+    ) -> bool {
+        let id = crate::util_name();
+        let color = env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal();
+        let Some(body) = self.render_body(span, label, help, color) else {
+            return false;
+        };
+        let body = Self::localize_help(&body, help.is_some());
+        let body = body.as_ref();
         if label.is_some() {
             eprint!("{id}: {message}\n{body}");
         } else {
@@ -549,6 +616,38 @@ mod tests {
 
     fn snapshot(args: &[&str]) -> Snapshot {
         Snapshot::new(args)
+    }
+
+    /// `localize_help` and `is_label_row` both address ariadne's output by row
+    /// number, which only they know is right. Render a report whose shape is
+    /// known and check it, so that an ariadne that adds or drops a row fails
+    /// here rather than silently deleting a row of somebody's command line.
+    #[test]
+    fn the_rendered_report_has_the_row_shape_the_rewriting_assumes() {
+        let snap = snapshot(&["-k", "1,0"]);
+        let body = snap
+            .render_body(3..6, Some("a label"), Some("some advice"), false)
+            .unwrap();
+        let rows: Vec<&str> = body.lines().collect();
+
+        // Row 2 echoes the arguments; rewriting it would edit what was typed.
+        assert!(rows[2].contains("-k 1,0"), "row 2: {:?}", rows[2]);
+        assert!(!Snapshot::is_label_row(2));
+
+        // Rows 3 and 4 are the underline and the arm carrying the label.
+        assert!(Snapshot::is_label_row(3) && Snapshot::is_label_row(4));
+        assert!(rows[3].contains('┬'), "row 3: {:?}", rows[3]);
+        assert!(
+            rows[4].contains('╰') && rows[4].contains("a label"),
+            "row 4: {:?}",
+            rows[4]
+        );
+
+        // The advice comes below those, where `localize_help` looks for it.
+        assert!(
+            rows.iter().skip(5).any(|row| row.contains("Help")),
+            "no help row below row 4: {rows:?}"
+        );
     }
 
     #[test]

--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -45,6 +45,7 @@ use self::{escape::parse_escape_code, num_format::Formatter};
 use crate::{
     NonUtf8OsStrError,
     error::{UError, strip_errno},
+    translate, translate_text,
 };
 pub use spec::Spec;
 use std::{
@@ -133,39 +134,38 @@ impl From<NonUtf8OsStrError> for FormatError {
 
 impl Display for FormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SpecError(s, _) => write!(
-                f,
-                "%{}: invalid conversion specification",
-                String::from_utf8_lossy(s)
-            ),
-            Self::TooManySpecs(s) => write!(
-                f,
-                "format '{}' has too many % directives",
-                String::from_utf8_lossy(s)
-            ),
-            Self::NeedAtLeastOneSpec(s) => write!(
-                f,
-                "format '{}' has no % directive",
-                String::from_utf8_lossy(s)
-            ),
-            Self::EndsWithPercent(s) => {
-                write!(f, "format {} ends in %", String::from_utf8_lossy(s).quote())
+        // Everything quoted below is text the user typed and has to come back
+        // unchanged, hence translate_text! rather than translate!.
+        let message = match self {
+            Self::SpecError(s, _) => {
+                translate_text!("format-error-invalid-spec", "spec" => String::from_utf8_lossy(s))
             }
-            Self::InvalidPrecision(precision) => write!(f, "invalid precision: '{precision}'"),
+            Self::TooManySpecs(s) => {
+                translate_text!("format-error-too-many-specs", "format" => String::from_utf8_lossy(s))
+            }
+            Self::NeedAtLeastOneSpec(s) => {
+                translate_text!("format-error-no-spec", "format" => String::from_utf8_lossy(s))
+            }
+            Self::EndsWithPercent(s) => {
+                translate_text!("format-error-ends-with-percent", "format" => String::from_utf8_lossy(s).quote())
+            }
+            Self::InvalidPrecision(precision) => {
+                translate_text!("format-error-invalid-precision", "precision" => precision)
+            }
             // TODO: Error message below needs some work
-            Self::WrongSpecType => write!(f, "wrong % directive type was given"),
-            Self::IoError(e) => write!(f, "write error: {}", strip_errno(e)),
-            Self::NoMoreArguments => write!(f, "no more arguments"),
-            Self::InvalidArgument(_) => write!(f, "invalid argument"),
-            Self::MissingHex(_) => write!(f, "missing hexadecimal number in escape"),
-            Self::InvalidCharacter(escape_char, digits, _) => write!(
-                f,
-                "invalid universal character name \\{escape_char}{}",
-                String::from_utf8_lossy(digits)
+            Self::WrongSpecType => translate!("format-error-wrong-spec-type"),
+            Self::IoError(e) => translate_text!("format-error-write", "error" => strip_errno(e)),
+            Self::NoMoreArguments => translate!("format-error-no-more-arguments"),
+            Self::InvalidArgument(_) => translate!("format-error-invalid-argument"),
+            Self::MissingHex(_) => translate!("format-error-missing-hex"),
+            Self::InvalidCharacter(escape_char, digits, _) => translate_text!(
+                "format-error-invalid-universal-character",
+                "escape" => escape_char,
+                "digits" => String::from_utf8_lossy(digits)
             ),
-            Self::InvalidEncoding(no) => no.fmt(f),
-        }
+            Self::InvalidEncoding(no) => return no.fmt(f),
+        };
+        f.write_str(&message)
     }
 }
 

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -613,11 +613,53 @@ fn get_locales_dir(p: &str) -> Result<PathBuf, LocalizationError> {
     }
 }
 
+/// Macro for retrieving localized messages, substituting arguments as text.
+///
+/// [`translate!`] hands Fluent a number whenever an argument parses as one,
+/// and the locale then formats it: a length of `123456` comes back as
+/// `123 456` wherever thousands are grouped. Use this macro instead whenever
+/// the argument is text the user typed or a value that must be echoed
+/// unchanged — a file name, an escape, a width — and [`translate!`] when the
+/// value really is a number the reader should see in their own conventions,
+/// or when a plural selector needs one.
+///
+/// # Arguments
+///
+/// * `$id` - The message identifier string
+/// * Key-value pairs in the format `"key" => value`, each substituted with
+///   its [`ToString`] rendering
+///
+/// # Examples
+///
+/// ```
+/// use uucore::translate_text;
+/// use fluent::FluentArgs;
+///
+/// // '17' stays '17', whatever the locale does to numbers
+/// let error = translate_text!("checksum-error-invalid-length", "length" => "17");
+/// ```
+#[macro_export]
+macro_rules! translate_text {
+    ($id:expr, $($key:expr => $value:expr),+ $(,)?) => {
+        {
+            let mut args = fluent::FluentArgs::new();
+            $(
+                args.set($key, $value.to_string());
+            )+
+            $crate::locale::get_message_with_args($id, args)
+        }
+    };
+}
+
 /// Macro for retrieving localized messages with optional arguments.
 ///
 /// This macro provides a unified interface for both simple message retrieval
 /// and message retrieval with variable substitution. It accepts a message ID
 /// and optionally key-value pairs using the `"key" => value` syntax.
+///
+/// An argument that parses as a number is handed to Fluent as one, so the
+/// locale formats it — grouping its digits, for instance. When the value has
+/// to come back exactly as it went in, reach for [`translate_text!`].
 ///
 /// # Arguments
 ///
@@ -673,8 +715,8 @@ macro_rules! translate {
     };
 }
 
-// Re-export the macro for easier access
-pub use translate;
+// Re-export the macros for easier access
+pub use {translate, translate_text};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Everything user-facing in a report is passed in already localized, so the
diagnostics module holds no messages of its own. These three close the gaps
that were still English: the format-string errors, the checksum errors, and the
`Help` word ariadne writes in front of the advice line — without which a
translated report ends on a line half in English.

- uucore: localize the format string errors
- diagnostics: localize the word heading the advice line
- uucore: localize the checksum errors

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
