### PR TITLE
uname: move label separators into locale strings for -A/--all-labeled

### DIFF
--- a/src/uu/uname/locales/en-US.ftl
+++ b/src/uu/uname/locales/en-US.ftl
@@ -21,11 +21,12 @@ uname-help-hardware-platform = print the hardware platform (non-portable)
 uname-help-all-labeled = like -a, print all information but one item per line, labeled.
 
 # Labels for --all-labeled
-uname-label-kernel-name = Kernel name
-uname-label-nodename = Node name
-uname-label-kernel-release = Kernel release
-uname-label-kernel-version = Kernel version
-uname-label-machine = Machine
-uname-label-processor = Processor
-uname-label-hardware-platform = Hardware platform
-uname-label-os = Operating system
+# Labels for --all-labeled; { $value } is the system-provided field value.
+uname-label-kernel-name = Kernel name: { $value }
+uname-label-nodename = Node name: { $value }
+uname-label-kernel-release = Kernel release: { $value }
+uname-label-kernel-version = Kernel version: { $value }
+uname-label-machine = Machine: { $value }
+uname-label-processor = Processor: { $value }
+uname-label-hardware-platform = Hardware platform: { $value }
+uname-label-os = Operating system: { $value }

--- a/src/uu/uname/locales/fr-FR.ftl
+++ b/src/uu/uname/locales/fr-FR.ftl
@@ -21,11 +21,11 @@ uname-help-hardware-platform = affiche la plateforme matérielle (non portable)
 uname-help-all-labeled = comme -a, affiche toutes les informations mais une par ligne, avec étiquette.
 
 # Étiquettes pour --all-labeled
-uname-label-kernel-name = Nom du noyau
-uname-label-nodename = Nom du nœud
-uname-label-kernel-release = Version du noyau
-uname-label-kernel-version = Version détaillée du noyau
-uname-label-machine = Machine
-uname-label-processor = Processeur
-uname-label-hardware-platform = Plateforme matérielle
-uname-label-os = Système d'exploitation
+uname-label-kernel-name = Nom du noyau : { $value }
+uname-label-nodename = Nom du nœud : { $value }
+uname-label-kernel-release = Version du noyau : { $value }
+uname-label-kernel-version = Version détaillée du noyau : { $value }
+uname-label-machine = Machine : { $value }
+uname-label-processor = Processeur : { $value }
+uname-label-hardware-platform = Plateforme matérielle : { $value }
+uname-label-os = Système d'exploitation : { $value }

--- a/src/uu/uname/src/uname.rs
+++ b/src/uu/uname/src/uname.rs
@@ -75,9 +75,9 @@ impl UNameOutput {
             ("uname-label-os", self.os.as_ref()),
         ] {
             let Some(value) = value else { continue };
-            out.push(translate!(label));
-            out.push(": ");
-            out.push(value);
+            out.push(OsStr::new(
+                &translate!(label, "value" => value.to_string_lossy()),
+            ));
             out.push("\n");
         }
         out


### PR DESCRIPTION
The hard-coded ": " separator in display_labeled() prevents translators from adapting punctuation to their locale. For example, French typography requires a non-breaking space before the colon ("Étiquette\u00a0: value") rather than the English style ("Label: value").
