### PR TITLE
numfmt: fix char-boundary panic on a multibyte locale decimal separator

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -57,7 +57,7 @@ fn find_valid_number_with_suffix(s: &str, unit: Unit) -> Option<&str> {
     let accepts_suffix = unit != Unit::None;
     let accepts_i = [Unit::Auto, Unit::Iec(true)].contains(&unit);
 
-    let mut characters = s.chars().skip(numeric_part.len());
+    let mut characters = s[numeric_part.len()..].chars();
     let potential_suffix = characters.next();
     let potential_i = characters.next();
 

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -468,6 +468,21 @@ fn test_field_with_multibyte_whitespace_separator() {
 }
 
 #[test]
+fn test_from_multibyte_decimal_separator_invalid_suffix() {
+    new_ucmd!()
+        .env("LC_ALL", "ar_SA.UTF-8")
+        .args(&["--from=si", "1٫€K"])
+        .fails_with_code(2)
+        .stderr_only("numfmt: invalid suffix in input '1٫€K': '€K'\n");
+
+    new_ucmd!()
+        .env("LC_ALL", "ar_SA.UTF-8")
+        .args(&["--from=auto", "1٫€Ki"])
+        .fails_with_code(2)
+        .stderr_only("numfmt: invalid suffix in input '1٫€Ki': '€Ki'\n");
+}
+
+#[test]
 fn test_format_selected_fields() {
     new_ucmd!()
         .args(&["--from=auto", "--field", "1,4,3", "1K 2K 3K 4K 5K 6K"])

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -470,7 +470,7 @@ fn test_field_with_multibyte_whitespace_separator() {
 #[test]
 fn test_from_multibyte_decimal_separator_invalid_suffix() {
     new_ucmd!()
-        .env("LC_ALL", "ar_SA.UTF-8")
+        .env("LC_ALL", "fr_FR. UTF-8")
         .args(&["--from=si", "1٫€K"])
         .fails_with_code(2)
         .stderr_only("numfmt: invalid suffix in input '1٫€K': '€K'\n");


### PR DESCRIPTION
Fixes #13937

`numfmt` aborts with a `str` char-boundary panic on an input like `1٫€K` under a locale whose decimal separator is multibyte (e.g. `LC_ALL=ar_SA.UTF-8`, where the separator is the Arabic `٫` U+066B), while GNU rejects it gracefully:

```console
$ LC_ALL=ar_SA.UTF-8 numfmt --from=si '1٫€K'
thread 'main' panicked at src/uu/numfmt/src/format.rs:70:20:
byte index 4 is not a char boundary; it is inside '€' (bytes 3..6) of `1٫€K`
# aborts, exit 134

$ LC_ALL=ar_SA.UTF-8 /usr/bin/numfmt --from=si '1٫€K'
numfmt: invalid suffix in input: '1٫€K'
# exit 2
```

## Cause

`find_valid_number_with_suffix` located the suffix with `s.chars().skip(numeric_part.len())`, using `numeric_part.len()` — a **byte** length — as a **char** skip count. When the numeric part holds a multibyte char (here the locale decimal separator `٫`, so `1٫` is the numeric part with `len() == 3` bytes but only 2 chars), the byte count over-skips past the following multibyte `€` onto a later valid suffix (`K`), taking a slicing arm; `&s[..=numeric_part.len()]` then slices to a byte offset inside `€` and panics.

## Fix

Index the suffix from the byte offset `numeric_part.len()` (`s[numeric_part.len()..].chars()`) rather than skipping by chars. `numeric_part` is always a prefix of `s`, so `numeric_part.len()` is a char boundary and the slice is safe; the real next char (`€`) is now examined, is not a valid suffix, and the input takes the same graceful "invalid suffix" rejection GNU gives. The existing byte-slices are unaffected — a valid suffix is ASCII, so they remain char-aligned.

A regression test covers the `--from=si` and `--from=auto` variants under `LC_ALL=ar_SA.UTF-8`.
