### PR TITLE
who: do not abort on a stdout write error with -q

### DIFF
--- a/src/uu/who/src/platform/unix.rs
+++ b/src/uu/who/src/platform/unix.rs
@@ -209,8 +209,15 @@ impl Who {
                 .filter(UtmpxRecord::is_user_process)
                 .map(|ut| ut.user())
                 .collect::<Vec<_>>();
-            println!("{}", users.join(" "));
-            println!("{}", translate!("who-user-count", "count" => users.len()));
+            // `println!` panics on a write error; the rest of this file surfaces
+            // it through `?` instead so the caller can report it and exit
+            // non-zero, matching GNU (#13388).
+            writeln!(stdout(), "{}", users.join(" "))?;
+            writeln!(
+                stdout(),
+                "{}",
+                translate!("who-user-count", "count" => users.len())
+            )?;
         } else {
             let records = utmpx::Utmpx::iter_all_records_from(f);
 

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -292,3 +292,22 @@ fn test_piped_to_dev_full() {
         .fails()
         .stderr_is("who: No space left on device\n");
 }
+
+// `-q` took a separate branch that printed with `println!`, which aborts the
+// process on a write error instead of reporting it (#13388).
+#[cfg(target_os = "linux")]
+#[test]
+fn test_short_list_piped_to_dev_full() {
+    let ts = TestScenario::new(util_name!());
+
+    let dev_full = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .unwrap();
+
+    ts.ucmd()
+        .arg("-q")
+        .set_stdout(dev_full)
+        .fails()
+        .stderr_is("who: No space left on device\n");
+}


### PR DESCRIPTION
Fixes #13388

## Problem

The `-q` (`--count`) branch printed both the user list and the count with `println!`, which panics when the write fails, so `who -q > /dev/full` aborted instead of reporting the error.

Every other print in `src/uu/who/src/platform/unix.rs` already goes through `writeln!(stdout(), ...)?` and lets `exec()` surface the error, so `-q` was the only path left that could still abort.

## Fix

Use the same pattern for both lines. No new imports, `stdout` and `Write` were already in scope.

## Verification

`/dev/full` is Linux-only, so I reproduced a real `ENOSPC` on macOS with a filled 512 KB RAM disk and compared binaries built from the same tree:

| binary | exit | stderr |
| --- | --- | --- |
| before | 101 (panic; 134 with `panic=abort`) | `failed printing to stdout: No space left on device` |
| after | 1 | `who: No space left on device` |
| `--heading` (untouched control) | 1 | `who: No space left on device` |

So `-q` now behaves exactly like the path that already worked.

Added `test_short_list_piped_to_dev_full`, mirroring the existing `test_piped_to_dev_full`. It is `#[cfg(target_os = "linux")]` like its neighbour, so **CI is what actually exercises it** — locally I confirmed it compiles and runs by temporarily lifting the gate, after which it fails only because macOS has no `/dev/full`.

`cargo build`, `cargo clippy --all-targets` and `cargo fmt --check` are clean for `uu_who`, and the 10 runnable `who` tests pass locally.
