### PR TITLE
Add empty-backup-suffix.sh to backport list

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -8,6 +8,7 @@ backport=(
   cat/splice.sh # split tests
   misc/uname-labeled.sh # uname -A/--all-labeled, added after $ver
   nproc/nproc-quota.sh # remove LD_PRELOAD
+  misc/empty-backup-suffix.sh
 )
 for f in "${backport[@]}"
   do curl -L ${repo}/raw/refs/heads/master/tests/$f > tests/$f


### PR DESCRIPTION
probably related to 
https://github.com/uutils/coreutils/pull/13966