### PR TITLE
test(comm): enable --check-order/--nocheck-order order-checking tests

### DIFF
--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -309,7 +309,6 @@ fn zero_terminated_with_total() {
     }
 }
 
-#[ignore = "not implemented"]
 #[test]
 fn check_order() {
     let scene = TestScenario::new(util_name!());
@@ -320,36 +319,42 @@ fn check_order() {
         .ucmd()
         .args(&["--check-order", "bad_order_1", "bad_order_2"])
         .fails()
-        .stdout_is("\t\te")
-        .stderr_is("error to be defined");
+        .stdout_is("\t\te\n")
+        .stderr_is("comm: file 2 is not in sorted order\n");
 }
 
-#[ignore = "not implemented"]
 #[test]
 fn nocheck_order() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
     at.write("bad_order_1", "e\nd\nb\na\n");
     at.write("bad_order_2", "e\nc\nb\na\n");
-    new_ucmd!()
+    scene
+        .ucmd()
         .args(&["--nocheck-order", "bad_order_1", "bad_order_2"])
         .succeeds()
-        .stdout_is("\t\te\n\tc\n\tb\n\ta\nd\nb\na\n");
+        .stdout_is("\t\te\n\tc\n\tb\n\ta\nd\nb\na\n")
+        .no_stderr();
 }
 
 // when neither --check-order nor --no-check-order is provided,
 // stderr and the error code behaves like check order, but stdout
 // behaves like nocheck_order. However with some quirks detailed below.
-#[ignore = "not implemented"]
 #[test]
 fn defaultcheck_order() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
+    at.write("a", "a\n");
     at.write("bad_order_1", "e\nd\nb\na\n");
-    new_ucmd!()
+    scene
+        .ucmd()
         .args(&["a", "bad_order_1"])
         .fails()
-        .stderr_only("error to be defined");
+        .stdout_is("a\n\te\n\td\n\tb\n\ta\n")
+        .stderr_is(
+            "comm: file 2 is not in sorted order\n\
+             comm: input is not in sorted order\n",
+        );
 }
 
 // * the first: if both files are not in order, the default behavior is the only


### PR DESCRIPTION
## Summary

The three order-checking tests for `comm` in `tests/by-util/test_comm.rs` (`check_order`, `nocheck_order`, `defaultcheck_order`) were disabled with `#[ignore = "not implemented"]` and contained placeholder assertions (`"error to be defined"`) and fixtures that were never written — even though the implementation (`src/uu/comm/src/comm.rs`, flags `CHECK_ORDER`/`NO_CHECK_ORDER` via `OrderChecker`) fully supports `--check-order`, `--nocheck-order`, and default order checking.

This change completes the fixtures (real file writes via the test scene), replaces the placeholder assertions with expected output captured from the actual binary, and enables the three tests.

## Type

Test-only, additive change. No source code, behavior, or dependency changes. Single file changed: `tests/by-util/test_comm.rs` (+14/−9).

## Testing

- `cargo test --package coreutils --test tests -- comm::` → `test result: ok. 43 passed; 0 failed; 1 ignored; 0 measured; 4934 filtered out; finished in 0.03s` — the three previously-ignored order-checking tests now run and pass.
- `cargo fmt --check` → clean
- `git diff --check` → clean
- Rebased onto `upstream/main` → up to date, no conflicts.

The single remaining ignored test (`output_delimiter_multiple_different_prevents_help`) is a pre-existing, deliberate deviation and is unchanged by this PR.

**AI disclosure:** This contribution was prepared with the assistance of AI tools and was human-reviewed before submission. The author understands and can explain the change.
