### PR TITLE
env, cut, head, tail, truncate: point at the failing part of a value

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -29,6 +29,7 @@
     "**/*.svg",
     "src/uu/*/locales/*.ftl",
     "src/uucore/locales/*.ftl",
+    "src/uucore/locales/*/*.ftl",
     ".devcontainer/**",
     "util/gnu-patches/**",
     "docs/src/release-notes/**",

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -236,6 +236,12 @@ locales:
 		for locale_file in "$(BASEDIR)"/src/uucore/locales/*.ftl; do \
 			$(INSTALL) -m 644 "$$locale_file" "$(BUILDDIR)/locales/uucore/"; \
 		done; \
+		if [ -d "$(BASEDIR)/src/uucore/locales/errors" ]; then \
+			$(INSTALL) -d "$(BUILDDIR)/locales/uucore/errors"; \
+			for locale_file in "$(BASEDIR)"/src/uucore/locales/errors/*.ftl; do \
+				$(INSTALL) -m 644 "$$locale_file" "$(BUILDDIR)/locales/uucore/errors/"; \
+			done; \
+		fi; \
 	fi; \
 	# Copy utility-specific locales
 	@for prog in $(INSTALLEES); do \
@@ -255,6 +261,15 @@ INSTALLEES_WITH_EXTRA_LOCALE = \
 	$(INSTALLEES) \
 	$(if $(findstring sum, $(INSTALLEES)),checksum_common, )
 install-locales:
+	@# Install lazy error locales shared by all utilities
+	@if [ -d "$(BASEDIR)/src/uucore/locales/errors" ]; then \
+		$(INSTALL) -d "$(DESTDIR)$(DATAROOTDIR)/locales/uucore/errors"; \
+		for locale_file in "$(BASEDIR)"/src/uucore/locales/errors/*.ftl; do \
+			if [ "$$(basename "$$locale_file")" != "en-US.ftl" ]; then \
+				$(INSTALL) -m 644 "$$locale_file" "$(DESTDIR)$(DATAROOTDIR)/locales/uucore/errors/"; \
+			fi; \
+		done; \
+	fi
 	@for prog in $(INSTALLEES_WITH_EXTRA_LOCALE); do \
 		if [ -d "$(BASEDIR)/src/uu/$$prog/locales" ]; then \
 			$(INSTALL) -d "$(DESTDIR)$(DATAROOTDIR)/locales/$$prog"; \

--- a/docs/src/extensions-errors.md
+++ b/docs/src/extensions-errors.md
@@ -280,7 +280,7 @@ the difference:
 | `numfmt` | the failing part of a `--field` or `--format` specification | [`numfmt --format=%q 1000`](https://uutils.org/playground/?cmd=numfmt+--format%3D%25q+1000) |
 | `printf` | the failing conversion or escape in the format string | [`printf %5.2c q`](https://uutils.org/playground/?cmd=printf+%255.2c+q) |
 | `env`    | the failing part of a `-S`/`--split-string` string | [`env -S 'echo ${1FOO}'`](https://uutils.org/playground/?cmd=env+-S+%27echo+%24%7B1FOO%7D%27) |
-| `cut`    | the failing range in the list given to `-b`, `-c` or `-f` | [`cut -f 1,4-2 fruits.txt`](https://uutils.org/playground/?cmd=cut+-f+1%2C4-2+fruits.txt) |
+| `cut`    | the failing range in the list given to `-b`, `-c`, `-f` or `-F` | [`cut -f 1,4-2 fruits.txt`](https://uutils.org/playground/?cmd=cut+-f+1%2C4-2+fruits.txt) |
 | `head`   | the failing part of the SIZE given to `-c` or `-n` | [`head -c 1fb fruits.txt`](https://uutils.org/playground/?cmd=head+-c+1fb+fruits.txt) |
 | `tail`   | the failing part of the SIZE given to `-c` or `-n` | [`tail -c 1fb fruits.txt`](https://uutils.org/playground/?cmd=tail+-c+1fb+fruits.txt) |
 | `truncate` | the failing part of the SIZE given to `-s`/`--size` | [`truncate -s 10fb fruits.txt`](https://uutils.org/playground/?cmd=truncate+-s+10fb+fruits.txt) |

--- a/docs/src/extensions-errors.md
+++ b/docs/src/extensions-errors.md
@@ -1,0 +1,346 @@
+<!-- spell-checker:ignore numfmt OPTS ariadne mydir mypipe mydev -->
+
+# Error diagnostics
+
+GNU coreutils reports every error as a single line on stderr. That line
+answers *what* went wrong, but not *where*. For utilities whose arguments form
+a small language of their own — a `test` expression, a `chmod` mode, a `sort`
+key — the interesting question is usually which argument, or which character
+inside an argument, broke the parse.
+
+When stderr is a terminal, uutils renders these errors as a compiler-style
+report instead: the command line is echoed back as a source line, and a caret
+points at the part that is at fault, often with a line of advice. Everywhere
+else — a script, a pipe, a test harness — the plain one-line message is kept,
+so nothing that reads stderr can tell the difference.
+
+## Before and after
+
+Each utility below shows the plain one-line message first — what uutils
+prints when stderr is not a terminal, and in most cases exactly what GNU
+prints — then the report rendered on a terminal.
+
+### `test`
+
+```
+$ test 7 -eq zap
+test: invalid integer 'zap'
+```
+
+```
+$ test 7 -eq zap
+test: invalid integer 'zap'
+   ╭─[ test:1:7 ]
+   │
+ 1 │ 7 -eq zap
+   │       ───
+   │
+   │ Help: -eq, -ne, -lt, -le, -gt and -ge compare integers; use =, !=, < or > to compare strings
+   │       -eq equal, -ne not equal, -lt less than, -le less than or equal, -gt greater than, -ge greater than or equal
+───╯
+```
+
+[Try it in the playground](https://uutils.org/playground/?cmd=test+7+-eq+zap).
+
+### `expr`
+
+```
+$ expr 9 + foo
+expr: non-integer argument
+```
+
+```
+$ expr 9 + foo
+expr: non-integer argument
+   ╭─[ expr:1:5 ]
+   │
+ 1 │ 9 + foo
+   │     ───
+   │
+   │ Help: arithmetic operators need integers; use = or != to compare strings instead
+───╯
+```
+
+[Try it in the playground](https://uutils.org/playground/?cmd=expr+9+%2B+foo).
+
+### `chmod`
+
+The caret can point *inside* an argument, at the exact character that broke
+the parse:
+
+```
+$ chmod g+rw?x notes.txt
+chmod: invalid operator (expected +, -, or =, but found ?)
+```
+
+```
+$ chmod g+rw?x notes.txt
+chmod: invalid operator (expected +, -, or =, but found ?)
+   ╭─[ chmod:1:5 ]
+   │
+ 1 │ g+rw?x notes.txt
+   │     ─
+   │
+   │ Help: a mode is either octal, as in 644, or clauses such as u+rwx,go-w
+───╯
+```
+
+### `tr`
+
+```
+$ tr 'qw[y-b]' x
+tr: range-endpoints of 'y-b' are in reverse collating sequence order
+```
+
+```
+$ tr 'qw[y-b]' x
+tr: range-endpoints of 'y-b' are in reverse collating sequence order
+   ╭─[ tr:1:7 ]
+   │
+ 1 │ tr qw[y-b] x
+   │       ─┬─
+   │        ╰─── did you mean 'b-y'?
+   │
+   │ Help: a range goes from the lower character to the higher one, as in a-z
+───╯
+```
+
+[Try it in the playground](https://uutils.org/playground/?cmd=tr+%27qw%5By-b%5D%27+x).
+
+### `sort`
+
+```
+$ sort -k2.3x notes.txt
+sort: stray character in field spec: invalid field specification '2.3x'
+```
+
+```
+$ sort -k2.3x notes.txt
+sort: stray character in field spec: invalid field specification '2.3x'
+   ╭─[ sort:1:11 ]
+   │
+ 1 │ sort -k2.3x notes.txt
+   │           ─
+   │
+   │ Help: a key is FIELD[.CHAR][OPTS][,FIELD[.CHAR][OPTS]], as in -k2.3,4nr
+───╯
+```
+
+[Try it in the playground](https://uutils.org/playground/?cmd=sort+-k2.3x+fruits.txt).
+
+### `numfmt`
+
+```
+$ numfmt --format=%q 1000
+numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
+```
+
+```
+$ numfmt --format=%q 1000
+numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
+   ╭─[ numfmt:1:18 ]
+   │
+ 1 │ numfmt --format=%q 1000
+   │                  ─
+   │
+   │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in "%'-10.2f"
+───╯
+```
+
+[Try it in the playground](https://uutils.org/playground/?cmd=numfmt+--format%3D%25q+1000).
+
+### `printf`
+
+```
+$ printf %5.2c q
+printf: %5.2c: invalid conversion specification
+```
+
+```
+$ printf %5.2c q
+printf: %5.2c: invalid conversion specification
+   ╭─[ printf:1:8 ]
+   │
+ 1 │ printf %5.2c q
+   │        ─────
+   │
+   │ Help: %d, %s, %x, %f and the other C conversions are accepted, plus %b and %q; a literal % is written %%
+───╯
+```
+
+The same goes for a broken escape: `printf 'a\xzb'` puts the caret under the
+`\x` that is missing its hexadecimal digits.
+
+[Try it in the playground](https://uutils.org/playground/?cmd=printf+%255.2c+q).
+
+### `env`
+
+`env -S` takes a whole command line and splits it as a shell would. Its
+messages name an offset, which is precisely the thing a caret can show
+instead:
+
+```
+$ env -S 'echo ${1FOO}'
+env: only ${VARNAME} expansion is supported, error at: ${1FOO}
+```
+
+```
+$ env -S 'echo ${1FOO}'
+env: only ${VARNAME} expansion is supported, error at: ${1FOO}
+   ╭─[ env:1:14 ]
+   │
+ 1 │ env -S 'echo ${1FOO}'
+   │              ─┬─
+   │               ╰─── a variable name cannot start with a digit
+   │
+   │ Help: only $NAME and ${NAME} are expanded; the other shell forms are not
+───╯
+```
+
+Note that the `-S` string holds spaces, so it is echoed back quoted — and the
+caret still points inside it.
+
+### `cut`
+
+A list of ranges is often long, and only one item in it is wrong:
+
+```
+$ cut -f 1,4-2,9-12 notes.txt
+cut: range '4-2' was invalid: high end of range less than low end
+```
+
+```
+$ cut -f 1,4-2,9-12 notes.txt
+cut: range '4-2' was invalid: high end of range less than low end
+   ╭─[ cut:1:10 ]
+   │
+ 1 │ cut -f 1,4-2,9-12 notes.txt
+   │          ─┬─
+   │           ╰─── this range ends before it starts
+   │
+   │ Help: a list is N, N-M, N- or -M, separated by commas, as in -f1,4-6,9-
+───╯
+```
+
+### `head`
+
+A SIZE is a number and a unit, and the caret says which of the two was
+rejected:
+
+```
+$ head -c 1fb notes.txt
+head: invalid number of bytes: '1fb'
+```
+
+```
+$ head -c 1fb notes.txt
+head: invalid number of bytes: '1fb'
+   ╭─[ head:1:10 ]
+   │
+ 1 │ head -c 1fb notes.txt
+   │          ─┬
+   │           ╰── not a known unit
+   │
+   │ Help: a size is a number and an optional unit: K, M, G and so on for 1024, KB, MB, GB for 1000
+───╯
+```
+
+## Compatibility
+
+This is strictly an interactive nicety; nothing that reads our output can tell
+the difference:
+
+- Reports are only rendered when **stderr is a terminal**. In a script, a
+  pipe, or a test harness, the utility keeps printing its plain one-line
+  message, so existing scripts that match on stderr keep working.
+- Exit codes are unchanged.
+- Colors follow the usual conventions: they are used only on a terminal, and
+  [`NO_COLOR`](https://no-color.org/) disables them.
+- All messages, labels and help lines are localized like the rest of uutils
+  (see [Localization](l10n.md)).
+- The rendering can be compiled out entirely: it sits behind the
+  `feat_diagnostics` cargo feature, which is on by default. Building with
+  `--no-default-features` (plus a `feat_os_*` selection) drops the renderer
+  and its `ariadne` dependency, and every utility keeps its plain one-line
+  messages.
+
+## Supported utilities
+
+| Utility  | What the caret points at | Try it |
+| -------- | ------------------------ | ------ |
+| `test`   | the argument that made the expression fail | [`test 7 -eq zap`](https://uutils.org/playground/?cmd=test+7+-eq+zap) |
+| `expr`   | the argument that made the expression fail | [`expr 9 + foo`](https://uutils.org/playground/?cmd=expr+9+%2B+foo) |
+| `chmod`  | the failing clause (or character) of an invalid symbolic or octal mode | [`chmod 'g+rw?x' fruits.txt`](https://uutils.org/playground/?cmd=chmod+%27g%2Brw%3Fx%27+fruits.txt) |
+| `mkdir`  | the failing part of the mode given to `-m`/`--mode` | [`mkdir -m u+q mydir`](https://uutils.org/playground/?cmd=mkdir+-m+u%2Bq+mydir) |
+| `mkfifo` | the failing part of the mode given to `-m`/`--mode` | [`mkfifo -m u+q mypipe`](https://uutils.org/playground/?cmd=mkfifo+-m+u%2Bq+mypipe) |
+| `mknod`  | the failing part of the mode given to `-m`/`--mode` | [`mknod -m u+q mydev c 1 3`](https://uutils.org/playground/?cmd=mknod+-m+u%2Bq+mydev+c+1+3) |
+| `install`| the failing part of the mode given to `-m`/`--mode` | [`install -m u+q fruits.txt dest`](https://uutils.org/playground/?cmd=install+-m+u%2Bq+fruits.txt+dest) |
+| `tr`     | the part of a set that is at fault (bad class, backwards range, bad repeat count, …) | [`tr 'qw[y-b]' x`](https://uutils.org/playground/?cmd=tr+%27qw%5By-b%5D%27+x) |
+| `sort`   | the failing part of a `-k`/`--key` or field specification | [`sort -k2.3x fruits.txt`](https://uutils.org/playground/?cmd=sort+-k2.3x+fruits.txt) |
+| `numfmt` | the failing part of a `--field` or `--format` specification | [`numfmt --format=%q 1000`](https://uutils.org/playground/?cmd=numfmt+--format%3D%25q+1000) |
+| `printf` | the failing conversion or escape in the format string | [`printf %5.2c q`](https://uutils.org/playground/?cmd=printf+%255.2c+q) |
+| `env`    | the failing part of a `-S`/`--split-string` string | [`env -S 'echo ${1FOO}'`](https://uutils.org/playground/?cmd=env+-S+%27echo+%24%7B1FOO%7D%27) |
+| `cut`    | the failing range in the list given to `-b`, `-c` or `-f` | [`cut -f 1,4-2 fruits.txt`](https://uutils.org/playground/?cmd=cut+-f+1%2C4-2+fruits.txt) |
+| `head`   | the failing part of the SIZE given to `-c` or `-n` | [`head -c 1fb fruits.txt`](https://uutils.org/playground/?cmd=head+-c+1fb+fruits.txt) |
+| `tail`   | the failing part of the SIZE given to `-c` or `-n` | [`tail -c 1fb fruits.txt`](https://uutils.org/playground/?cmd=tail+-c+1fb+fruits.txt) |
+| `truncate` | the failing part of the SIZE given to `-s`/`--size` | [`truncate -s 10fb fruits.txt`](https://uutils.org/playground/?cmd=truncate+-s+10fb+fruits.txt) |
+
+## How it works
+
+The rendering lives in `uucore::features::diagnostics` and is built on
+[ariadne](https://crates.io/crates/ariadne). A utility that opts in:
+
+1. Takes a `Snapshot` of its argument list. The snapshot joins the arguments
+   into one line (quoting where needed, and rendering non-UTF-8 arguments the
+   way the shell would) and remembers the byte range of each argument.
+2. Maps its own error type to a position, and optionally a label and a line
+   of advice, in a small per-utility `diagnostics.rs` module. A label is only
+   used when it adds something the message does not say — an expectation, or
+   a fix such as tr's `did you mean 'b-y'?` — never to restate it; with no
+   label the span is drawn as a bare underline. Everything user-facing is
+   passed in already localized.
+3. Locates the argument the operand came from — with
+   `Snapshot::index_of_value` for an option's value in whatever spelling it
+   was given (`-k 2.3x`, `-k2.3x`, `-rk2.3x`, `--key 2.3x`, `--key=2.3x`),
+   `Snapshot::index_of_positional` for a positional operand, or an index the
+   utility tracked itself — and calls `Snapshot::render` to point at the
+   whole argument, or `Snapshot::render_inside_at` to point at a byte range
+   *inside* the operand it carries. Because the argument is named rather than
+   searched for, a file, another option, or the program name that happens to
+   share the operand's text can never take the caret.
+   `Snapshot::render_option_value` does the two steps in one, which is what
+   most option values want.
+
+An argument holding a space is echoed back quoted, and the caret still points
+inside it: the quotes only wrap the operand, so its bytes are found where they
+were printed and offsets count from there. An argument that could not be
+printed as-is — a non-UTF-8 one, or one whose quoting had to be broken up — is
+underlined as a whole instead, since no offset into it would line up with what
+the reader sees.
+
+Callers check `diagnostics::enabled()` first, so the non-interactive path
+costs nothing and keeps its GNU-compatible message.
+
+Errors that come out of a shared parser are rendered by a shared helper, so
+that a syntax common to several utilities is explained the same way in all of
+them, and its labels live in the common locale strings rather than being
+repeated per utility. Three parsers work this way:
+
+- **Modes** (`uucore::mode`), for `chmod`, `mkdir`, `mkfifo`, `mknod` and
+  `install`.
+- **Range lists** (`uucore::ranges`), for `cut`'s `-b`, `-c` and `-f` and for
+  `numfmt --field`. `Range::from_list` reports which item of the list failed
+  and where it sat.
+- **Sizes** (`uucore::parser::parse_size`), for `head`, `tail` and `truncate`
+  today, and available to the other nine callers of the parser.
+  `ParseSizeError::span` works out from the operand which of its two parts —
+  the number or the unit — was rejected, so the error type keeps the shape its
+  callers build by hand.
+
+Taking modes as the worked example: the parser reports errors as a structured
+`ModeError` carrying the byte range at fault, and its rendering places the
+caret for every utility that takes a mode — `ModeError::render_option_value`
+finds the mode as the value of `-m`/`--mode` for `mkdir`, `mkfifo`, `mknod`
+and `install`, while `chmod`, which accepts modes clap cannot see (such as
+`chmod -w -r file`), tracks where each mode operand sat and passes the index
+to `ModeError::render_at`.

--- a/src/bin/uudoc.rs
+++ b/src/bin/uudoc.rs
@@ -275,6 +275,7 @@ fn main() -> io::Result<()> {
         \t* [Code of Conduct](CODE_OF_CONDUCT.md)\n\
         * [GNU test coverage](test_coverage.md)\n\
         * [Extensions](extensions.md)\n\
+        \t* [Error diagnostics](extensions-errors.md)\n\
         \n\
         # Reference\n\
         * [Multi-call binary](multicall.md)\n",

--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -26,6 +26,9 @@ fluent = { workspace = true }
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
 
+[features]
+diagnostics = ["uucore/diagnostics"]
+
 [lints]
 workspace = true
 

--- a/src/uu/cut/locales/en-US.ftl
+++ b/src/uu/cut/locales/en-US.ftl
@@ -123,3 +123,7 @@ cut-error-invalid-field-value = invalid field value { $value }
 cut-error-invalid-position-value = invalid byte/character position { $value }
 cut-error-field-number-too-large = field number { $value } is too large
 cut-error-position-too-large = byte/character offset { $value } is too large
+
+# Diagnostic labels: what the caret points at in a list of ranges
+cut-diag-label-zero-bound = counting starts at 1
+cut-diag-help-list-syntax = a list is N, N-M, N- or -M, separated by commas, as in -f1,4-6,9-

--- a/src/uu/cut/locales/fr-FR.ftl
+++ b/src/uu/cut/locales/fr-FR.ftl
@@ -123,3 +123,7 @@ cut-error-invalid-field-value = valeur de champ invalide { $value }
 cut-error-invalid-position-value = position d'octet/caractère invalide { $value }
 cut-error-field-number-too-large = le numéro de champ { $value } est trop grand
 cut-error-position-too-large = le décalage d'octet/caractère { $value } est trop grand
+
+# Étiquettes de diagnostic : ce que le caret désigne dans une liste d'intervalles
+cut-diag-label-zero-bound = le décompte commence à 1
+cut-diag-help-list-syntax = une liste s'écrit N, N-M, N- ou -M, séparés par des virgules, comme -f1,4-6,9-

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -19,7 +19,7 @@ use uucore::os_str_as_bytes;
 
 use self::searcher::Searcher;
 use matcher::{ExactMatcher, Matcher, MbExactMatcher, WhitespaceMatcher};
-use uucore::ranges::Range;
+use uucore::ranges::{Range, RangeError, RangeErrorKind};
 use uucore::translate;
 use uucore::{format_usage, show_error, show_if_err};
 
@@ -99,29 +99,46 @@ fn split_digits(s: &str) -> (&str, &str) {
     s.split_at(s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len()))
 }
 
+/// One item of a range list that does not parse: GNU's wording for it, plus
+/// which label a caret should carry. The span is added by the caller, which is
+/// the only place that knows where in the list the item sat.
+struct ItemError {
+    message: String,
+    kind: RangeErrorKind,
+}
+
 /// Parse one endpoint of a range, `default` standing in for an omitted one.
 /// GNU rejects `usize::MAX` itself, so the highest value taken is `MAX - 1`.
-fn parse_endpoint(digits: &str, default: usize, errors: &RangeErrors) -> Result<usize, String> {
+fn parse_endpoint(digits: &str, default: usize, errors: &RangeErrors) -> Result<usize, ItemError> {
     if digits.is_empty() {
         return Ok(default);
     }
     match digits.parse::<usize>() {
         Ok(n) if n != usize::MAX => Ok(n),
-        _ => Err(about(errors.too_large, digits)),
+        _ => Err(ItemError {
+            message: about(errors.too_large, digits),
+            kind: RangeErrorKind::TooLarge,
+        }),
     }
 }
 
 /// Parse a single `N`, `N-`, `-N` or `N-M` item into a range.
-fn parse_range(item: &str, errors: &RangeErrors) -> Result<Range, String> {
+fn parse_range(item: &str, errors: &RangeErrors) -> Result<Range, ItemError> {
     let (low_digits, rest) = split_digits(item);
     // GNU reports everything it could not consume, not just the first byte.
     if low_digits.is_empty() && !rest.starts_with('-') {
-        return Err(about(errors.invalid_value, item));
+        return Err(ItemError {
+            message: about(errors.invalid_value, item),
+            kind: RangeErrorKind::NotANumber,
+        });
     }
     let Some(high_part) = rest.strip_prefix('-') else {
         // No dash at all: a lone number, or trailing junk after it.
         if !rest.is_empty() {
-            return Err(about(errors.invalid_value, rest));
+            return Err(ItemError {
+                message: about(errors.invalid_value, rest),
+                kind: RangeErrorKind::NotANumber,
+            });
         }
         let n = parse_endpoint(low_digits, 0, errors)?;
         return Ok(Range { low: n, high: n });
@@ -132,19 +149,31 @@ fn parse_range(item: &str, errors: &RangeErrors) -> Result<Range, String> {
         // A second dash makes the item a malformed range, anything else a bad
         // value.
         return Err(if tail.starts_with('-') {
-            translate!(errors.invalid_range)
+            ItemError {
+                message: translate!(errors.invalid_range),
+                kind: RangeErrorKind::NoEndpoint,
+            }
         } else {
-            about(errors.invalid_value, tail)
+            ItemError {
+                message: about(errors.invalid_value, tail),
+                kind: RangeErrorKind::NotANumber,
+            }
         });
     }
     if low_digits.is_empty() && high_digits.is_empty() {
-        return Err(translate!("cut-error-invalid-range-no-endpoint", "range" => item));
+        return Err(ItemError {
+            message: translate!("cut-error-invalid-range-no-endpoint", "range" => item),
+            kind: RangeErrorKind::NoEndpoint,
+        });
     }
 
     let low = parse_endpoint(low_digits, 1, errors)?;
     let high = parse_endpoint(high_digits, usize::MAX - 1, errors)?;
     if low > high {
-        return Err(translate!("cut-error-invalid-decreasing-range"));
+        return Err(ItemError {
+            message: translate!("cut-error-invalid-decreasing-range"),
+            kind: RangeErrorKind::Inverted,
+        });
     }
     Ok(Range { low, high })
 }
@@ -154,23 +183,37 @@ fn parse_range(item: &str, errors: &RangeErrors) -> Result<Range, String> {
 /// GNU distinguishes its messages by mode and by the kind of problem, which the
 /// shared [`Range::from_list`] parser does not, so the list is parsed here and
 /// the resulting ranges are merged directly.
-fn parse_range_list(list: &str, is_field: bool) -> Result<Vec<Range>, String> {
+fn parse_range_list(list: &str, is_field: bool) -> Result<Vec<Range>, RangeError> {
     let errors = if is_field {
         &FIELD_ERRORS
     } else {
         &POSITION_ERRORS
     };
     let mut ranges = Vec::new();
+    // Where the current item starts inside `list`; the separators are one byte
+    // each, so stepping past an item is its length plus one.
+    let mut at = 0;
 
     for item in list.split([',', ' ']) {
+        let span = at..at + item.len();
+        at = span.end + 1;
         // A stray separator leaves an empty item, which GNU reads as position
         // zero -- the same complaint as an explicit `0`.
+        let zero_bound = || RangeError {
+            message: translate!(errors.numbered_from_1),
+            span: span.clone(),
+            kind: RangeErrorKind::ZeroBound,
+        };
         if item.is_empty() {
-            return Err(translate!(errors.numbered_from_1));
+            return Err(zero_bound());
         }
-        let range = parse_range(item, errors)?;
+        let range = parse_range(item, errors).map_err(|e| RangeError {
+            message: e.message,
+            span: span.clone(),
+            kind: e.kind,
+        })?;
         if range.low == 0 {
-            return Err(translate!(errors.numbered_from_1));
+            return Err(zero_bound());
         }
         ranges.push(range);
     }
@@ -178,7 +221,7 @@ fn parse_range_list(list: &str, is_field: bool) -> Result<Vec<Range>, String> {
     Ok(Range::merge(ranges))
 }
 
-fn list_to_ranges(list: &str, complement: bool, is_field: bool) -> Result<Vec<Range>, String> {
+fn list_to_ranges(list: &str, complement: bool, is_field: bool) -> Result<Vec<Range>, RangeError> {
     let ranges = parse_range_list(list, is_field)?;
     Ok(if complement {
         uucore::ranges::complement(&ranges)
@@ -1016,6 +1059,11 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let args: Vec<OsString> = args.collect();
+    // Kept for the caret in list diagnostics, which needs the arguments as
+    // they were typed, before the rewrite below edits one of them.
+    let diag_args = uucore::diagnostics::capture(&args);
+
     // GNU `cut` supports `-d=` to set the delimiter to `=`.
     // Clap parsing is limited in this situation, see:
     // https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
@@ -1045,7 +1093,21 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .get_one::<String>(mode_arg)
         .expect("should be ensured by get_mode_arg");
     let is_field = matches!(mode_arg, options::FIELDS | options::FIELDS_MERGED);
-    let ranges = list_to_ranges(list, complement, is_field).map_err(|e| UUsageError::new(1, e))?;
+    let ranges = list_to_ranges(list, complement, is_field).map_err(|e| {
+        // The list is the value of the option that selected the mode, so the
+        // caret can be put under the one range that is at fault.
+        let reported = diag_args.as_ref().is_some_and(|args| {
+            e.render_option_value(
+                args,
+                list,
+                Some(mode_arg_short(mode_arg)),
+                Some(mode_arg),
+                &translate!("cut-diag-label-zero-bound"),
+                &translate!("cut-diag-help-list-syntax"),
+            )
+        });
+        uucore::error::quiet_if_reported(reported, UUsageError::new(1, e.message))
+    })?;
 
     let mode = match mode_arg {
         options::BYTES => Mode::Bytes(
@@ -1171,6 +1233,16 @@ fn get_mode_arg(matches: &ArgMatches) -> UResult<&str> {
     }
 
     Ok(mode_arg)
+}
+
+/// The short name of a mode option, since the caret has to recognize the value
+/// however it was written: `-f2-`, `-f 2-` or `--fields=2-`.
+fn mode_arg_short(mode_arg: &str) -> char {
+    match mode_arg {
+        options::BYTES => 'b',
+        options::CHARACTERS => 'c',
+        _ => 'f',
+    }
 }
 
 pub fn uu_app() -> Command {

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -1096,12 +1096,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let ranges = list_to_ranges(list, complement, is_field).map_err(|e| {
         // The list is the value of the option that selected the mode, so the
         // caret can be put under the one range that is at fault.
+        let (short, long) = mode_arg_names(mode_arg);
         let reported = diag_args.as_ref().is_some_and(|args| {
             e.render_option_value(
                 args,
                 list,
-                Some(mode_arg_short(mode_arg)),
-                Some(mode_arg),
+                Some(short),
+                long,
                 &translate!("cut-diag-label-zero-bound"),
                 &translate!("cut-diag-help-list-syntax"),
             )
@@ -1235,13 +1236,15 @@ fn get_mode_arg(matches: &ArgMatches) -> UResult<&str> {
     Ok(mode_arg)
 }
 
-/// The short name of a mode option, since the caret has to recognize the value
+/// The names of a mode option, since the caret has to recognize the value
 /// however it was written: `-f2-`, `-f 2-` or `--fields=2-`.
-fn mode_arg_short(mode_arg: &str) -> char {
+fn mode_arg_names(mode_arg: &str) -> (char, Option<&str>) {
     match mode_arg {
-        options::BYTES => 'b',
-        options::CHARACTERS => 'c',
-        _ => 'f',
+        options::BYTES => ('b', Some(options::BYTES)),
+        options::CHARACTERS => ('c', Some(options::CHARACTERS)),
+        options::FIELDS => ('f', Some(options::FIELDS)),
+        options::FIELDS_MERGED => ('F', None),
+        _ => unreachable!("unknown cut mode option"),
     }
 }
 

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -25,6 +25,9 @@ fluent = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["signal"] }
 
+[features]
+diagnostics = ["uucore/diagnostics"]
+
 [lints]
 workspace = true
 

--- a/src/uu/env/locales/en-US.ftl
+++ b/src/uu/env/locales/en-US.ftl
@@ -42,3 +42,12 @@ env-error-failed-set-signal-action = failed to set signal action for signal { $s
 
 # Warning messages
 env-warning-no-name-specified = no name specified for value { $value }
+
+# Diagnostic labels: what the caret points at in a -S string
+env-diag-label-variable-digit = a variable name cannot start with a digit
+env-diag-label-missing-brace = this {"{"} is never closed
+env-diag-help-quoting = -S quotes as the shell does: ' and " come in pairs, and \' escapes a quote
+env-diag-help-backslash = a backslash escapes the character after it, so one cannot end the string
+env-diag-help-backslash-c = \c ends the -S string, and has no meaning inside double quotes
+env-diag-help-escape = -S understands \r, \n, \t, \f, \v, \_, \#, \$, \" and \c
+env-diag-help-variable = only $NAME and ${"{"}NAME{"}"} are expanded; the other shell forms are not

--- a/src/uu/env/locales/fr-FR.ftl
+++ b/src/uu/env/locales/fr-FR.ftl
@@ -42,3 +42,12 @@ env-error-failed-set-signal-action = échec de la définition de l'action du sig
 
 # Messages d'avertissement
 env-warning-no-name-specified = aucun nom spécifié pour la valeur { $value }
+
+# Étiquettes de diagnostic : ce que le caret désigne dans une chaîne -S
+env-diag-label-variable-digit = un nom de variable ne peut pas commencer par un chiffre
+env-diag-label-missing-brace = cette {"{"} n'est jamais fermée
+env-diag-help-quoting = -S cite comme le shell : ' et " vont par paires, et \' échappe une apostrophe
+env-diag-help-backslash = une barre oblique inverse échappe le caractère qui suit, elle ne peut donc pas terminer la chaîne
+env-diag-help-backslash-c = \c termine la chaîne -S et n'a aucun sens entre guillemets
+env-diag-help-escape = -S comprend \r, \n, \t, \f, \v, \_, \#, \$, \" et \c
+env-diag-help-variable = seuls $NOM et ${"{"}NOM{"}"} sont développés ; les autres formes du shell ne le sont pas

--- a/src/uu/env/src/diagnostics.rs
+++ b/src/uu/env/src/diagnostics.rs
@@ -1,0 +1,150 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Maps an [`EnvError`] onto the part of the `-S` string it came from, so that
+//! [`uucore::diagnostics`] can render it with a caret.
+//!
+//! Every error the splitter raises already knows the offset it stopped at —
+//! the plain message reports it as `at position 12` — so the caret has only to
+//! be placed there.
+
+use std::ffi::OsString;
+use std::ops::Range;
+
+use uucore::diagnostics::{self, Snapshot};
+use uucore::translate;
+
+use crate::EnvError;
+
+/// Render `err`, raised while splitting `payload`, against `args`.
+///
+/// # Arguments
+///
+/// * `args` - The whole argument list, program name included.
+/// * `index` - Position of the argument carrying the `-S` string.
+/// * `payload` - The `-S` string as typed. It is the tail of the argument at
+///   `index`, whether it was written `-S 'a b'`, `-S'a b'` or
+///   `--split-string='a b'`.
+/// * `message` - The error message, already localized.
+///
+/// # Returns
+///
+/// `false` when the error carries no position to point at, in which case the
+/// caller should fall back to the plain one-line message.
+pub fn render(
+    args: &[OsString],
+    index: usize,
+    payload: &str,
+    message: &str,
+    err: &EnvError,
+) -> bool {
+    let Some((span, label, help)) = describe(payload, err) else {
+        return false;
+    };
+    Snapshot::with_program(args).render_inside_at(
+        index,
+        payload,
+        span,
+        message,
+        label.map(|key| translate!(key)).as_deref(),
+        Some(&translate!(help)),
+    )
+}
+
+/// Where to point inside `payload` for `err`, the caret label, and the advice
+/// that goes under it.
+///
+/// Labelled only where a label would add to the message, per the convention in
+/// [`uucore::diagnostics`].
+fn describe(
+    payload: &str,
+    err: &EnvError,
+) -> Option<(Range<usize>, Option<&'static str>, &'static str)> {
+    match err {
+        // The string ran out while a quote was still open. The parser stopped
+        // at the end, which is exactly where the missing quote belongs.
+        EnvError::EnvMissingClosingQuote(pos, _) => {
+            let at = byte_offset(payload, *pos);
+            Some((at..at, None, "env-diag-help-quoting"))
+        }
+        EnvError::EnvInvalidBackslashAtEndOfStringInMinusS(pos, _) => {
+            let at = byte_offset(payload, *pos);
+            Some((at..at, None, "env-diag-help-backslash"))
+        }
+        EnvError::EnvBackslashCNotAllowedInDoubleQuotes(pos) => Some((
+            span_back_to(payload, *pos, '\\'),
+            None,
+            "env-diag-help-backslash-c",
+        )),
+        // The offset is the character after the backslash; the sequence that
+        // was rejected is the two of them together.
+        EnvError::EnvInvalidSequenceBackslashXInMinusS(pos, _) => Some((
+            span_back_to(payload, *pos, '\\'),
+            None,
+            "env-diag-help-escape",
+        )),
+        // Raised anywhere inside a `$…` reference, so the caret covers the
+        // reference from its `$` rather than the one character that stopped
+        // the parse.
+        EnvError::EnvParsingOfVariableUnexpectedNumber(pos, _) => Some((
+            span_back_to(payload, *pos, '$'),
+            Some("env-diag-label-variable-digit"),
+            "env-diag-help-variable",
+        )),
+        EnvError::EnvParsingOfVariableMissingClosingBrace(pos) => Some((
+            span_back_to(payload, *pos, '$'),
+            Some("env-diag-label-missing-brace"),
+            "env-diag-help-variable",
+        )),
+        EnvError::EnvParsingOfMissingVariable(pos)
+        | EnvError::EnvParsingOfVariableOnlyBracedName(pos) => Some((
+            span_back_to(payload, *pos, '$'),
+            None,
+            "env-diag-help-variable",
+        )),
+        // Control-flow signals and internal errors: nothing a reader typed.
+        EnvError::EnvReachedEnd
+        | EnvError::EnvContinueWithDelimiter
+        | EnvError::EnvInternalError(_, _) => None,
+    }
+}
+
+/// `pos`, as a byte offset into `payload`.
+///
+/// The splitter counts in `NativeCharInt`s, which are bytes on unix but UTF-16
+/// units on Windows; a caret needs the offset in the UTF-8 bytes the report is
+/// drawn from. Anything past the end of `payload` stays past it, so that
+/// [`diagnostics::char_span`] still reads it as "nothing left to point at".
+fn byte_offset(payload: &str, pos: usize) -> usize {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = payload;
+        pos
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let mut units = 0;
+        for (offset, c) in payload.char_indices() {
+            if units >= pos {
+                return offset;
+            }
+            units += c.len_utf16();
+        }
+        payload.len()
+    }
+}
+
+/// The character the parser stopped at, extended back to the nearest `opener`
+/// in front of it — the `\` of an escape, or the `$` of a variable reference.
+///
+/// Blaming the whole of what was written reads better than a caret on the one
+/// character the parse gave up on, which on its own says little.
+fn span_back_to(payload: &str, pos: usize, opener: char) -> Range<usize> {
+    let stopped = diagnostics::char_span(payload, byte_offset(payload, pos));
+    let start = payload[..stopped.start]
+        .rfind(opener)
+        .unwrap_or(stopped.start);
+    start..stopped.end
+}

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -5,6 +5,7 @@
 
 // spell-checker:ignore (ToDO) chdir progname subcommand subcommands unsets setenv putenv spawnp SIGSEGV SIGBUS sigaction Sigmask sigprocmask elidable sigset sigaddset sigemptyset
 
+pub mod diagnostics;
 pub mod native_int_str;
 pub mod split_iterator;
 pub mod string_expander;
@@ -463,38 +464,70 @@ pub fn uu_app() -> Command {
 }
 
 pub fn parse_args_from_str(text: &NativeIntStr) -> UResult<Vec<NativeIntString>> {
+    parse_args_from_str_at(text, None)
+}
+
+/// As [`parse_args_from_str`], pointing a caret into the argument the string
+/// came from.
+///
+/// # Arguments
+///
+/// * `text` - The `-S` string to split.
+/// * `located` - The whole argument list and the index of the argument
+///   carrying `text`, or `None` when no diagnostic is wanted. The argument is
+///   named rather than searched for, so a command that repeats the string
+///   elsewhere still points at the right one.
+fn parse_args_from_str_at(
+    text: &NativeIntStr,
+    located: Option<(&[OsString], usize)>,
+) -> UResult<Vec<NativeIntString>> {
     split_iterator::split(text).map_err(|e| {
-        let var_error = |pos: usize| {
-            // Find the '$' that started this variable reference and format
-            // the error like GNU: "only ${VARNAME} expansion is supported, error at: $..."
-            let dollar = get_single_native_int_value('$');
-            let dollar_pos = text[..pos]
-                .iter()
-                .rposition(|&c| Some(c) == dollar)
-                .unwrap_or(pos);
-            let rest = from_native_int_representation(Cow::Borrowed(&text[dollar_pos..]));
-            USimpleError::new(
-                125,
-                translate!("env-error-only-braced-variable-at", "rest" => rest.to_string_lossy()),
-            )
-        };
-        match e {
-            EnvError::EnvBackslashCNotAllowedInDoubleQuotes(_)
-            | EnvError::EnvInvalidBackslashAtEndOfStringInMinusS(_, _)
-            | EnvError::EnvInvalidSequenceBackslashXInMinusS(_, _) => {
-                USimpleError::new(125, e.to_string())
-            }
-            EnvError::EnvMissingClosingQuote(_, _) => USimpleError::new(125, e.to_string()),
-            EnvError::EnvParsingOfVariableMissingClosingBrace(pos)
-            | EnvError::EnvParsingOfMissingVariable(pos)
-            | EnvError::EnvParsingOfVariableOnlyBracedName(pos)
-            | EnvError::EnvParsingOfVariableUnexpectedNumber(pos, _) => var_error(pos),
-            _ => USimpleError::new(
-                125,
-                translate!("env-error-generic", "error" => format!("{e:?}")),
-            ),
-        }
+        let error = to_error(text, &e);
+        // The `-S` string is echoed back as typed, so a string that is not
+        // text cannot be pointed into.
+        let reported = located.is_some_and(|(args, index)| {
+            from_native_int_representation(Cow::Borrowed(text))
+                .to_str()
+                .is_some_and(|payload| {
+                    diagnostics::render(args, index, payload, &error.to_string(), &e)
+                })
+        });
+        uucore::error::quiet_if_reported(reported, error)
     })
+}
+
+/// The user-facing error for a `-S` string that does not split.
+fn to_error(text: &NativeIntStr, e: &EnvError) -> Box<dyn UError> {
+    let var_error = |pos: usize| {
+        // Find the '$' that started this variable reference and format
+        // the error like GNU: "only ${VARNAME} expansion is supported, error at: $..."
+        let dollar = get_single_native_int_value('$');
+        let dollar_pos = text[..pos]
+            .iter()
+            .rposition(|&c| Some(c) == dollar)
+            .unwrap_or(pos);
+        let rest = from_native_int_representation(Cow::Borrowed(&text[dollar_pos..]));
+        USimpleError::new(
+            125,
+            translate!("env-error-only-braced-variable-at", "rest" => rest.to_string_lossy()),
+        )
+    };
+    match e {
+        EnvError::EnvBackslashCNotAllowedInDoubleQuotes(_)
+        | EnvError::EnvInvalidBackslashAtEndOfStringInMinusS(_, _)
+        | EnvError::EnvInvalidSequenceBackslashXInMinusS(_, _) => {
+            USimpleError::new(125, e.to_string())
+        }
+        EnvError::EnvMissingClosingQuote(_, _) => USimpleError::new(125, e.to_string()),
+        EnvError::EnvParsingOfVariableMissingClosingBrace(pos)
+        | EnvError::EnvParsingOfMissingVariable(pos)
+        | EnvError::EnvParsingOfVariableOnlyBracedName(pos)
+        | EnvError::EnvParsingOfVariableUnexpectedNumber(pos, _) => var_error(*pos),
+        _ => USimpleError::new(
+            125,
+            translate!("env-error-generic", "error" => format!("{e:?}")),
+        ),
+    }
 }
 
 fn debug_print_args(args: &[OsString]) {
@@ -512,6 +545,7 @@ fn check_and_handle_string_args(
     do_debug_print_args: Option<&Vec<OsString>>,
     require_non_empty_payload: bool,
     strip_optional_leading_equals: bool,
+    located: Option<(&[OsString], usize)>,
 ) -> UResult<bool> {
     let native_arg = NCvt::convert(arg);
     if let Some(remaining_arg) = native_arg.strip_prefix(&*NCvt::convert(prefix_to_test)) {
@@ -533,7 +567,7 @@ fn check_and_handle_string_args(
             remaining_arg
         };
 
-        let arg_strings = parse_args_from_str(remaining_arg)?;
+        let arg_strings = parse_args_from_str_at(remaining_arg, located)?;
         all_args.extend(
             arg_strings
                 .into_iter()
@@ -606,6 +640,9 @@ impl EnvAppData {
                 continue;
             }
             expecting_arg = false;
+            // Where the `-S` string sits, for the caret: the argument the
+            // parser is looking at right now.
+            let located = uucore::diagnostics::enabled().then_some((original_args.as_slice(), n));
             match arg {
                 b if check_and_handle_string_args(
                     b,
@@ -614,14 +651,33 @@ impl EnvAppData {
                     None,
                     true,
                     true,
+                    located,
                 )? =>
                 {
                     self.had_string_argument = true;
                 }
-                b if check_and_handle_string_args(b, "-S", &mut all_args, None, true, false)? => {
+                b if check_and_handle_string_args(
+                    b,
+                    "-S",
+                    &mut all_args,
+                    None,
+                    true,
+                    false,
+                    located,
+                )? =>
+                {
                     self.had_string_argument = true;
                 }
-                b if check_and_handle_string_args(b, "-vS", &mut all_args, None, true, false)? => {
+                b if check_and_handle_string_args(
+                    b,
+                    "-vS",
+                    &mut all_args,
+                    None,
+                    true,
+                    false,
+                    located,
+                )? =>
+                {
                     self.do_debug_printing = true;
                     self.had_string_argument = true;
                 }
@@ -632,6 +688,7 @@ impl EnvAppData {
                     Some(original_args),
                     true,
                     false,
+                    located,
                 )? =>
                 {
                     self.do_debug_printing = true;
@@ -653,7 +710,10 @@ impl EnvAppData {
                     }
 
                     let native_next_arg = NCvt::convert(next_arg);
-                    let arg_strings = parse_args_from_str(native_next_arg.as_ref())?;
+                    // The string is the argument after this one, detached.
+                    let located =
+                        uucore::diagnostics::enabled().then_some((original_args.as_slice(), n + 1));
+                    let arg_strings = parse_args_from_str_at(native_next_arg.as_ref(), located)?;
                     all_args.extend(
                         arg_strings
                             .into_iter()

--- a/src/uu/head/Cargo.toml
+++ b/src/uu/head/Cargo.toml
@@ -28,6 +28,9 @@ uucore = { workspace = true, features = [
 ] }
 fluent = { workspace = true }
 
+[features]
+diagnostics = ["uucore/diagnostics"]
+
 [lints]
 workspace = true
 

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -20,6 +20,8 @@ use thiserror::Error;
 use uucore::display::{Quotable, print_verbatim};
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::line_ending::LineEnding;
+use uucore::parser::parse_signed_num::number_offset;
+use uucore::parser::parse_size::ParseSizeError;
 use uucore::show;
 use uucore::translate;
 
@@ -76,19 +78,65 @@ impl Default for Mode {
     }
 }
 
+/// A `-c` or `-n` value that does not parse.
+///
+/// The message is built where it always was; the rest is what a caret needs:
+/// the value as typed, the option it was given to, and what the size parser
+/// made of it.
+pub struct SizeError {
+    pub message: String,
+    value: String,
+    short: char,
+    long: &'static str,
+    error: ParseSizeError,
+}
+
+impl SizeError {
+    /// The error to raise, a caret under the part of the value at fault when
+    /// the arguments as typed were kept.
+    fn into_error(self, diag_args: Option<&[OsString]>) -> Box<dyn UError> {
+        self.error.size_value_error(
+            diag_args,
+            &self.value,
+            // The parser never saw the sign; the caret has to count it back in.
+            number_offset(&self.value),
+            self.short,
+            self.long,
+            &self.message,
+            HeadError::MatchOption(self.message.clone()),
+        )
+    }
+}
+
 impl Mode {
-    fn from(matches: &ArgMatches) -> Result<Self, String> {
+    fn from(matches: &ArgMatches) -> Result<Self, SizeError> {
+        fn failed(
+            value: &str,
+            short: char,
+            long: &'static str,
+            key: &'static str,
+        ) -> impl FnOnce(ParseSizeError) -> SizeError {
+            let value = value.to_string();
+            move |error| SizeError {
+                message: translate!(key, "err" => &error),
+                value,
+                short,
+                long,
+                error,
+            }
+        }
+
         if let Some(v) = matches.get_one::<String>(options::BYTES) {
-            let (n, all_but_last) = parse::parse_num(v)
-                .map_err(|err| translate!("head-error-invalid-bytes", "err" => err))?;
+            let (n, all_but_last) =
+                parse::parse_num(v).map_err(failed(v, 'c', "bytes", "head-error-invalid-bytes"))?;
             if all_but_last {
                 Ok(Self::AllButLastBytes(n))
             } else {
                 Ok(Self::FirstBytes(n))
             }
         } else if let Some(v) = matches.get_one::<String>(options::LINES) {
-            let (n, all_but_last) = parse::parse_num(v)
-                .map_err(|err| translate!("head-error-invalid-lines", "err" => err))?;
+            let (n, all_but_last) =
+                parse::parse_num(v).map_err(failed(v, 'n', "lines", "head-error-invalid-lines"))?;
             if all_but_last {
                 Ok(Self::AllButLastLines(n))
             } else {
@@ -141,7 +189,7 @@ struct HeadOptions {
 
 impl HeadOptions {
     ///Construct options from matches
-    pub fn get_from(matches: &ArgMatches) -> Result<Self, String> {
+    pub fn get_from(matches: &ArgMatches) -> Result<Self, SizeError> {
         let mut options = Self::default();
 
         options.quiet = matches.get_flag(options::QUIET);
@@ -537,8 +585,11 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<_> = arg_iterate(args)?.collect();
+    // Kept for the caret in size diagnostics, which needs the value as typed.
+    let diag_args = uucore::diagnostics::capture(&args);
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
-    let options = HeadOptions::get_from(&matches).map_err(HeadError::MatchOption)?;
+    let options =
+        HeadOptions::get_from(&matches).map_err(|e| e.into_error(diag_args.as_deref()))?;
     uu_head(&options)
 }
 
@@ -550,11 +601,12 @@ mod tests {
     use super::*;
 
     fn options(args: &str) -> Result<HeadOptions, String> {
+        // The unit tests compare messages, not the rest of the failure.
         let combined = "head ".to_owned() + args;
         let args = combined.split_whitespace().map(OsString::from);
         let matches = uu_app()
             .get_matches_from(arg_iterate(args).map_err(|_| String::from("Arg iterate failed"))?);
-        HeadOptions::get_from(&matches)
+        HeadOptions::get_from(&matches).map_err(|e| e.message)
     }
 
     #[test]

--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -584,9 +584,10 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let args: Vec<_> = arg_iterate(args)?.collect();
-    // Kept for the caret in size diagnostics, which needs the value as typed.
-    let diag_args = uucore::diagnostics::capture(&args);
+    let raw_args: Vec<_> = args.collect();
+    // Capture before obsolete options such as `-5` are rewritten to `-n 5`.
+    let diag_args = uucore::diagnostics::capture(&raw_args);
+    let args: Vec<_> = arg_iterate(raw_args.into_iter())?.collect();
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
     let options =
         HeadOptions::get_from(&matches).map_err(|e| e.into_error(diag_args.as_deref()))?;

--- a/src/uu/numfmt/locales/en-US.ftl
+++ b/src/uu/numfmt/locales/en-US.ftl
@@ -88,3 +88,5 @@ numfmt-debug-header-ignored = --header ignored with command-line input
 numfmt-diag-label-number-overflow = this number is too large
 numfmt-diag-label-stray-percent = a literal % must be written %%
 numfmt-diag-help-format-syntax = a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in "%'-10.2f"
+numfmt-diag-label-zero-field = fields are numbered from 1
+numfmt-diag-help-field-syntax = --field takes N, N-M, N- or -M, separated by commas, as in --field=1,3-5

--- a/src/uu/numfmt/locales/fr-FR.ftl
+++ b/src/uu/numfmt/locales/fr-FR.ftl
@@ -87,3 +87,5 @@ numfmt-debug-header-ignored = --header ignoré avec une entrée en ligne de comm
 numfmt-diag-label-number-overflow = ce nombre est trop grand
 numfmt-diag-label-stray-percent = un % littéral doit s'écrire %%
 numfmt-diag-help-format-syntax = un format s'écrit [PRÉFIXE]%[0]['][-][LARGEUR][.PRÉCISION]f[SUFFIXE], comme "%'-10.2f"
+numfmt-diag-label-zero-field = les champs sont numérotés à partir de 1
+numfmt-diag-help-field-syntax = --field prend N, N-M, N- ou -M, séparés par des virgules, comme --field=1,3-5

--- a/src/uu/numfmt/src/diagnostics.rs
+++ b/src/uu/numfmt/src/diagnostics.rs
@@ -4,11 +4,13 @@
 // file that was distributed with this source code.
 
 //! Maps a [`FormatError`] onto the part of the `--format` string it came from,
-//! so that [`uucore::diagnostics`] can render it with a caret.
+//! so that [`uucore::diagnostics`] can render it with a caret. A bad `--field`
+//! list goes through [`RangeError`], which knows how to render itself.
 
 use std::ffi::OsString;
 
 use uucore::diagnostics::Snapshot;
+use uucore::ranges::RangeError;
 use uucore::translate;
 
 use crate::options::{FormatError, FormatErrorKind};
@@ -38,5 +40,23 @@ pub fn render(args: &[OsString], format: &str, err: &FormatError) -> bool {
         &err.message,
         label.map(|label| translate!(label)).as_deref(),
         Some(&translate!("numfmt-diag-help-format-syntax")),
+    )
+}
+
+/// Render `err`, raised while parsing `fields` — the value of `--field` —
+/// against `args`.
+///
+/// # Returns
+///
+/// `false` when the list cannot be found among the arguments, in which case
+/// the caller should fall back to the plain one-line message.
+pub fn render_field(args: &[OsString], fields: &str, err: &RangeError) -> bool {
+    err.render_option_value(
+        args,
+        fields,
+        None,
+        Some("field"),
+        &translate!("numfmt-diag-label-zero-field"),
+        &translate!("numfmt-diag-help-field-syntax"),
     )
 }

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -406,6 +406,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 NumfmtError::IllegalArgument(error.message),
             ));
         }
+        // As for a format, a field list knows which of its ranges is at fault.
+        Err(ParseError::Field(error)) => {
+            let reported = format_args
+                .as_ref()
+                .zip(matches.get_one::<String>(FIELD))
+                .is_some_and(|(args, fields)| diagnostics::render_field(args, fields, &error));
+            return Err(quiet_if_reported(
+                reported,
+                NumfmtError::IllegalArgument(error.message),
+            ));
+        }
         Err(ParseError::Other(message)) => {
             return Err(NumfmtError::IllegalArgument(message).into());
         }

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -156,6 +156,8 @@ impl Display for FormatError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseError {
     Format(FormatError),
+    /// A `--field` list that does not parse, knowing where in the list.
+    Field(uucore::ranges::RangeError),
     Other(String),
 }
 
@@ -168,6 +170,12 @@ impl From<FormatError> for ParseError {
 impl From<String> for ParseError {
     fn from(message: String) -> Self {
         Self::Other(message)
+    }
+}
+
+impl From<uucore::ranges::RangeError> for ParseError {
+    fn from(error: uucore::ranges::RangeError) -> Self {
+        Self::Field(error)
     }
 }
 

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -42,6 +42,9 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 rstest = { workspace = true }
 
+[features]
+diagnostics = ["uucore/diagnostics"]
+
 [lints]
 workspace = true
 

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::time::Duration;
 use uucore::error::{UResult, USimpleError, UUsageError};
-use uucore::parser::parse_signed_num::{SignPrefix, parse_signed_num_max};
+use uucore::parser::parse_signed_num::{SignPrefix, number_offset, parse_signed_num_max};
 use uucore::parser::parse_size::ParseSizeError;
 use uucore::parser::parse_time;
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
@@ -71,16 +71,29 @@ impl FilterMode {
         }
     }
 
-    fn from(matches: &ArgMatches) -> UResult<Self> {
+    fn from(matches: &ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
+        // The plain message, or a caret under the part of the size at fault.
+        let raise = |message: String, arg: &str, short, long, error: &ParseSizeError| {
+            error.size_value_error(
+                diag_args,
+                arg,
+                // The parser never saw the sign; the caret has to count it back in.
+                number_offset(arg),
+                short,
+                long,
+                &message,
+                USimpleError::new(1, message.clone()),
+            )
+        };
+
         let zero_term = matches.get_flag(options::ZERO_TERM);
         let mode = if let Some(arg) = matches.get_one::<String>(options::BYTES) {
             match parse_num(arg) {
                 Ok(signum) => Self::Bytes(signum),
                 Err(e) => {
-                    return Err(USimpleError::new(
-                        1,
-                        translate!("tail-error-invalid-number-of-bytes", "arg" => e.to_string()),
-                    ));
+                    let message =
+                        translate!("tail-error-invalid-number-of-bytes", "arg" => e.to_string());
+                    return Err(raise(message, arg, 'c', "bytes", &e));
                 }
             }
         } else if let Some(arg) = matches.get_one::<String>(options::LINES) {
@@ -89,11 +102,10 @@ impl FilterMode {
                     let delimiter = if zero_term { 0 } else { b'\n' };
                     Self::Lines(signum, delimiter)
                 }
-                Err(_) => {
-                    return Err(USimpleError::new(
-                        1,
-                        translate!("tail-error-invalid-number-of-lines", "arg" => arg.quote()),
-                    ));
+                Err(e) => {
+                    let message =
+                        translate!("tail-error-invalid-number-of-lines", "arg" => arg.quote());
+                    return Err(raise(message, arg, 'n', "lines", &e));
                 }
             }
         } else if zero_term {
@@ -183,7 +195,7 @@ impl Settings {
         settings
     }
 
-    pub fn from(matches: &ArgMatches) -> UResult<Self> {
+    pub fn from(matches: &ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
         // We're parsing --follow, -F and --retry under the following conditions:
         // * -F sets --retry and --follow=name
         // * plain --follow or short -f is the same like specifying --follow=descriptor
@@ -223,7 +235,7 @@ impl Settings {
             follow,
             retry,
             use_polling: matches.get_flag(options::USE_POLLING),
-            mode: FilterMode::from(matches)?,
+            mode: FilterMode::from(matches, diag_args)?,
             verbose: matches.get_flag(options::verbosity::VERBOSE),
             presume_input_pipe: matches.get_flag(options::PRESUME_INPUT_PIPE),
             debug: matches.get_flag(options::DEBUG),
@@ -410,7 +422,12 @@ pub fn parse_args(args: impl uucore::Args) -> UResult<Settings> {
     let args_vec: Vec<OsString> = args.collect();
     let clap_args = uu_app().try_get_matches_from(args_vec.clone());
     let clap_result = match clap_args {
-        Ok(matches) => Ok(Settings::from(&matches)?),
+        // Kept for the caret in size diagnostics, which needs the value as
+        // typed.
+        Ok(matches) => Ok(Settings::from(
+            &matches,
+            uucore::diagnostics::capture(&args_vec).as_deref(),
+        )?),
         Err(err) => Err(err.into()),
     };
 
@@ -659,7 +676,7 @@ mod tests {
         #[case] expected_retry: bool,
     ) {
         let settings =
-            Settings::from(&uu_app().no_binary_name(true).get_matches_from(args)).unwrap();
+            Settings::from(&uu_app().no_binary_name(true).get_matches_from(args), None).unwrap();
         assert_eq!(settings.follow, expected_follow_mode);
         assert_eq!(settings.retry, expected_retry);
     }

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -195,7 +195,14 @@ impl Settings {
         settings
     }
 
-    pub fn from(matches: &ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
+    pub fn from(matches: &ArgMatches) -> UResult<Self> {
+        Self::from_with_diagnostics(matches, None)
+    }
+
+    fn from_with_diagnostics(
+        matches: &ArgMatches,
+        diag_args: Option<&[OsString]>,
+    ) -> UResult<Self> {
         // We're parsing --follow, -F and --retry under the following conditions:
         // * -F sets --retry and --follow=name
         // * plain --follow or short -f is the same like specifying --follow=descriptor
@@ -424,7 +431,7 @@ pub fn parse_args(args: impl uucore::Args) -> UResult<Settings> {
     let clap_result = match clap_args {
         // Kept for the caret in size diagnostics, which needs the value as
         // typed.
-        Ok(matches) => Ok(Settings::from(
+        Ok(matches) => Ok(Settings::from_with_diagnostics(
             &matches,
             uucore::diagnostics::capture(&args_vec).as_deref(),
         )?),
@@ -676,7 +683,7 @@ mod tests {
         #[case] expected_retry: bool,
     ) {
         let settings =
-            Settings::from(&uu_app().no_binary_name(true).get_matches_from(args), None).unwrap();
+            Settings::from(&uu_app().no_binary_name(true).get_matches_from(args)).unwrap();
         assert_eq!(settings.follow, expected_follow_mode);
         assert_eq!(settings.retry, expected_retry);
     }

--- a/src/uu/truncate/Cargo.toml
+++ b/src/uu/truncate/Cargo.toml
@@ -20,6 +20,9 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["parser-size"] }
 fluent = { workspace = true }
 
+[features]
+diagnostics = ["uucore/diagnostics"]
+
 [lints]
 workspace = true
 

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -18,7 +18,9 @@ use uucore::format_usage;
 use uucore::show_if_err;
 use uucore::translate;
 
-use uucore::parser::parse_size::{ParseSizeError, Parser, allow_list_with_all_suffixes};
+use uucore::parser::parse_size::{
+    ParseSizeError, Parser, allow_list_with_all_suffixes, size_offset,
+};
 
 #[derive(Debug, Eq, PartialEq)]
 enum TruncateMode {
@@ -119,6 +121,9 @@ pub mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let args: Vec<OsString> = args.collect();
+    // Kept for the caret in size diagnostics, which needs the size as typed.
+    let diag_args = uucore::diagnostics::capture(&args);
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let files: Vec<OsString> = matches
@@ -140,7 +145,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(String::from);
     let size = matches.get_one::<String>(options::SIZE).map(String::from);
 
-    truncate(&files, no_create, io_blocks, reference, size)
+    truncate(
+        &files,
+        no_create,
+        io_blocks,
+        reference,
+        size,
+        diag_args.as_deref(),
+    )
 }
 
 pub fn uu_app() -> Command {
@@ -276,6 +288,7 @@ fn truncate(
     _io_blocks: bool, // TODO: implement handling
     reference: Option<String>,
     size: Option<String>,
+    diag_args: Option<&[OsString]>,
 ) -> UResult<()> {
     let reference_size = match reference {
         Some(reference_path) => {
@@ -298,9 +311,17 @@ fn truncate(
     let mode = match size_string {
         Some(string) => match parse_mode_and_size(string) {
             Err(error) => {
-                return Err(USimpleError::new(
-                    1,
-                    translate!("truncate-error-invalid-number", "error" => error),
+                let message = translate!("truncate-error-invalid-number", "error" => &error);
+                return Err(error.size_value_error(
+                    diag_args,
+                    string,
+                    // The parser never saw the mode character; the caret has
+                    // to count it back in.
+                    size_offset(string, is_modifier),
+                    's',
+                    "size",
+                    &message,
+                    USimpleError::new(1, message.clone()),
                 ));
             }
             Ok(mode) => mode,
@@ -392,6 +413,21 @@ mod tests {
     use crate::SizeCalculationError;
     use crate::TruncateMode;
     use crate::parse_mode_and_size;
+    use crate::{is_modifier, size_offset};
+
+    /// The offset a caret counts has to be the one the parser skipped, or the
+    /// underline lands beside what went wrong.
+    #[test]
+    fn size_offset_counts_what_the_parser_stripped() {
+        let offset = |s| size_offset(s, is_modifier);
+        assert_eq!(offset("5x"), 0);
+        assert_eq!(offset("+5x"), 1);
+        // Only the first modifier is stripped; the second is part of the size.
+        assert_eq!(offset("//5x"), 1);
+        // The parser trims before looking for a modifier.
+        assert_eq!(offset("  +5x"), 3);
+        assert_eq!(offset("  5x"), 2);
+    }
 
     #[test]
     fn test_parse_mode_and_size() {

--- a/src/uucore/build.rs
+++ b/src/uucore/build.rs
@@ -161,7 +161,28 @@ fn embed_single_utility_locale(
         project_root.join(format!("src/uucore/locales/{locale}.ftl"))
     })?;
 
+    embed_error_locales(embedded_file, project_root, locales_to_embed)?;
+
     Ok(())
+}
+
+/// Embed the strings only an error path asks for.
+///
+/// They are embedded like any other component but parsed only when something
+/// actually looks one up, so the common bundle every utility builds at startup
+/// stays small.
+///
+/// # Errors
+///
+/// Returns an error if writing to the `embedded_file` fails.
+fn embed_error_locales(
+    embedded_file: &mut File,
+    project_root: &Path,
+    locales_to_embed: &(String, Option<String>),
+) -> Result<(), Box<dyn std::error::Error>> {
+    embed_component_locales(embedded_file, locales_to_embed, "uucore-errors", |locale| {
+        project_root.join(format!("src/uucore/locales/errors/{locale}.ftl"))
+    })
 }
 
 /// Embed locale files for all utilities (multicall binary).
@@ -211,6 +232,8 @@ fn embed_all_utility_locales(
         project_root.join(format!("src/uucore/locales/{locale}.ftl"))
     })?;
 
+    embed_error_locales(embedded_file, project_root, locales_to_embed)?;
+
     embedded_file.flush()?;
     Ok(())
 }
@@ -240,6 +263,10 @@ fn embed_static_utility_locales(
     // First, try to embed uucore locales - critical for common translations like "Usage:"
     embed_component_locales(embedded_file, locales_to_embed, "uucore", |locale| {
         Path::new(&manifest_dir).join(format!("locales/{locale}.ftl"))
+    })?;
+
+    embed_component_locales(embedded_file, locales_to_embed, "uucore-errors", |locale| {
+        Path::new(&manifest_dir).join(format!("locales/errors/{locale}.ftl"))
     })?;
 
     // Collect and sort for deterministic builds

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -134,6 +134,11 @@ checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
     Use --help for more information.
 checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case
 
+# Diagnostic labels: what the caret points at in a SIZE
+size-diag-label-invalid-suffix = not a known unit
+size-diag-label-too-big = this number is too large to use
+size-diag-help-syntax = a size is a number and an optional unit: K, M, G and so on for 1024, KB, MB, GB for 1000
+
 # Diagnostic labels: what the caret points at in a list of ranges. What a zero
 # bound got wrong depends on what the range counts, so each utility says that
 # in its own words.

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -93,4 +93,3 @@ mode-error-invalid-operator = invalid operator (expected +, -, or =, but found {
 mode-diag-label-missing-operator = this clause says who, but not what to change
 mode-diag-label-invalid-number = not an octal mode
 mode-diag-help-syntax = a mode is either octal, as in 644, or clauses such as u+rwx,go-w
-    Use --help for more information.

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -68,7 +68,6 @@ safe-traversal-directory = <directory>
 # checksum-related messages
 checksum-no-properly-formatted = { $checksum_file }: no properly formatted checksum lines found
 checksum-no-file-verified = { $checksum_file }: no file was verified
-checksum-error-failed-to-read-input = failed to read input
 checksum-bad-format = { $count ->
     [1] { $count } line is improperly formatted
    *[other] { $count } lines are improperly formatted
@@ -81,7 +80,6 @@ checksum-failed-open-file = { $count ->
     [1] { $count } listed file could not be read
    *[other] { $count } listed files could not be read
 }
-checksum-error-algo-bad-format = { $file }: { $line }: improperly formatted { $algo } checksum line
 
 # uudoc tldr examples messages
 uudoc-tldr-attribution = The examples are provided by the [tldr-pages project](https://tldr.sh) under the [CC BY 4.0 License](https://github.com/tldr-pages/tldr/blob/main/LICENSE.md).
@@ -95,52 +93,4 @@ mode-error-invalid-operator = invalid operator (expected +, -, or =, but found {
 mode-diag-label-missing-operator = this clause says who, but not what to change
 mode-diag-label-invalid-number = not an octal mode
 mode-diag-help-syntax = a mode is either octal, as in 644, or clauses such as u+rwx,go-w
-# Format string parsing messages (printf, seq, env, ...)
-format-error-invalid-spec = %{ $spec }: invalid conversion specification
-format-error-too-many-specs = format '{ $format }' has too many % directives
-format-error-no-spec = format '{ $format }' has no % directive
-format-error-ends-with-percent = format { $format } ends in %
-format-error-invalid-precision = invalid precision: '{ $precision }'
-format-error-wrong-spec-type = wrong % directive type was given
-format-error-write = write error: { $error }
-format-error-no-more-arguments = no more arguments
-format-error-invalid-argument = invalid argument
-format-error-missing-hex = missing hexadecimal number in escape
-format-error-invalid-universal-character = invalid universal character name \{ $escape }{ $digits }
-
-# The word ariadne heads the advice line of a caret report with
-diagnostics-help-label = Help
-
-# Diagnostic label shared by the utilities whose arguments are an expression
-diagnostics-label-expression-complete = the expression was already complete here
-
-# Checksum errors (cksum, md5sum, sha*sum, b2sum)
-checksum-error-raw-multiple-files = the --raw option is not supported with multiple files
-checksum-error-check-only-flag = the --{ $flag } option is meaningful only when verifying checksums
-checksum-error-length-required = --length required for { $algorithm }
-checksum-error-invalid-length = invalid length: { $length }
-checksum-error-length-too-big-for-blake = maximum digest length for { $algorithm } is 512 bits
-checksum-error-length-not-multiple-of-8 = length is not a multiple of 8
-checksum-error-invalid-length-for-sha = digest length for { $algorithm } must be 224, 256, 384, or 512
-checksum-error-length-required-for-sha = --algorithm={ $algorithm } requires specifying --length 224, 256, 384, or 512
-checksum-error-length-only-for-blake2b-sha2-sha3 = --length is only supported with --algorithm blake2b, sha2, or sha3
-checksum-error-binary-text-conflict = the --binary and --text options are meaningless when verifying checksums
-checksum-error-text-without-untagged = --text mode is only supported with --untagged
-checksum-error-tag-check = the --tag option is meaningless when verifying checksums
-checksum-error-text-after-tag = --tag does not support --text mode
-checksum-error-algorithm-not-supported-with-check = --check is not supported with --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
-checksum-error-combine-multiple-algorithms = You cannot combine multiple hash algorithms!
-checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
     Use --help for more information.
-checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case
-
-# Diagnostic labels: what the caret points at in a SIZE
-size-diag-label-invalid-suffix = not a known unit
-size-diag-label-too-big = this number is too large to use
-size-diag-help-syntax = a size is a number and an optional unit: K, M, G and so on for 1024, KB, MB, GB for 1000
-
-# Diagnostic labels: what the caret points at in a list of ranges. What a zero
-# bound got wrong depends on what the range counts, so each utility says that
-# in its own words.
-range-diag-label-too-large = this number is too large
-range-diag-label-inverted = this range ends before it starts

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -133,3 +133,9 @@ checksum-error-combine-multiple-algorithms = You cannot combine multiple hash al
 checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
     Use --help for more information.
 checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case
+
+# Diagnostic labels: what the caret points at in a list of ranges. What a zero
+# bound got wrong depends on what the range counts, so each utility says that
+# in its own words.
+range-diag-label-too-large = this number is too large
+range-diag-label-inverted = this range ends before it starts

--- a/src/uucore/locales/errors/en-US.ftl
+++ b/src/uucore/locales/errors/en-US.ftl
@@ -41,6 +41,7 @@ checksum-error-text-after-tag = --tag does not support --text mode
 checksum-error-algorithm-not-supported-with-check = --check is not supported with --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
 checksum-error-combine-multiple-algorithms = You cannot combine multiple hash algorithms!
 checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
+    Use --help for more information.
 checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case
 
 # Diagnostic labels: what the caret points at in a SIZE

--- a/src/uucore/locales/errors/en-US.ftl
+++ b/src/uucore/locales/errors/en-US.ftl
@@ -1,0 +1,55 @@
+# Strings only an error path ever asks for: the messages of the shared
+# parsers and the labels a caret carries. They live apart from the common
+# uucore strings because every utility parses those at startup, and almost
+# no run ever needs one of these.
+
+checksum-error-failed-to-read-input = failed to read input
+checksum-error-algo-bad-format = { $file }: { $line }: improperly formatted { $algo } checksum line
+# Format string parsing messages (printf, seq, env, ...)
+format-error-invalid-spec = %{ $spec }: invalid conversion specification
+format-error-too-many-specs = format '{ $format }' has too many % directives
+format-error-no-spec = format '{ $format }' has no % directive
+format-error-ends-with-percent = format { $format } ends in %
+format-error-invalid-precision = invalid precision: '{ $precision }'
+format-error-wrong-spec-type = wrong % directive type was given
+format-error-write = write error: { $error }
+format-error-no-more-arguments = no more arguments
+format-error-invalid-argument = invalid argument
+format-error-missing-hex = missing hexadecimal number in escape
+format-error-invalid-universal-character = invalid universal character name \{ $escape }{ $digits }
+
+# The word ariadne heads the advice line of a caret report with
+diagnostics-help-label = Help
+
+# Diagnostic label shared by the utilities whose arguments are an expression
+diagnostics-label-expression-complete = the expression was already complete here
+
+# Checksum errors (cksum, md5sum, sha*sum, b2sum)
+checksum-error-raw-multiple-files = the --raw option is not supported with multiple files
+checksum-error-check-only-flag = the --{ $flag } option is meaningful only when verifying checksums
+checksum-error-length-required = --length required for { $algorithm }
+checksum-error-invalid-length = invalid length: { $length }
+checksum-error-length-too-big-for-blake = maximum digest length for { $algorithm } is 512 bits
+checksum-error-length-not-multiple-of-8 = length is not a multiple of 8
+checksum-error-invalid-length-for-sha = digest length for { $algorithm } must be 224, 256, 384, or 512
+checksum-error-length-required-for-sha = --algorithm={ $algorithm } requires specifying --length 224, 256, 384, or 512
+checksum-error-length-only-for-blake2b-sha2-sha3 = --length is only supported with --algorithm blake2b, sha2, or sha3
+checksum-error-binary-text-conflict = the --binary and --text options are meaningless when verifying checksums
+checksum-error-text-without-untagged = --text mode is only supported with --untagged
+checksum-error-tag-check = the --tag option is meaningless when verifying checksums
+checksum-error-text-after-tag = --tag does not support --text mode
+checksum-error-algorithm-not-supported-with-check = --check is not supported with --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
+checksum-error-combine-multiple-algorithms = You cannot combine multiple hash algorithms!
+checksum-error-need-algorithm-to-hash = Needs an algorithm to hash with.
+checksum-error-unknown-algorithm = unknown algorithm: { $algorithm }: clap should have prevented this case
+
+# Diagnostic labels: what the caret points at in a SIZE
+size-diag-label-invalid-suffix = not a known unit
+size-diag-label-too-big = this number is too large to use
+size-diag-help-syntax = a size is a number and an optional unit: K, M, G and so on for 1024, KB, MB, GB for 1000
+
+# Diagnostic labels: what the caret points at in a list of ranges. What a zero
+# bound got wrong depends on what the range counts, so each utility says that
+# in its own words.
+range-diag-label-too-large = this number is too large
+range-diag-label-inverted = this range ends before it starts

--- a/src/uucore/locales/errors/fr-FR.ftl
+++ b/src/uucore/locales/errors/fr-FR.ftl
@@ -41,6 +41,7 @@ checksum-error-text-after-tag = --tag ne prend pas en charge le mode --text
 checksum-error-algorithm-not-supported-with-check = --check n'est pas pris en charge avec --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
 checksum-error-combine-multiple-algorithms = Vous ne pouvez pas combiner plusieurs algorithmes de hachage !
 checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire.
+    Utilisez --help pour plus d'informations.
 checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas
 
 # Étiquettes de diagnostic : ce que le caret désigne dans une TAILLE

--- a/src/uucore/locales/errors/fr-FR.ftl
+++ b/src/uucore/locales/errors/fr-FR.ftl
@@ -1,0 +1,55 @@
+# Chaînes que seul un chemin d'erreur demande : les messages des analyseurs
+# partagés et les étiquettes portées par un caret. Elles sont séparées des
+# chaînes uucore communes, que chaque utilitaire analyse au démarrage alors
+# que presque aucune exécution n'en a besoin.
+
+checksum-error-failed-to-read-input = échec de la lecture de l'entrée
+checksum-error-algo-bad-format = { $file }: { $line }: ligne invalide pour { $algo }
+# Messages d'analyse des chaînes de format (printf, seq, env, ...)
+format-error-invalid-spec = %{ $spec } : spécification de conversion invalide
+format-error-too-many-specs = le format '{ $format }' a trop de directives %
+format-error-no-spec = le format '{ $format }' n'a pas de directive %
+format-error-ends-with-percent = le format { $format } se termine par %
+format-error-invalid-precision = précision invalide : '{ $precision }'
+format-error-wrong-spec-type = type de directive % incorrect
+format-error-write = erreur d'écriture : { $error }
+format-error-no-more-arguments = plus d'arguments
+format-error-invalid-argument = argument invalide
+format-error-missing-hex = nombre hexadécimal manquant dans l'échappement
+format-error-invalid-universal-character = nom de caractère universel invalide \{ $escape }{ $digits }
+
+# Le mot en tête de la ligne de conseil d'un rapport avec caret
+diagnostics-help-label = Aide{" "}
+
+# Étiquette de diagnostic partagée par les utilitaires dont les arguments forment une expression
+diagnostics-label-expression-complete = l'expression était déjà complète ici
+
+# Erreurs de somme de contrôle (cksum, md5sum, sha*sum, b2sum)
+checksum-error-raw-multiple-files = l'option --raw n'est pas prise en charge avec plusieurs fichiers
+checksum-error-check-only-flag = l'option --{ $flag } n'a de sens que lors de la vérification de sommes de contrôle
+checksum-error-length-required = --length est requis pour { $algorithm }
+checksum-error-invalid-length = longueur invalide : { $length }
+checksum-error-length-too-big-for-blake = la longueur maximale d'empreinte pour { $algorithm } est de 512 bits
+checksum-error-length-not-multiple-of-8 = la longueur n'est pas un multiple de 8
+checksum-error-invalid-length-for-sha = la longueur d'empreinte pour { $algorithm } doit être 224, 256, 384 ou 512
+checksum-error-length-required-for-sha = --algorithm={ $algorithm } nécessite de préciser --length 224, 256, 384 ou 512
+checksum-error-length-only-for-blake2b-sha2-sha3 = --length n'est pris en charge qu'avec --algorithm blake2b, sha2 ou sha3
+checksum-error-binary-text-conflict = les options --binary et --text n'ont pas de sens lors de la vérification de sommes de contrôle
+checksum-error-text-without-untagged = le mode --text n'est pris en charge qu'avec --untagged
+checksum-error-tag-check = l'option --tag n'a pas de sens lors de la vérification de sommes de contrôle
+checksum-error-text-after-tag = --tag ne prend pas en charge le mode --text
+checksum-error-algorithm-not-supported-with-check = --check n'est pas pris en charge avec --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
+checksum-error-combine-multiple-algorithms = Vous ne pouvez pas combiner plusieurs algorithmes de hachage !
+checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire.
+checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas
+
+# Étiquettes de diagnostic : ce que le caret désigne dans une TAILLE
+size-diag-label-invalid-suffix = unité inconnue
+size-diag-label-too-big = ce nombre est trop grand pour être utilisé
+size-diag-help-syntax = une taille est un nombre suivi d'une unité facultative : K, M, G et ainsi de suite pour 1024, KB, MB, GB pour 1000
+
+# Étiquettes de diagnostic : ce que le caret désigne dans une liste
+# d'intervalles. Ce qu'une borne nulle a de faux dépend de ce que l'intervalle
+# compte, donc chaque utilitaire le dit avec ses propres mots.
+range-diag-label-too-large = ce nombre est trop grand
+range-diag-label-inverted = cet intervalle se termine avant de commencer

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -62,7 +62,6 @@ safe-traversal-directory = <répertoire>
 # Messages relatifs au module checksum
 checksum-no-properly-formatted = { $checksum_file }: aucune ligne correctement formattée n'a été trouvée
 checksum-no-file-verified = { $checksum_file }: aucun fichier n'a été vérifié
-checksum-error-failed-to-read-input = échec de la lecture de l'entrée
 checksum-bad-format = { $count ->
     [1] { $count } ligne invalide
    *[other] { $count } lignes invalides
@@ -75,7 +74,6 @@ checksum-failed-open-file = { $count ->
     [1] { $count } fichier passé n'a pas pu être lu
    *[other] { $count } fichiers passés n'ont pas pu être lu
 }
-checksum-error-algo-bad-format = { $file }: { $line }: ligne invalide pour { $algo }
 
 # Messages uudoc pour les exemples tldr
 uudoc-tldr-attribution = Les exemples sont fournis par le [projet tldr-pages](https://tldr.sh) sous la [licence CC BY 4.0](https://github.com/tldr-pages/tldr/blob/main/LICENSE.md).
@@ -89,52 +87,4 @@ mode-error-invalid-operator = opérateur invalide (+, - ou = attendu, mais { $op
 mode-diag-label-missing-operator = cette clause indique qui, mais pas quoi changer
 mode-diag-label-invalid-number = n'est pas un mode octal
 mode-diag-help-syntax = un mode est soit octal, comme 644, soit des clauses comme u+rwx,go-w
-# Messages d'analyse des chaînes de format (printf, seq, env, ...)
-format-error-invalid-spec = %{ $spec } : spécification de conversion invalide
-format-error-too-many-specs = le format '{ $format }' a trop de directives %
-format-error-no-spec = le format '{ $format }' n'a pas de directive %
-format-error-ends-with-percent = le format { $format } se termine par %
-format-error-invalid-precision = précision invalide : '{ $precision }'
-format-error-wrong-spec-type = type de directive % incorrect
-format-error-write = erreur d'écriture : { $error }
-format-error-no-more-arguments = plus d'arguments
-format-error-invalid-argument = argument invalide
-format-error-missing-hex = nombre hexadécimal manquant dans l'échappement
-format-error-invalid-universal-character = nom de caractère universel invalide \{ $escape }{ $digits }
-
-# Le mot en tête de la ligne de conseil d'un rapport avec caret
-diagnostics-help-label = Aide{" "}
-
-# Étiquette de diagnostic partagée par les utilitaires dont les arguments forment une expression
-diagnostics-label-expression-complete = l'expression était déjà complète ici
-
-# Erreurs de somme de contrôle (cksum, md5sum, sha*sum, b2sum)
-checksum-error-raw-multiple-files = l'option --raw n'est pas prise en charge avec plusieurs fichiers
-checksum-error-check-only-flag = l'option --{ $flag } n'a de sens que lors de la vérification de sommes de contrôle
-checksum-error-length-required = --length est requis pour { $algorithm }
-checksum-error-invalid-length = longueur invalide : { $length }
-checksum-error-length-too-big-for-blake = la longueur maximale d'empreinte pour { $algorithm } est de 512 bits
-checksum-error-length-not-multiple-of-8 = la longueur n'est pas un multiple de 8
-checksum-error-invalid-length-for-sha = la longueur d'empreinte pour { $algorithm } doit être 224, 256, 384 ou 512
-checksum-error-length-required-for-sha = --algorithm={ $algorithm } nécessite de préciser --length 224, 256, 384 ou 512
-checksum-error-length-only-for-blake2b-sha2-sha3 = --length n'est pris en charge qu'avec --algorithm blake2b, sha2 ou sha3
-checksum-error-binary-text-conflict = les options --binary et --text n'ont pas de sens lors de la vérification de sommes de contrôle
-checksum-error-text-without-untagged = le mode --text n'est pris en charge qu'avec --untagged
-checksum-error-tag-check = l'option --tag n'a pas de sens lors de la vérification de sommes de contrôle
-checksum-error-text-after-tag = --tag ne prend pas en charge le mode --text
-checksum-error-algorithm-not-supported-with-check = --check n'est pas pris en charge avec --algorithm={"{"}bsd,sysv,crc,crc32b{"}"}
-checksum-error-combine-multiple-algorithms = Vous ne pouvez pas combiner plusieurs algorithmes de hachage !
-checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire.
     Utilisez --help pour plus d'informations.
-checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas
-
-# Étiquettes de diagnostic : ce que le caret désigne dans une TAILLE
-size-diag-label-invalid-suffix = unité inconnue
-size-diag-label-too-big = ce nombre est trop grand pour être utilisé
-size-diag-help-syntax = une taille est un nombre suivi d'une unité facultative : K, M, G et ainsi de suite pour 1024, KB, MB, GB pour 1000
-
-# Étiquettes de diagnostic : ce que le caret désigne dans une liste
-# d'intervalles. Ce qu'une borne nulle a de faux dépend de ce que l'intervalle
-# compte, donc chaque utilitaire le dit avec ses propres mots.
-range-diag-label-too-large = ce nombre est trop grand
-range-diag-label-inverted = cet intervalle se termine avant de commencer

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -127,3 +127,9 @@ checksum-error-combine-multiple-algorithms = Vous ne pouvez pas combiner plusieu
 checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire.
     Utilisez --help pour plus d'informations.
 checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas
+
+# Étiquettes de diagnostic : ce que le caret désigne dans une liste
+# d'intervalles. Ce qu'une borne nulle a de faux dépend de ce que l'intervalle
+# compte, donc chaque utilitaire le dit avec ses propres mots.
+range-diag-label-too-large = ce nombre est trop grand
+range-diag-label-inverted = cet intervalle se termine avant de commencer

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -87,4 +87,3 @@ mode-error-invalid-operator = opérateur invalide (+, - ou = attendu, mais { $op
 mode-diag-label-missing-operator = cette clause indique qui, mais pas quoi changer
 mode-diag-label-invalid-number = n'est pas un mode octal
 mode-diag-help-syntax = un mode est soit octal, comme 644, soit des clauses comme u+rwx,go-w
-    Utilisez --help pour plus d'informations.

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -128,6 +128,11 @@ checksum-error-need-algorithm-to-hash = Un algorithme de hachage est nécessaire
     Utilisez --help pour plus d'informations.
 checksum-error-unknown-algorithm = algorithme inconnu : { $algorithm } : clap aurait dû empêcher ce cas
 
+# Étiquettes de diagnostic : ce que le caret désigne dans une TAILLE
+size-diag-label-invalid-suffix = unité inconnue
+size-diag-label-too-big = ce nombre est trop grand pour être utilisé
+size-diag-help-syntax = une taille est un nombre suivi d'une unité facultative : K, M, G et ainsi de suite pour 1024, KB, MB, GB pour 1000
+
 # Étiquettes de diagnostic : ce que le caret désigne dans une liste
 # d'intervalles. Ce qu'une borne nulle a de faux dépend de ce que l'intervalle
 # compte, donc chaque utilitaire le dit avec ses propres mots.

--- a/src/uucore/src/lib/features/parser/parse_signed_num.rs
+++ b/src/uucore/src/lib/features/parser/parse_signed_num.rs
@@ -8,7 +8,7 @@
 //! These utilities accept arguments like `-5`, `+10`, `-100K` where the leading
 //! sign indicates different behavior (e.g., "first N" vs "last N" vs "starting from N").
 
-use super::parse_size::{ParseSizeError, parse_size_u64, parse_size_u64_max};
+use super::parse_size::{ParseSizeError, parse_size_u64, parse_size_u64_max, size_offset};
 
 /// The sign prefix found on a numeric argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +127,20 @@ pub fn parse_signed_num(src: &str) -> Result<SignedNum, ParseSizeError> {
     Ok(SignedNum { value, sign })
 }
 
+/// Where the number starts inside `src`, past what this module strips before
+/// parsing: the surrounding whitespace and the sign prefix.
+///
+/// The prefix here is the sign this module's own `strip_sign_prefix` takes, so
+/// the two agree on what was stripped; see [`size_offset`] for the rest of the
+/// reasoning.
+///
+/// # Arguments
+///
+/// * `src` - The argument as typed, the one [`parse_signed_num_max`] was given.
+pub fn number_offset(src: &str) -> usize {
+    size_offset(src, |c| matches!(c, '+' | '-'))
+}
+
 /// Strip the sign prefix from a string and return both the sign and remaining string.
 fn strip_sign_prefix(src: &str) -> (Option<SignPrefix>, &str) {
     let trimmed = src.trim();
@@ -143,6 +157,30 @@ fn strip_sign_prefix(src: &str) -> (Option<SignPrefix>, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The offset a caret counts has to be the one the parser skipped, or the
+    /// underline lands beside what went wrong — under the sign rather than
+    /// under the unit that was not a unit.
+    #[test]
+    fn number_offset_counts_what_the_parser_stripped() {
+        assert_eq!(number_offset("1fb"), 0);
+        assert_eq!(number_offset("-1fb"), 1);
+        assert_eq!(number_offset("+5zz"), 1);
+        assert_eq!(number_offset("  -1fb"), 3);
+        // The parser reads leading zeros as part of the number, so they stay.
+        assert_eq!(number_offset("-001fb"), 1);
+    }
+
+    /// What the two agree on is the point: `span` is only right about an
+    /// operand once the sign in front of it has been counted out.
+    #[test]
+    fn the_span_lands_on_the_unit_of_a_signed_operand() {
+        let operand = "-1fb";
+        let error = parse_signed_num_max(operand).unwrap_err();
+        let at = number_offset(operand);
+        assert_eq!(error.span(&operand[at..]), 1..3);
+        assert_eq!(&operand[at..][1..3], "fb");
+    }
 
     #[test]
     fn test_no_sign() {

--- a/src/uucore/src/lib/features/parser/parse_size.rs
+++ b/src/uucore/src/lib/features/parser/parse_size.rs
@@ -6,6 +6,32 @@
 
 //! Parser for sizes in SI or IEC units (multiples of 1000 or 1024 bytes).
 
+/// Where the size itself starts inside `src`, past the leading whitespace and
+/// one optional prefix character.
+///
+/// A [`ParseSizeError`] reports offsets into the size the parser saw, never
+/// into the argument as typed. The parsers taking a SIZE trim it and then take
+/// at most one character of their own before the size proper — a sign for
+/// `head` and `tail`, a mode character for `truncate` — so a caret over the
+/// argument has to count both back in. Only *one* such character is taken, so
+/// a second one belongs to the size as far as the parser is concerned and is
+/// left in.
+///
+/// # Arguments
+///
+/// * `src` - The argument as typed.
+/// * `is_prefix` - Whether a character is the prefix the caller's parser
+///   strips.
+pub fn size_offset(src: &str, is_prefix: impl Fn(char) -> bool) -> usize {
+    let trimmed = src.trim_start();
+    (src.len() - trimmed.len())
+        + trimmed
+            .chars()
+            .next()
+            .filter(|&c| is_prefix(c))
+            .map_or(0, char::len_utf8)
+}
+
 /// The first eleven powers of 1000: `1, 10^3, 10^6, ..., 10^30`.
 ///
 /// Index `n` is the SI base for the `n`-th suffix (0 → no suffix, 1 → K/kB,
@@ -45,6 +71,7 @@ pub const IEC_BASES: [u128; 11] = [
 use std::error::Error;
 use std::fmt;
 use std::num::{IntErrorKind, ParseIntError};
+use std::ops::Range;
 
 use crate::display::Quotable;
 #[cfg(target_os = "linux")]
@@ -143,6 +170,39 @@ enum NumberSystem {
     Octal,
     Hexadecimal,
     Binary,
+}
+
+/// The leading part of `size` that spells out its number.
+///
+/// The rest is the unit, so this is also where a caret goes when the unit is
+/// the part at fault.
+///
+/// # Arguments
+///
+/// * `size` - The SIZE operand as typed.
+/// * `number_system` - How its digits are to be read.
+fn numeric_prefix(size: &str, number_system: NumberSystem) -> &str {
+    let len = match number_system {
+        NumberSystem::Hexadecimal | NumberSystem::Binary => {
+            let is_digit = |c: char| match number_system {
+                NumberSystem::Hexadecimal => c.is_ascii_hexdigit(),
+                _ => c.is_digit(2),
+            };
+            // The `0x` or `0b` that named the system, and the digits after it.
+            2 + size
+                .chars()
+                .skip(2)
+                .take_while(|&c| is_digit(c))
+                .map(char::len_utf8)
+                .sum::<usize>()
+        }
+        _ => size
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .map(char::len_utf8)
+            .sum(),
+    };
+    &size[..len.min(size.len())]
 }
 
 impl<'parser> Parser<'parser> {
@@ -552,6 +612,116 @@ impl ParseSizeError {
         //                   --strings
         // etc.
         Self::ParseFailure(format!("{}", s.quote()))
+    }
+
+    /// Where in `size` this error belongs.
+    ///
+    /// The parser splits a SIZE into the number it starts with and the unit
+    /// that follows, and every failure is about one or the other. The split
+    /// is worked out the same way here, so the caret covers exactly the part
+    /// the parser rejected.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The SIZE operand as typed, the one this error is about.
+    pub fn span(&self, size: &str) -> Range<usize> {
+        let number = numeric_prefix(size, Parser::determine_number_system(size)).len();
+        match self {
+            // The number is fine; it is the unit that is not.
+            Self::InvalidSuffix(_) => number..size.len(),
+            // The number is what does not fit.
+            Self::SizeTooBig(_) => 0..number,
+            // Nothing usable was read: the operand as a whole is at fault.
+            Self::ParseFailure(_) | Self::PhysicalMem(_) => 0..size.len(),
+        }
+    }
+
+    /// Render this error against `args`, with a caret under the part of the
+    /// SIZE that is at fault.
+    ///
+    /// Every utility taking a SIZE takes the same syntax, so the label and the
+    /// advice are written once here rather than in each of them.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The whole argument list, program name included — as
+    ///   [`crate::diagnostics::capture`] returns it.
+    /// * `operand` - The option's value as typed. It may carry something in
+    ///   front of the size — `truncate` takes a mode character, as in `+2K`,
+    ///   `head` and `tail` a sign — which the caret has to count but the parser
+    ///   never saw.
+    /// * `size_at` - Where the size itself starts inside `operand`, zero when
+    ///   the whole of it is the size.
+    /// * `short` - The short name of the option it was given to, if it has one.
+    /// * `long` - Its long name, if it has one.
+    /// * `message` - The headline, already localized. It differs between
+    ///   utilities, so it is passed in rather than built here.
+    ///
+    /// # Returns
+    ///
+    /// `false` when no argument carries `size` as that option's value, in
+    /// which case the caller should fall back to the plain one-line message.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_size_value(
+        &self,
+        args: &[std::ffi::OsString],
+        operand: &str,
+        size_at: usize,
+        short: Option<char>,
+        long: Option<&str>,
+        message: &str,
+    ) -> bool {
+        let Some(size) = operand.get(size_at..) else {
+            return false;
+        };
+        // Labelled only where a label would add to the message, per the
+        // convention in `crate::diagnostics`.
+        let label = match self {
+            Self::InvalidSuffix(_) => Some(crate::translate!("size-diag-label-invalid-suffix")),
+            Self::SizeTooBig(_) => Some(crate::translate!("size-diag-label-too-big")),
+            Self::ParseFailure(_) | Self::PhysicalMem(_) => None,
+        };
+        let span = self.span(size);
+        crate::diagnostics::Snapshot::with_program(args).render_option_value(
+            operand,
+            short,
+            long,
+            size_at + span.start..size_at + span.end,
+            message,
+            label.as_deref(),
+            Some(&crate::translate!("size-diag-help-syntax")),
+        )
+    }
+
+    /// The error to raise for a SIZE that does not parse.
+    ///
+    /// Draws the caret when the arguments as typed were kept, and quiets
+    /// `error` when it did: the report has already said everything the
+    /// one-line message would, and the exit code is all that is left to
+    /// carry.
+    ///
+    /// # Arguments
+    ///
+    /// * `diag_args` - The arguments as typed, or `None` when they were not
+    ///   kept — as [`crate::diagnostics::capture`] returns them.
+    /// * `operand`, `size_at`, `short`, `long`, `message` - As for
+    ///   [`Self::render_size_value`].
+    /// * `error` - The error to raise if nothing was drawn.
+    #[allow(clippy::too_many_arguments)]
+    pub fn size_value_error(
+        &self,
+        diag_args: Option<&[std::ffi::OsString]>,
+        operand: &str,
+        size_at: usize,
+        short: char,
+        long: &str,
+        message: &str,
+        error: impl Into<Box<dyn crate::error::UError>>,
+    ) -> Box<dyn crate::error::UError> {
+        let reported = diag_args.is_some_and(|args| {
+            self.render_size_value(args, operand, size_at, Some(short), Some(long), message)
+        });
+        crate::error::quiet_if_reported(reported, error)
     }
 
     fn size_too_big(s: &str) -> Self {

--- a/src/uucore/src/lib/features/ranges.rs
+++ b/src/uucore/src/lib/features/ranges.rs
@@ -8,6 +8,7 @@
 //! A module for handling ranges of values.
 
 use std::cmp::max;
+use std::ops::Range as ByteRange;
 use std::str::FromStr;
 
 use crate::display::Quotable;
@@ -41,36 +42,172 @@ impl FromStr for Range {
     /// assert!(Range::from_str("a-b").is_err());
     /// ```
     fn from_str(s: &str) -> Result<Self, &'static str> {
-        fn parse(s: &str) -> Result<usize, &'static str> {
-            match s.parse::<usize>() {
-                Ok(0) => Err("fields and positions are numbered from 1"),
+        Self::parse(s).map_err(|invalid| invalid.reason)
+    }
+}
+
+/// What is wrong with a range, so that a caller can label a caret.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeErrorKind {
+    /// A bound that is not a number at all.
+    NotANumber,
+    /// A bound of zero, where counting starts at one.
+    ZeroBound,
+    /// A bound too large to be used.
+    TooLarge,
+    /// A bare `-`, with a bound on neither side.
+    NoEndpoint,
+    /// A range that ends before it starts.
+    Inverted,
+}
+
+/// A list of ranges that does not parse, and the part of it that is at fault.
+///
+/// The message is built here so that it reads exactly as it always has; `span`
+/// and `kind` are what a caret needs on top of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeError {
+    pub message: String,
+    /// Byte range inside the whole list, not inside the one item at fault.
+    pub span: ByteRange<usize>,
+    pub kind: RangeErrorKind,
+}
+
+impl std::fmt::Display for RangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RangeError {}
+
+impl RangeError {
+    /// Render this error against `args`, with a caret under the one range in
+    /// `list` that is at fault.
+    ///
+    /// A list of ranges reads the same wherever it is taken, so what a caret
+    /// says about a bad one is written here rather than in each utility. Only
+    /// the two texts that genuinely differ between them are passed in: what a
+    /// range counts, and how the option spells a list.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The whole argument list, program name included — as
+    ///   [`crate::diagnostics::capture`] returns it.
+    /// * `list` - The list of ranges as typed, the value of the option below.
+    /// * `short` - The short name of that option, if it has one.
+    /// * `long` - Its long name, if it has one.
+    /// * `zero_bound` - Already localized: what a zero bound got wrong, which
+    ///   depends on what the range counts — bytes, fields, characters.
+    /// * `help` - Already localized: how a list is written for this option.
+    ///
+    /// # Returns
+    ///
+    /// `false` when no argument carries `list` as that option's value, in which
+    /// case the caller should fall back to the plain one-line message.
+    pub fn render_option_value(
+        &self,
+        args: &[std::ffi::OsString],
+        list: &str,
+        short: Option<char>,
+        long: Option<&str>,
+        zero_bound: &str,
+        help: &str,
+    ) -> bool {
+        // Labelled only where a label would add to the message, per the
+        // convention in `crate::diagnostics`.
+        let label = match self.kind {
+            RangeErrorKind::NotANumber | RangeErrorKind::NoEndpoint => None,
+            RangeErrorKind::ZeroBound => Some(std::borrow::Cow::Borrowed(zero_bound)),
+            RangeErrorKind::TooLarge => Some(std::borrow::Cow::Owned(crate::translate!(
+                "range-diag-label-too-large"
+            ))),
+            RangeErrorKind::Inverted => Some(std::borrow::Cow::Owned(crate::translate!(
+                "range-diag-label-inverted"
+            ))),
+        };
+
+        crate::diagnostics::Snapshot::with_program(args).render_option_value(
+            list,
+            short,
+            long,
+            self.span.clone(),
+            &self.message,
+            label.as_deref(),
+            Some(help),
+        )
+    }
+}
+
+/// One range that does not parse, located inside the item it was read from.
+struct Invalid {
+    reason: &'static str,
+    span: ByteRange<usize>,
+    kind: RangeErrorKind,
+}
+
+impl Range {
+    /// Parse one range, reporting where inside `s` the trouble is.
+    fn parse(s: &str) -> Result<Self, Invalid> {
+        // Each bound is parsed where it sits, so that a caret can point at the
+        // one that is wrong rather than at the pair.
+        let bound = |part: &str, offset: usize| -> Result<usize, Invalid> {
+            let at = |reason, kind| Invalid {
+                reason,
+                span: offset..offset + part.len(),
+                kind,
+            };
+            match part.parse::<usize>() {
+                Ok(0) => Err(at(
+                    "fields and positions are numbered from 1",
+                    RangeErrorKind::ZeroBound,
+                )),
                 // GNU fails when we are at the limit. Match their behavior
-                Ok(n) if n == usize::MAX => Err("byte/character offset is too large"),
+                Ok(n) if n == usize::MAX => Err(at(
+                    "byte/character offset is too large",
+                    RangeErrorKind::TooLarge,
+                )),
                 Ok(n) => Ok(n),
-                Err(_) => Err("failed to parse range"),
+                Err(_) => Err(at("failed to parse range", RangeErrorKind::NotANumber)),
             }
-        }
+        };
+        // Everything after the dash starts one byte past it.
+        let after_dash = |low: &str| low.len() + 1;
 
         Ok(match s.split_once('-') {
             None => {
-                let n = parse(s)?;
+                let n = bound(s, 0)?;
                 Self { low: n, high: n }
             }
-            Some(("", "")) => return Err("invalid range with no endpoint"),
+            Some(("", "")) => {
+                return Err(Invalid {
+                    reason: "invalid range with no endpoint",
+                    span: 0..s.len(),
+                    kind: RangeErrorKind::NoEndpoint,
+                });
+            }
             Some((low, "")) => Self {
-                low: parse(low)?,
+                low: bound(low, 0)?,
                 high: usize::MAX - 1,
             },
             Some(("", high)) => Self {
                 low: 1,
-                high: parse(high)?,
+                high: bound(high, after_dash(""))?,
             },
             Some((low, high)) => {
-                let (low, high) = (parse(low)?, parse(high)?);
-                if low <= high {
-                    Self { low, high }
+                let (low_value, high_value) = (bound(low, 0)?, bound(high, after_dash(low))?);
+                if low_value <= high_value {
+                    Self {
+                        low: low_value,
+                        high: high_value,
+                    }
                 } else {
-                    return Err("high end of range less than low end");
+                    return Err(Invalid {
+                        reason: "high end of range less than low end",
+                        // Neither bound is wrong on its own; it is the pair.
+                        span: 0..s.len(),
+                        kind: RangeErrorKind::Inverted,
+                    });
                 }
             }
         })
@@ -79,13 +216,26 @@ impl FromStr for Range {
 
 impl Range {
     /// Parse a list of ranges separated by commas and/or spaces
-    pub fn from_list(list: &str) -> Result<Vec<Self>, String> {
+    ///
+    /// # Returns
+    ///
+    /// On failure, the message as it has always read, and where in `list` the
+    /// item at fault sits, so that a caller may point a caret at it.
+    pub fn from_list(list: &str) -> Result<Vec<Self>, RangeError> {
         let mut ranges = Vec::new();
 
+        // Where the item being read starts inside the whole list. The
+        // separators are one byte each, so stepping over them is enough to
+        // keep count.
+        let mut start = 0;
         for item in list.split(&[',', ' ']) {
-            let range_item = FromStr::from_str(item)
-                .map_err(|e| format!("range {} was invalid: {e}", item.quote()))?;
+            let range_item = Self::parse(item).map_err(|invalid| RangeError {
+                message: format!("range {} was invalid: {}", item.quote(), invalid.reason),
+                span: start + invalid.span.start..start + invalid.span.end,
+                kind: invalid.kind,
+            })?;
             ranges.push(range_item);
+            start += item.len() + 1;
         }
 
         Ok(Self::merge(ranges))

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -145,26 +145,33 @@ fn errors_resource(locale: &LanguageIdentifier) -> Option<String> {
 /// Build the bundle behind [`errors_message`]: English underneath, so a locale
 /// that has not translated one of these still says something, and the
 /// requested locale over the top of it.
-fn build_errors_bundle(
+fn build_errors_bundle(locales: &[LanguageIdentifier]) -> Option<FluentBundle<FluentResource>> {
+    build_errors_bundle_with(locales, errors_resource)
+}
+
+fn build_errors_bundle_with(
     locales: &[LanguageIdentifier],
-) -> Option<FluentBundle<&'static FluentResource>> {
+    mut resource_for: impl FnMut(&LanguageIdentifier) -> Option<String>,
+) -> Option<FluentBundle<FluentResource>> {
     let default_locale = LanguageIdentifier::from_str(DEFAULT_LOCALE)
         .expect("Default locale should always be valid");
     let locale = locales.first().unwrap_or(&default_locale).clone();
 
-    let mut bundle: FluentBundle<&'static FluentResource> = FluentBundle::new(vec![locale.clone()]);
+    // Own the resources in this thread-local bundle so one thread's requested
+    // locale cannot populate a process-wide cache used by another locale.
+    let mut bundle: FluentBundle<FluentResource> = FluentBundle::new(vec![locale.clone()]);
     bundle.set_use_isolating(false);
 
     let mut any = false;
-    if let Some(content) = errors_resource(&default_locale)
-        && let Ok(resource) = parse_fluent_resource(&content, &ERRORS_FLUENT_EN)
+    if let Some(content) = resource_for(&default_locale)
+        && let Ok(resource) = parse_fluent_resource_owned(&content)
     {
         bundle.add_resource_overriding(resource);
         any = true;
     }
     if locale != default_locale
-        && let Some(content) = errors_resource(&locale)
-        && let Ok(resource) = parse_fluent_resource(&content, &ERRORS_FLUENT)
+        && let Some(content) = resource_for(&locale)
+        && let Ok(resource) = parse_fluent_resource_owned(&content)
     {
         bundle.add_resource_overriding(resource);
         any = true;
@@ -175,8 +182,6 @@ fn build_errors_bundle(
 
 // Cache localizer. FluentResource cannot be shared between threads while FluentBundle can be shared
 static UUCORE_FLUENT: OnceLock<FluentResource> = OnceLock::new();
-static ERRORS_FLUENT: OnceLock<FluentResource> = OnceLock::new();
-static ERRORS_FLUENT_EN: OnceLock<FluentResource> = OnceLock::new();
 static CHECKSUM_FLUENT: OnceLock<FluentResource> = OnceLock::new();
 static UTIL_FLUENT: OnceLock<FluentResource> = OnceLock::new();
 thread_local! {
@@ -197,7 +202,7 @@ thread_local! {
             reason = "https://github.com/rust-lang/rust-clippy/issues/13422"
         )
     )]
-    static ERRORS_BUNDLE: OnceLock<Option<FluentBundle<&'static FluentResource>>> =
+    static ERRORS_BUNDLE: OnceLock<Option<FluentBundle<FluentResource>>> =
         const { OnceLock::new() };
 }
 
@@ -319,18 +324,8 @@ fn init_localization(
     Ok(())
 }
 
-/// Helper function to parse FluentResource from content string
-fn parse_fluent_resource(
-    content: &str,
-    cache: &'static OnceLock<FluentResource>,
-) -> Result<&'static FluentResource, LocalizationError> {
-    // global cache breaks unit tests
-    #[cfg(not(test))]
-    if let Some(res) = cache.get() {
-        return Ok(res);
-    }
-
-    let resource = FluentResource::try_new(content.to_string()).map_err(
+fn parse_fluent_resource_owned(content: &str) -> Result<FluentResource, LocalizationError> {
+    FluentResource::try_new(content.to_string()).map_err(
         |(_partial_resource, errs): (FluentResource, Vec<ParserError>)| {
             if let Some(first_err) = errs.into_iter().next() {
                 let snippet = first_err
@@ -347,7 +342,21 @@ fn parse_fluent_resource(
                 LocalizationError::LocalesDirNotFound("Parse error without details".to_string())
             }
         },
-    )?;
+    )
+}
+
+/// Helper function to parse FluentResource from content string
+fn parse_fluent_resource(
+    content: &str,
+    cache: &'static OnceLock<FluentResource>,
+) -> Result<&'static FluentResource, LocalizationError> {
+    // global cache breaks unit tests
+    #[cfg(not(test))]
+    if let Some(res) = cache.get() {
+        return Ok(res);
+    }
+
+    let resource = parse_fluent_resource_owned(content)?;
     // global cache breaks unit tests
     if cfg!(not(test)) {
         Ok(cache.get_or_init(|| resource))
@@ -646,6 +655,13 @@ fn get_locales_dir(p: &str) -> Result<PathBuf, LocalizationError> {
     {
         // During development, use the project's locales directory
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        if p == "uucore" {
+            let uucore_path = PathBuf::from(manifest_dir).join("locales");
+            if uucore_path.exists() {
+                return Ok(uucore_path);
+            }
+        }
+
         // from uucore path, load the locales directory from the program directory
         let dev_path = PathBuf::from(manifest_dir)
             .join("../uu")
@@ -1482,6 +1498,56 @@ invalid-syntax = This is { $missing
         } else {
             panic!("Expected LocalizationError::ParseResource with snippet");
         }
+    }
+
+    #[test]
+    fn test_lazy_error_resources_follow_runtime_locale() {
+        fn resource_for(locale: &LanguageIdentifier) -> Option<String> {
+            match locale.to_string().as_str() {
+                "en-US" => Some(include_str!("../../../locales/errors/en-US.ftl").to_string()),
+                "fr-FR" => Some(include_str!("../../../locales/errors/fr-FR.ftl").to_string()),
+                _ => None,
+            }
+        }
+
+        fn message_for(locale: &str, id: &str) -> String {
+            let locale = LanguageIdentifier::from_str(locale).unwrap();
+            let bundle = build_errors_bundle_with(&[locale], resource_for).unwrap();
+            let message = bundle
+                .get_message(id)
+                .and_then(|message| message.value())
+                .unwrap();
+            let mut errors = Vec::new();
+            bundle
+                .format_pattern(message, None, &mut errors)
+                .to_string()
+        }
+
+        assert_eq!(
+            message_for("en-US", "size-diag-label-invalid-suffix"),
+            "not a known unit"
+        );
+        assert_eq!(
+            message_for("fr-FR", "size-diag-label-invalid-suffix"),
+            "unité inconnue"
+        );
+        assert_eq!(
+            message_for("en-US", "checksum-error-need-algorithm-to-hash"),
+            "Needs an algorithm to hash with.\nUse --help for more information."
+        );
+        assert_eq!(
+            message_for("fr-FR", "checksum-error-need-algorithm-to-hash"),
+            "Un algorithme de hachage est nécessaire.\nUtilisez --help pour plus d'informations."
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_uucore_locale_directory_in_development() {
+        assert_eq!(
+            get_locales_dir("uucore").unwrap(),
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("locales")
+        );
     }
 
     #[test]

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -102,13 +102,81 @@ impl Localizer {
                 .to_string();
         }
 
+        // Only now, once nothing common has matched, is it worth parsing the
+        // strings that only an error path asks for.
+        if let Some(message) = errors_message(self.primary_bundle.locales.as_slice(), id, args) {
+            return message;
+        }
+
         // Return the key ID if not found anywhere
         id.to_string()
     }
 }
 
+/// Look `id` up among the strings only an error path ever asks for.
+///
+/// Their resource is deliberately not part of the bundle every utility builds
+/// at startup: parsing it costs every binary, while almost no run reads one of
+/// these. It is parsed here instead, on the first lookup that reaches it, and
+/// kept for the rest of the process.
+fn errors_message(
+    locales: &[LanguageIdentifier],
+    id: &str,
+    args: Option<&FluentArgs>,
+) -> Option<String> {
+    ERRORS_BUNDLE.with(|cell| {
+        let bundle = cell.get_or_init(|| build_errors_bundle(locales)).as_ref()?;
+        let message = bundle.get_message(id)?.value()?;
+        let mut errs = Vec::new();
+        Some(bundle.format_pattern(message, args, &mut errs).to_string())
+    })
+}
+
+/// The error strings for `locale`, from the locales directory when there is
+/// one to read and from the embedded copy otherwise.
+fn errors_resource(locale: &LanguageIdentifier) -> Option<String> {
+    let from_disk = get_locales_dir("uucore")
+        .ok()
+        .and_then(|dir| fs::read_to_string(dir.join("errors").join(format!("{locale}.ftl"))).ok());
+    from_disk
+        .or_else(|| get_embedded_locale(&format!("uucore-errors/{locale}.ftl")).map(str::to_owned))
+}
+
+/// Build the bundle behind [`errors_message`]: English underneath, so a locale
+/// that has not translated one of these still says something, and the
+/// requested locale over the top of it.
+fn build_errors_bundle(
+    locales: &[LanguageIdentifier],
+) -> Option<FluentBundle<&'static FluentResource>> {
+    let default_locale = LanguageIdentifier::from_str(DEFAULT_LOCALE)
+        .expect("Default locale should always be valid");
+    let locale = locales.first().unwrap_or(&default_locale).clone();
+
+    let mut bundle: FluentBundle<&'static FluentResource> = FluentBundle::new(vec![locale.clone()]);
+    bundle.set_use_isolating(false);
+
+    let mut any = false;
+    if let Some(content) = errors_resource(&default_locale)
+        && let Ok(resource) = parse_fluent_resource(&content, &ERRORS_FLUENT_EN)
+    {
+        bundle.add_resource_overriding(resource);
+        any = true;
+    }
+    if locale != default_locale
+        && let Some(content) = errors_resource(&locale)
+        && let Ok(resource) = parse_fluent_resource(&content, &ERRORS_FLUENT)
+    {
+        bundle.add_resource_overriding(resource);
+        any = true;
+    }
+
+    any.then_some(bundle)
+}
+
 // Cache localizer. FluentResource cannot be shared between threads while FluentBundle can be shared
 static UUCORE_FLUENT: OnceLock<FluentResource> = OnceLock::new();
+static ERRORS_FLUENT: OnceLock<FluentResource> = OnceLock::new();
+static ERRORS_FLUENT_EN: OnceLock<FluentResource> = OnceLock::new();
 static CHECKSUM_FLUENT: OnceLock<FluentResource> = OnceLock::new();
 static UTIL_FLUENT: OnceLock<FluentResource> = OnceLock::new();
 thread_local! {
@@ -120,6 +188,17 @@ thread_local! {
         )
     )]
     static LOCALIZER: OnceLock<Localizer> = const { OnceLock::new() };
+    /// Built on the first lookup that misses every ordinary bundle; `None`
+    /// when there are no error strings to be found at all.
+    #[cfg_attr(
+        target_os = "android",
+        expect(
+            clippy::missing_const_for_thread_local,
+            reason = "https://github.com/rust-lang/rust-clippy/issues/13422"
+        )
+    )]
+    static ERRORS_BUNDLE: OnceLock<Option<FluentBundle<&'static FluentResource>>> =
+        const { OnceLock::new() };
 }
 
 /// Helper function to find the uucore locales directory from a utility's locales directory

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -1201,3 +1201,93 @@ fn test_cut_chars_utf8_mixed_ascii_lines() {
         .succeeds()
         .stdout_only("okk\när\nmba\nøys\n");
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_points_at_the_inverted_range() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-f", "1,4-2", "/dev/null"])
+            .fails_with_code(1);
+
+        // One item of the list is at fault, not the whole of it.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+cut: invalid decreasing range
+   ╭─[ cut:1:10 ]
+   │
+ 1 │ cut -f 1,4-2 /dev/null
+   │          ─┬─
+   │           ╰─── this range ends before it starts
+   │
+   │ Help: a list is N, N-M, N- or -M, separated by commas, as in -f1,4-6,9-
+───╯"
+        );
+    }
+
+    #[test]
+    fn test_snippet_points_at_the_zero_bound() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-f1,0,3", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        // Glued to the option, so the caret counts the two columns it takes.
+        assert!(stderr.contains("cut:1:9"), "{stderr}");
+        assert!(stderr.contains("counting starts at 1"), "{stderr}");
+    }
+
+    #[test]
+    fn test_snippet_points_at_the_bound_that_is_not_a_number() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-c", "1-3,x", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        // The message names the item, so a bare underline is enough.
+        assert!(
+            stderr.contains("invalid byte/character position 'x'"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("cut:1:12"), "{stderr}");
+    }
+
+    #[test]
+    fn test_snippet_ignores_a_file_named_like_the_list() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("1,0");
+
+        // The file is named exactly like the list; the caret belongs to the
+        // value of -f.
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["-f", "1,0", "1,0"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("cut:1:10"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        let result = new_ucmd!()
+            .args(&["-f", "1,4-2", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_str();
+
+        // The message reads as it always has, and nothing is drawn under it;
+        // the usage hint that follows is cut's own.
+        assert!(
+            stderr.starts_with("cut: invalid decreasing range\n"),
+            "{stderr}"
+        );
+        assert!(!stderr.contains('\u{256d}'), "{stderr}");
+    }
+}

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -1231,6 +1231,21 @@ cut: invalid decreasing range
     }
 
     #[test]
+    fn test_snippet_finds_fields_merged_value() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-F", "1,4-2", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("1 │ cut -F 1,4-2 /dev/null"), "{stderr}");
+        assert!(
+            stderr.contains("this range ends before it starts"),
+            "{stderr}"
+        );
+    }
+
+    #[test]
     fn test_snippet_points_at_the_zero_bound() {
         let result = new_ucmd!()
             .terminal_sim_stderr()

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -2139,3 +2139,102 @@ fn test_env_disallow_double_underscore_all() {
         .fails()
         .stderr_contains("invalid signal");
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_points_at_the_unterminated_quote() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-S", "echo 'unterminated"])
+            .fails_with_code(125);
+
+        // The string is echoed back quoted, since it holds spaces; the caret
+        // still lands inside it, on the run that never closes.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+env: no terminating quote in -S string at position 18 for quote '''
+   ╭─[ env:1:9 ]
+   │
+ 1 │ env -S \"echo 'unterminated\"
+   │         ──────────────────
+   │
+   │ Help: -S quotes as the shell does: ' and \" come in pairs, and \\' escapes a quote
+───╯"
+        );
+    }
+
+    #[test]
+    fn test_snippet_points_at_the_invalid_escape() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-S", "echo \\q"])
+            .fails_with_code(125);
+        let stderr = result.stderr_as_displayed();
+
+        // The caret covers the backslash and the character it was meant to
+        // escape, not just the one the parser stopped on.
+        assert!(stderr.contains("invalid sequence '\\q'"), "{stderr}");
+        assert!(stderr.contains(" 1 │ env -S 'echo \\q'"), "{stderr}");
+        assert!(stderr.contains("\n   │              ──"), "{stderr}");
+    }
+
+    #[test]
+    fn test_snippet_points_at_the_whole_variable_reference() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-S", "echo ${1FOO}"])
+            .fails_with_code(125);
+        let stderr = result.stderr_as_displayed();
+
+        // Raised on the digit, but the caret covers the reference from its
+        // `$`, which is what the reader has to fix.
+        assert!(stderr.contains("only ${VARNAME} expansion"), "{stderr}");
+        assert!(
+            stderr.contains("a variable name cannot start with a digit"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("\n   │              ─┬─"), "{stderr}");
+    }
+
+    #[test]
+    fn test_snippet_follows_the_string_when_it_is_glued_to_the_option() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-Secho ${FOO"])
+            .fails_with_code(125);
+        let stderr = result.stderr_as_displayed();
+
+        // `-Secho …` carries the string in the same argument, so the caret
+        // shifts by the two columns the option takes.
+        assert!(stderr.contains("this { is never closed"), "{stderr}");
+        assert!(stderr.contains(" 1 │ env '-Secho ${FOO'"), "{stderr}");
+        assert!(stderr.contains("\n   │             ──┬──"), "{stderr}");
+    }
+
+    #[test]
+    fn test_snippet_points_into_the_right_argument() {
+        // The same text appears as the command env is asked to run; the caret
+        // belongs to the -S string, which is where the parse failed.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-S", "echo \\q", "echo \\q"])
+            .fails_with_code(125);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("env:1:14"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        // The harness pipes stderr, so the report must not appear.
+        new_ucmd!()
+            .args(&["-S", "echo 'unterminated"])
+            .fails_with_code(125)
+            .stderr_is("env: no terminating quote in -S string at position 18 for quote '''\n");
+    }
+}

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1137,6 +1137,18 @@ head: invalid number of bytes: '1fb'
     }
 
     #[test]
+    fn test_snippet_preserves_obsolete_option_spelling() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-5", "-c", "1fb", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("1 │ head -5 -c 1fb /dev/null"), "{stderr}");
+        assert!(!stderr.contains("head -n 5 -c"), "{stderr}");
+    }
+
+    #[test]
     fn test_plain_message_when_stderr_is_a_pipe() {
         new_ucmd!()
             .args(&["-c", "1fb", "/dev/null"])

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1093,3 +1093,54 @@ fn test_head_follows_symlink_to_regular_file() {
         .succeeds()
         .stdout_is("hello\n");
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_points_at_the_unknown_unit() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-c", "1fb", "/dev/null"])
+            .fails_with_code(1);
+
+        // The number parsed; it is the unit that did not.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+head: invalid number of bytes: '1fb'
+   ╭─[ head:1:10 ]
+   │
+ 1 │ head -c 1fb /dev/null
+   │          ─┬
+   │           ╰── not a known unit
+   │
+   │ Help: a size is a number and an optional unit: K, M, G and so on for 1024, KB, MB, GB for 1000
+───╯"
+        );
+    }
+
+    #[test]
+    fn test_snippet_underlines_a_size_with_no_number() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--bytes=xyz", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        // Nothing usable was read, so the whole value is underlined, and the
+        // message already says what is wrong.
+        assert!(stderr.contains("head:1:14"), "{stderr}");
+        assert!(!stderr.contains("not a known unit"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        new_ucmd!()
+            .args(&["-c", "1fb", "/dev/null"])
+            .fails_with_code(1)
+            .stderr_is("head: invalid number of bytes: '1fb'\n");
+    }
+}

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1847,3 +1847,44 @@ numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
             .stderr_only("numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f\n");
     }
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod field_diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_points_at_the_inverted_field_range() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--field", "1,3-2", "--to=si", "1"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("numfmt:1:18"), "{stderr}");
+        assert!(
+            stderr.contains("this range ends before it starts"),
+            "{stderr}"
+        );
+    }
+
+    #[test]
+    fn test_snippet_points_at_the_zero_field() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--field=0", "--to=si", "1"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("numfmt:1:16"), "{stderr}");
+        assert!(stderr.contains("fields are numbered from 1"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        new_ucmd!()
+            .args(&["--field=0", "--to=si", "1"])
+            .fails_with_code(1)
+            .stderr_contains("range '0' was invalid: fields and positions are numbered from 1");
+    }
+}

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -5265,3 +5265,29 @@ fn test_no_skip_after_error() {
         .fails()
         .stdout_contains("hello");
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_points_at_the_unknown_unit() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["-c", "1fb", "/dev/null"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        assert!(stderr.contains("tail:1:10"), "{stderr}");
+        assert!(stderr.contains("not a known unit"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        new_ucmd!()
+            .args(&["-n", "5QQ", "/dev/null"])
+            .fails_with_code(1)
+            .stderr_is("tail: invalid number of lines: '5QQ'\n");
+    }
+}

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -507,3 +507,36 @@ fn test_sign_as_a_size() {
         .fails()
         .stderr_is("truncate: Invalid number: '+'\n");
 }
+
+#[cfg(unix)]
+#[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
+mod diagnostics {
+    use super::*;
+
+    #[test]
+    fn test_snippet_counts_the_mode_character_before_the_size() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        let result = ucmd
+            .terminal_sim_stderr()
+            .args(&["--size=+2Zx", "probe"])
+            .fails_with_code(1);
+        let stderr = result.stderr_as_displayed();
+
+        // The `+` is part of the operand but not of the size, so the caret has
+        // to count it back in to land on the unit.
+        assert!(stderr.contains("truncate:1:19"), "{stderr}");
+        assert!(stderr.contains("not a known unit"), "{stderr}");
+    }
+
+    #[test]
+    fn test_plain_message_when_stderr_is_a_pipe() {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.touch("probe");
+
+        ucmd.args(&["-s", "10fb", "probe"])
+            .fails_with_code(1)
+            .stderr_contains("Invalid number: '10fb'");
+    }
+}


### PR DESCRIPTION
The last of the utilities, and the chapter that describes the whole thing.

- env: point at the failing part of a -S string
- cut, numfmt: point at the failing range in a list
- head, tail, truncate: point at the failing part of a SIZE
- docs: describe the caret diagnostics in the book

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
