### PR TITLE
cut: allow shortcuts for `--whitespace-delimited`

### DIFF
--- a/src/uu/cut/Cargo.toml
+++ b/src/uu/cut/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["ranges", "i18n-charmap"] }
+uucore = { workspace = true, features = ["i18n-charmap", "parser", "ranges"] }
 memchr = { workspace = true }
 bstr = { workspace = true }
 fluent = { workspace = true }

--- a/src/uu/cut/src/cut.rs
+++ b/src/uu/cut/src/cut.rs
@@ -6,7 +6,8 @@
 // spell-checker:ignore (ToDO) delim foxjumping sourcefiles undelimited xacfoxjumping
 
 use bstr::io::BufReadExt;
-use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser};
+use clap::builder::{PossibleValue, ValueParser};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, IsTerminal, Read, Write, stdin, stdout};
@@ -16,6 +17,7 @@ use uucore::error::{FromIo, UResult, USimpleError, UUsageError, set_exit_code};
 use uucore::i18n::charmap::{Encoding, locale_encoding, mb_char_len};
 use uucore::line_ending::LineEnding;
 use uucore::os_str_as_bytes;
+use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 
 use self::searcher::Searcher;
 use matcher::{ExactMatcher, Matcher, MbExactMatcher, WhitespaceMatcher};
@@ -946,9 +948,7 @@ where
 /// Get delimiter and output delimiter from `-d`/`--delimiter` and `--output-delimiter` options respectively
 /// Allow either delimiter to have a value that is neither UTF-8 nor ASCII to align with GNU behavior
 fn get_delimiters(matches: &ArgMatches) -> UResult<(Delimiter<'_>, Option<&[u8]>)> {
-    let whitespace_delimited = matches
-        .get_one::<String>(options::WHITESPACE_DELIMITED)
-        .is_some();
+    let whitespace_delimited = matches.contains_id(options::WHITESPACE_DELIMITED);
     let delim_opt = matches.get_one::<OsString>(options::DELIMITER);
     let delim = match delim_opt {
         Some(_) if whitespace_delimited => {
@@ -1038,7 +1038,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // `--whitespace-delimited[=trimmed]` (`-w`): the optional value selects trimming.
     let whitespace_trimmed = matches
         .get_one::<String>(options::WHITESPACE_DELIMITED)
-        .is_some_and(|value| value == "trimmed");
+        .is_some();
 
     let mode_arg = get_mode_arg(&matches)?;
     let list = matches
@@ -1152,9 +1152,7 @@ fn get_mode_arg(matches: &ArgMatches) -> UResult<&str> {
             ),
             (
                 // GNU words `-w` as a delimiter too, so it shares the message.
-                matches
-                    .get_one::<String>(options::WHITESPACE_DELIMITED)
-                    .is_some(),
+                matches.contains_id(options::WHITESPACE_DELIMITED),
                 "cut-error-delimiter-only-with-fields",
             ),
             (
@@ -1221,10 +1219,9 @@ pub fn uu_app() -> Command {
                 .long(options::WHITESPACE_DELIMITED)
                 .help(translate!("cut-help-whitespace-delimited"))
                 .value_name("trimmed")
-                .value_parser(["", "trimmed"])
+                .value_parser(ShortcutValueParser::new([PossibleValue::new("trimmed")]))
                 .num_args(0..=1)
                 .require_equals(true)
-                .default_missing_value("")
                 .action(ArgAction::Set),
         )
         .arg(

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -721,12 +721,15 @@ fn test_whitespace_delimited_long_and_trimmed() {
         .pipe_in("   alpha beta\n")
         .succeeds()
         .stdout_only("\talpha\n");
-    // =trimmed strips leading/trailing blanks before splitting.
-    new_ucmd!()
-        .args(&["--whitespace-delimited=trimmed", "-f1,2"])
-        .pipe_in("  hello world  \n")
-        .succeeds()
-        .stdout_only("hello\tworld\n");
+    // =trimmed (or it's shortcuts) strips leading/trailing blanks before splitting.
+    for trimmed in ["trimmed", "tri", ""] {
+        new_ucmd!()
+            .arg(format!("--whitespace-delimited={trimmed}"))
+            .arg("-f1,2")
+            .pipe_in("  hello world  \n")
+            .succeeds()
+            .stdout_only("hello\tworld\n");
+    }
     // With -s a single (undelimited) field is suppressed.
     new_ucmd!()
         .args(&["-s", "--whitespace-delimited=trimmed", "-f1"])


### PR DESCRIPTION
GNU `cut` supports shortcuts of the `trimmed` value for `--whitespace-delimited`, including an empty string, whereas we only supported `trimmed`.

This PR uses the `ShortcutValueParser` to support the same behavior.