### PR TITLE
du: warm OS page cache before timing in benchmarks

### DIFF
--- a/src/uu/du/benches/du_bench.rs
+++ b/src/uu/du/benches/du_bench.rs
@@ -59,12 +59,18 @@ fn du_human_balanced_tree(
 }
 */
 
-/// Benchmark du on wide directory structures (many files/dirs, shallow)
+/// Run a throwaway traversal to warm the OS page/inode cache before timing.
+fn warm_cache(path: &std::path::Path) {
+    let _ = black_box(uumain(get_bench_args(&[&path]).into_iter()));
+}
+
+/// Benchmark du on wide directory structures (many files/dirs, shallow).
 #[divan::bench(args = [(5000, 500)])]
 fn du_wide_tree(bencher: Bencher, (total_files, total_dirs): (usize, usize)) {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();
     fs_tree::create_wide_tree(temp_path, total_files, total_dirs);
+    warm_cache(temp_path);
 
     bencher
         .with_inputs(|| get_bench_args(&[&temp_path]).into_iter())
@@ -77,6 +83,7 @@ fn du_all_wide_tree(bencher: Bencher, (total_files, total_dirs): (usize, usize))
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();
     fs_tree::create_wide_tree(temp_path, total_files, total_dirs);
+    warm_cache(temp_path);
 
     bencher
         .with_inputs(|| get_bench_args(&[&"-a", &temp_path]).into_iter())
@@ -89,6 +96,7 @@ fn du_deep_tree(bencher: Bencher, (depth, files_per_level): (usize, usize)) {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();
     fs_tree::create_deep_tree(temp_path, depth, files_per_level);
+    warm_cache(temp_path);
 
     bencher
         .with_inputs(|| get_bench_args(&[&temp_path]).into_iter())
@@ -104,6 +112,7 @@ fn du_summarize_balanced_tree(
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();
     fs_tree::create_balanced_tree(temp_path, depth, dirs_per_level, files_per_dir);
+    warm_cache(temp_path);
 
     bencher
         .with_inputs(|| get_bench_args(&[&"-s", &temp_path]).into_iter())


### PR DESCRIPTION
First iterations run cold (page cache empty) and subsequent ones hot, creating a bimodal distribution and spurious CI regression alerts. Add warm_cache() to run one untimed traversal before measurement starts.