### PR TITLE
docs: remove `-w` flag of `cut` from the extensions

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -60,11 +60,6 @@ coreutils. We do not aim for full compatibility with the `more` utility from
 `util-linux`. Features from more modern pagers (like `less` and `bat`) are
 therefore welcomed.
 
-## `cut`
-
-`cut` can separate fields by whitespace (Space and Tab) with `-w` flag. This
-feature is adopted from [FreeBSD](https://www.freebsd.org/cgi/man.cgi?cut).
-
 ## `fmt`
 
 `fmt` has additional flags for prefixes: `-P`/`--skip-prefix`, `-x`/`--exact-prefix`, and


### PR DESCRIPTION
The `-w` flag of `cut` is no longer an extension but a regular flag, and so this PR removes it from the extensions list.