### PR TITLE
pr: accept -e at the end of a short flag cluster

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -427,7 +427,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 fn recreate_arguments(args: &[String]) -> Vec<String> {
     let num_regex = Regex::new(r"^[^-]\d*$").unwrap();
     let n_regex = Regex::new(r"^-n\s*$").unwrap();
-    let e_regex = Regex::new(r"^-e").unwrap();
+    // `-e` ends a cluster of short flags that take no value of their own, as in `-tre`.
+    // Options that do take a value are excluded so that `-se` keeps meaning `-s e`.
+    let e_regex = Regex::new(r"^-[dtTrFfabmJ]*e$").unwrap();
     let mut arguments = args.to_owned();
     let num_option = args
         .iter()
@@ -442,16 +444,15 @@ fn recreate_arguments(args: &[String]) -> Vec<String> {
         arguments.insert(pos + 2, could_be_file);
     }
 
-    // To ensure not to accidentally delete the next argument after a short flag for -e we insert
-    // the default values for the -e flag is '-e' is present without direct arguments.
+    // `-e` takes an optional attached argument, which clap cannot express, so it is filled in
+    // here. Without it clap would report a missing value for `-tre`, or swallow the following
+    // argument, usually a file name, for a bare `-e`.
     let expand_tabs_option = arguments
         .iter()
         .take_while(|arg| arg.as_str() != "--")
         .find_position(|x| e_regex.is_match(x.trim()));
-    if let Some((pos, value)) = expand_tabs_option
-        && value.trim().len() <= 2
-    {
-        arguments[pos] = "-e\t8".to_string();
+    if let Some((pos, value)) = expand_tabs_option {
+        arguments[pos] = format!("{}\t8", value.trim());
     }
 
     // Remove only whole-token legacy operands before clap parsing.

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -946,6 +946,34 @@ fn test_simple_expand_tab() {
 }
 
 #[test]
+fn test_expand_tab_at_end_of_short_flag_cluster() {
+    // `-e` closing a cluster of value-less short flags carries no attached argument, so it has
+    // to fall back to the defaults rather than report a missing value.
+    for (arg, expected) in [
+        ("-tre", "oi\n"),
+        ("-tre8", "oi\n"),
+        ("-tfre", "oi\n\x0c"),
+        ("-tfre8", "oi\n\x0c"),
+    ] {
+        new_ucmd!()
+            .arg(arg)
+            .pipe_in("oi\n")
+            .succeeds()
+            .stdout_only(expected);
+    }
+}
+
+#[test]
+fn test_expand_tab_does_not_consume_following_operand() {
+    // A bare `-e` must leave the file operand alone.
+    new_ucmd!()
+        .args(&["-t", "-e"])
+        .pipe_in("a\tb\n")
+        .succeeds()
+        .stdout_only("a       b\n");
+}
+
+#[test]
 fn test_simple_expand_tab_with_digit_argument() {
     let whitespace = " ".repeat(50);
     let datetime_pattern = r"\d\d\d\d-\d\d-\d\d \d\d:\d\d";


### PR DESCRIPTION
Fixes #13895.

`pr -tre` failed with `a value is required for '--expand-tabs <[CHAR][WIDTH]>' but none was supplied`, while GNU prints `oi`.

`-e` takes an optional attached argument, which clap cannot express, so `recreate_arguments` fills in the default before parsing. Its check was `^-e`, which only matches an argument that starts with `-e`, so `-e` at the end of a cluster like `-tre` was never given the default and reached clap bare.

Now it matches a cluster of value-less short flags ending in `e` and appends the default instead of replacing the whole argument, so `-tre` becomes `-tre\t8` and a bare `-e` still becomes `-e\t8`. Options that take a value are excluded from the cluster so `-se` keeps meaning `-s e`.

I used `recreate_arguments` rather than `num_args(0..=1)` as #13900 does for `-n`: with `num_args(0..=1)` a bare `-e` swallows the following operand, so `pr -t -e file` reports the file name as an invalid `-e` argument. The second test below guards that.

### Test

`test_expand_tab_at_end_of_short_flag_cluster` fails on main with the error from the issue and passes with this change. The full `pr` suite passes, 246 tests, and `cargo clippy -p uu_pr --all-targets -- -D warnings` is clean.

---

Written with AI assistance. I have reviewed the diff and checked the behaviour against GNU `pr` myself.
