### PR TITLE
stat: preserve nanosecond timestamp precision

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -28,6 +28,7 @@ use std::fs::{FileType, Metadata};
 use std::io::{self, Write};
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, fs};
 
 use thiserror::Error;
@@ -174,7 +175,7 @@ pub enum OutputType<'a> {
     Unsigned(u64),
     UnsignedHex(u64),
     UnsignedOct(u32),
-    Float(f64),
+    Timestamp(i64, u32),
     Unknown,
 }
 
@@ -372,8 +373,15 @@ fn print_it(output: &OutputType, flags: Flags, width: usize, precision: Precisio
         OutputType::UnsignedHex(num) => {
             print_unsigned_hex(*num, flags, width, precision, padding_char);
         }
-        OutputType::Float(num) => {
-            print_float(*num, flags, width, precision, padding_char);
+        OutputType::Timestamp(seconds, nanoseconds) => {
+            print_timestamp(
+                *seconds,
+                *nanoseconds,
+                flags,
+                width,
+                precision,
+                padding_char,
+            );
         }
         OutputType::Unknown => print!("?"),
     }
@@ -589,47 +597,55 @@ fn print_integer(
     pad_and_print(&extended, flags.left, width, padding_char);
 }
 
-/// Truncate a float to the given number of digits after the decimal point.
-fn precision_trunc(num: f64, precision: Precision) -> String {
-    // GNU `stat` doesn't round, it just seems to truncate to the
-    // given precision:
-    //
-    //     $ stat -c "%.5Y" /dev/pts/ptmx
-    //     1736344012.76399
-    //     $ stat -c "%.4Y" /dev/pts/ptmx
-    //     1736344012.7639
-    //     $ stat -c "%.3Y" /dev/pts/ptmx
-    //     1736344012.763
-    //
-    // Contrast this with `printf`, which seems to round the
-    // numbers:
-    //
-    //     $ printf "%.5f\n" 1736344012.76399
-    //     1736344012.76399
-    //     $ printf "%.4f\n" 1736344012.76399
-    //     1736344012.7640
-    //     $ printf "%.3f\n" 1736344012.76399
-    //     1736344012.764
-    //
-    let num_str = num.to_string();
-    let n = num_str.len();
-    match (num_str.find('.'), precision) {
-        (None, Precision::NotSpecified)
-        | (None, Precision::NoNumber)
-        | (None, Precision::Number(0))
-        | (Some(_), Precision::NoNumber) => num_str,
-        (None, Precision::Number(p)) => format!("{num_str}.{zeros}", zeros = "0".repeat(p)),
-        (Some(i), Precision::NotSpecified) | (Some(i), Precision::Number(0)) => {
-            num_str[..i].to_string()
-        }
-        (Some(i), Precision::Number(p)) if p < n - i => num_str[..i + 1 + p].to_string(),
-        (Some(i), Precision::Number(p)) => {
-            format!("{num_str}{zeros}", zeros = "0".repeat(p - (n - i - 1)))
-        }
+fn format_timestamp(seconds: i64, nanoseconds: u32, precision: Precision) -> String {
+    let precision = match precision {
+        Precision::NotSpecified => return seconds.to_string(),
+        Precision::NoNumber => 9,
+        Precision::Number(p) => p,
+    };
+
+    let total_nanoseconds = i128::from(seconds) * 1_000_000_000 + i128::from(nanoseconds);
+    if precision <= 9 {
+        let divisor = 10_i128.pow((9 - precision) as u32);
+        let value = total_nanoseconds.div_euclid(divisor);
+        format_scaled_decimal(value, precision)
+    } else {
+        let mut result = format_scaled_decimal(total_nanoseconds, 9);
+        result.push_str(&"0".repeat(precision - 9));
+        result
     }
 }
 
-fn print_float(num: f64, flags: Flags, width: usize, precision: Precision, padding_char: Padding) {
+fn system_time_to_timestamp(time: SystemTime) -> (i64, u32) {
+    let (mut seconds, mut nanoseconds) = system_time_to_sec(time);
+    if time < UNIX_EPOCH && nanoseconds != 0 {
+        seconds -= 1;
+        nanoseconds = 1_000_000_000 - nanoseconds;
+    }
+    (seconds, nanoseconds)
+}
+
+fn format_scaled_decimal(value: i128, precision: usize) -> String {
+    if precision == 0 {
+        return value.to_string();
+    }
+
+    let scale = 10_u128.pow(precision as u32);
+    let magnitude = value.unsigned_abs();
+    let whole = magnitude / scale;
+    let fraction = magnitude % scale;
+    let sign = if value < 0 { "-" } else { "" };
+    format!("{sign}{whole}.{fraction:0>precision$}")
+}
+
+fn print_timestamp(
+    seconds: i64,
+    nanoseconds: u32,
+    flags: Flags,
+    width: usize,
+    precision: Precision,
+    padding_char: Padding,
+) {
     let prefix = if flags.sign {
         "+"
     } else if flags.space {
@@ -637,7 +653,7 @@ fn print_float(num: f64, flags: Flags, width: usize, precision: Precision, paddi
     } else {
         ""
     };
-    let num_str = precision_trunc(num, precision);
+    let num_str = format_timestamp(seconds, nanoseconds, precision);
     let extended = format!("{prefix}{num_str}");
     pad_and_print(&extended, flags.left, width, padding_char);
 }
@@ -1171,7 +1187,7 @@ impl Stater {
                     // time of file birth, seconds since Epoch; 0 if unknown
                     'W' => OutputType::Integer(
                         metadata_get_time(meta, MetadataTimeField::Birth)
-                            .map_or(0, |x| system_time_to_sec(x).0),
+                            .map_or(0, |x| system_time_to_timestamp(x).0),
                     ),
 
                     // time of last access, human-readable
@@ -1179,24 +1195,24 @@ impl Stater {
                     // time of last access, seconds since Epoch
                     'X' => {
                         let (sec, nsec) = metadata_get_time(meta, MetadataTimeField::Access)
-                            .map_or((0, 0), system_time_to_sec);
-                        OutputType::Float(sec as f64 + nsec as f64 / 1_000_000_000.0)
+                            .map_or((0, 0), system_time_to_timestamp);
+                        OutputType::Timestamp(sec, nsec)
                     }
                     // time of last data modification, human-readable
                     'y' => OutputType::Str(pretty_time(meta, MetadataTimeField::Modification)),
                     // time of last data modification, seconds since Epoch
                     'Y' => {
                         let (sec, nsec) = metadata_get_time(meta, MetadataTimeField::Modification)
-                            .map_or((0, 0), system_time_to_sec);
-                        OutputType::Float(sec as f64 + nsec as f64 / 1_000_000_000.0)
+                            .map_or((0, 0), system_time_to_timestamp);
+                        OutputType::Timestamp(sec, nsec)
                     }
                     // time of last status change, human-readable
                     'z' => OutputType::Str(pretty_time(meta, MetadataTimeField::Change)),
                     // time of last status change, seconds since Epoch
                     'Z' => {
                         let (sec, nsec) = metadata_get_time(meta, MetadataTimeField::Change)
-                            .map_or((0, 0), system_time_to_sec);
-                        OutputType::Float(sec as f64 + nsec as f64 / 1_000_000_000.0)
+                            .map_or((0, 0), system_time_to_timestamp);
+                        OutputType::Timestamp(sec, nsec)
                     }
                     'R' => OutputType::UnsignedHex(meta.rdev()),
                     'r' if flag.major => OutputType::Unsigned(major(meta.rdev() as _) as u64),
@@ -1447,7 +1463,7 @@ fn pretty_time(meta: &Metadata, md_time_field: MetadataTimeField) -> String {
 mod tests {
     use crate::{quote_file_name, write_padded_bytes, write_padding};
 
-    use super::{Flags, Precision, ScanUtil, Stater, Token, group_num, precision_trunc};
+    use super::{Flags, Precision, ScanUtil, Stater, Token, format_timestamp, group_num};
 
     #[test]
     fn test_scanners() {
@@ -1558,15 +1574,42 @@ mod tests {
     }
 
     #[test]
-    fn test_precision_trunc() {
-        assert_eq!(precision_trunc(123.456, Precision::NotSpecified), "123");
-        assert_eq!(precision_trunc(123.456, Precision::NoNumber), "123.456");
-        assert_eq!(precision_trunc(123.456, Precision::Number(0)), "123");
-        assert_eq!(precision_trunc(123.456, Precision::Number(1)), "123.4");
-        assert_eq!(precision_trunc(123.456, Precision::Number(2)), "123.45");
-        assert_eq!(precision_trunc(123.456, Precision::Number(3)), "123.456");
-        assert_eq!(precision_trunc(123.456, Precision::Number(4)), "123.4560");
-        assert_eq!(precision_trunc(123.456, Precision::Number(5)), "123.45600");
+    fn test_format_timestamp() {
+        let cases = [
+            (Precision::NotSpecified, "123"),
+            (Precision::NoNumber, "123.456000000"),
+            (Precision::Number(0), "123"),
+            (Precision::Number(1), "123.4"),
+            (Precision::Number(2), "123.45"),
+            (Precision::Number(3), "123.456"),
+            (Precision::Number(4), "123.4560"),
+            (Precision::Number(5), "123.45600"),
+        ];
+        for (precision, expected) in cases {
+            assert_eq!(format_timestamp(123, 456_000_000, precision), expected);
+        }
+
+        let zero_nanoseconds_cases = [
+            (Precision::NotSpecified, "123"),
+            (Precision::NoNumber, "123.000000000"),
+            (Precision::Number(9), "123.000000000"),
+        ];
+        for (precision, expected) in zero_nanoseconds_cases {
+            assert_eq!(format_timestamp(123, 0, precision), expected);
+        }
+
+        let pre_epoch_cases = [
+            (Precision::NotSpecified, "-1"),
+            (Precision::NoNumber, "-0.876543211"),
+            (Precision::Number(0), "-1"),
+            (Precision::Number(1), "-0.9"),
+            (Precision::Number(3), "-0.877"),
+            (Precision::Number(9), "-0.876543211"),
+            (Precision::Number(10), "-0.8765432110"),
+        ];
+        for (precision, expected) in pre_epoch_cases {
+            assert_eq!(format_timestamp(-1, 123_456_789, precision), expected);
+        }
     }
 
     #[test]

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -11,8 +11,9 @@ use uutests::unwrap_or_return;
 use uutests::util::{TestScenario, expected_result};
 use uutests::util_name;
 
-use std::fs::metadata;
+use std::fs::{File, FileTimes, metadata};
 use std::os::unix::fs::MetadataExt;
+use std::time::{Duration, UNIX_EPOCH};
 
 #[test]
 fn test_invalid_arg() {
@@ -200,12 +201,6 @@ fn test_char() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_printf_atime_ctime_mtime_precision() {
-    // TODO Higher precision numbers (`%.3Y`, `%.4Y`, etc.) are
-    // formatted correctly, but we are not precise enough when we do
-    // some `mtime` computations, so we get `.7640` instead of
-    // `.7639`. This can be fixed by being more careful when
-    // transforming the number from `Metadata::mtime_nsec()` to the form
-    // used in rendering.
     let args = ["-c", "%.0Y %.1Y %.2X %.2Y %.2Z", "/dev/pts/ptmx"];
     let ts = TestScenario::new(util_name!());
     let expected_stdout = unwrap_or_return!(expected_result(&ts, &args)).stdout_move_str();
@@ -256,6 +251,53 @@ fn test_timestamp_format() {
             "Format '{format_str}' failed.\nExpected: '{expected}'\nGot: '{result}'",
         );
     }
+}
+
+#[test]
+fn test_timestamp_format_preserves_nanoseconds() {
+    let ts = TestScenario::new(util_name!());
+    let path = ts.fixtures.plus("timestamp");
+    let file = File::create(&path).unwrap();
+
+    let timestamp = UNIX_EPOCH + Duration::new(1_755_300_000, 123_456_789);
+    file.set_times(
+        FileTimes::new()
+            .set_accessed(timestamp)
+            .set_modified(timestamp),
+    )
+    .unwrap();
+
+    let metadata = metadata(&path).unwrap();
+    let expected = format!(
+        "1755300000.123456789 1755300000.123456789 {}.{:09}\n",
+        metadata.ctime(),
+        metadata.ctime_nsec()
+    );
+
+    ts.ucmd()
+        .args(&["-c", "%.9X %.9Y %.9Z", "timestamp"])
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
+fn test_timestamp_format_before_epoch() {
+    let ts = TestScenario::new(util_name!());
+    let path = ts.fixtures.plus("timestamp");
+    let file = File::create(&path).unwrap();
+
+    let timestamp = UNIX_EPOCH - Duration::new(0, 876_543_211);
+    file.set_times(
+        FileTimes::new()
+            .set_accessed(timestamp)
+            .set_modified(timestamp),
+    )
+    .unwrap();
+
+    ts.ucmd()
+        .args(&["-c", "%.1X %.3X %.9X %.1Y %.3Y %.9Y", "timestamp"])
+        .succeeds()
+        .stdout_is("-0.9 -0.877 -0.876543211 -0.9 -0.877 -0.876543211\n");
 }
 
 #[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
@@ -411,7 +453,7 @@ fn test_stdin_redirect() {
     at.touch("f");
     ts.ucmd()
         .arg("-")
-        .set_stdin(std::fs::File::open(at.plus("f")).unwrap())
+        .set_stdin(File::open(at.plus("f")).unwrap())
         .succeeds()
         .no_stderr()
         .stdout_contains("regular empty file")


### PR DESCRIPTION
For the affected %X, %Y, and %Z directives, GNU stat treats the precision as the exact number of digits after the decimal point. With no precision, %Y prints integer epoch seconds. %.Y is equivalent to %.9Y, %.3Y prints milliseconds, and precisions above nine append zeroes. When discarding digits, stat truncates the timestamp toward minus infinity.

uutils converted the seconds and nanoseconds to f64 before applying these rules. A binary64 value has 53 bits of precision. At epoch second 1755300000, adjacent values are 2^-22 seconds apart, or about 238.4 nanoseconds. The timestamp 1755300000.123456789 therefore rounds to approximately 1755300000.123456716537 before formatting. Its shortest decimal representation is 1755300000.1234567, which the old formatter zero-extended to 1755300000.123456700 for %.9Y. The precision flag cannot recover bits already discarded by the f64 conversion.

Keep the timestamp as an integer nanosecond count while applying decimal precision. Euclidean division provides GNU's floor truncation for both positive and pre-Epoch timestamps; integer formatting preserves all nine nanosecond digits and zero-extends higher precisions.

Add regressions for modern timestamps, bare-dot precision, and pre-Epoch truncation.