### PR TITLE
cp: use default suffix when backup suffix is empty

### DIFF
--- a/src/uucore/src/lib/features/backup_control.rs
+++ b/src/uucore/src/lib/features/backup_control.rs
@@ -246,7 +246,7 @@ pub mod arguments {
 ///
 /// 1. From the '-S' or '--suffix' CLI argument, if present
 /// 2. From the "SIMPLE_BACKUP_SUFFIX" environment variable, if present
-/// 3. By using the default '~' if none of the others apply, or if they contained slashes
+/// 3. By using the default '~' if none of the others apply, or if they are empty or contain slashes
 ///
 /// This function directly takes [`ArgMatches`] as argument and looks for
 /// the '-S' and '--suffix' arguments itself.
@@ -257,7 +257,7 @@ pub fn determine_backup_suffix(matches: &ArgMatches) -> String {
     } else {
         env::var("SIMPLE_BACKUP_SUFFIX").unwrap_or_else(|_| DEFAULT_BACKUP_SUFFIX.to_owned())
     };
-    if suffix.contains('/') {
+    if suffix.is_empty() || suffix.contains('/') {
         DEFAULT_BACKUP_SUFFIX.to_owned()
     } else {
         suffix

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1211,6 +1211,26 @@ fn test_cp_arg_suffix_without_backup_option() {
 }
 
 #[test]
+fn test_cp_empty_backup_suffix_uses_default() {
+    for backup_arg in ["--backup=nil", "--backup"] {
+        let (at, mut ucmd) = at_and_ucmd!();
+
+        ucmd.arg(backup_arg)
+            .arg("--suffix=")
+            .arg(TEST_HELLO_WORLD_SOURCE)
+            .arg(TEST_HOW_ARE_YOU_SOURCE)
+            .succeeds()
+            .no_stderr();
+
+        assert_eq!(at.read(TEST_HOW_ARE_YOU_SOURCE), "Hello, World!\n");
+        assert_eq!(
+            at.read(&format!("{TEST_HOW_ARE_YOU_SOURCE}~")),
+            "How are you?\n"
+        );
+    }
+}
+
+#[test]
 fn test_cp_arg_suffix_hyphen_value() {
     let (at, mut ucmd) = at_and_ucmd!();
 


### PR DESCRIPTION
Fixes #13143

Treat an empty backup suffix as the default `~`. Add regression coverage for `--backup=nil` and bare `--backup` with `--suffix=`.