### PR TITLE
cut, dd: use plain text help headings

### DIFF
--- a/src/uu/cut/locales/en-US.ftl
+++ b/src/uu/cut/locales/en-US.ftl
@@ -3,7 +3,7 @@ cut-usage = cut OPTION... [FILE]...
 cut-after-help = Each call must specify a mode (what to use for columns),
   a sequence (which columns to print), and provide a data source
 
-  ### Specifying a mode
+  Specifying a mode:
 
   Use --bytes (-b) or --characters (-c) to specify byte mode
 
@@ -11,7 +11,7 @@ cut-after-help = Each call must specify a mode (what to use for columns),
   fields identified by a delimiter character. For example for a typical CSV
   you could use this in combination with setting comma as the delimiter
 
-  ### Specifying a sequence
+  Specifying a sequence:
 
   A sequence is a group of 1 or more numbers or inclusive ranges separated
   by a commas.
@@ -40,7 +40,7 @@ cut-after-help = Each call must specify a mode (what to use for columns),
 
   will display the every field but the 4th, 5th, and 6th
 
-  ### Specifying a data source
+  Specifying a data source:
 
   If no sourcefile arguments are specified, stdin is used as the source of
   lines to print
@@ -53,11 +53,11 @@ cut-after-help = Each call must specify a mode (what to use for columns),
   To print columns from both STDIN and a file argument, use - (dash) as a
   sourcefile argument to represent stdin.
 
-  ### Field Mode options
+  Field mode options:
 
   The fields in each line are identified by a delimiter (separator)
 
-  #### Set the delimiter
+  Set the delimiter:
 
   Set the delimiter which separates fields in the file using the
   --delimiter (-d) option. Setting the delimiter is optional.
@@ -68,19 +68,19 @@ cut-after-help = Each call must specify a mode (what to use for columns),
   be a Tab unless explicitly specified. Only one of -d or -w option can be specified.
   This is an extension adopted from FreeBSD.
 
-  #### Optionally Filter based on delimiter
+  Optionally filter based on delimiter:
 
   If the --only-delimited (-s) flag is provided, only lines which
   contain the delimiter will be printed
 
-  #### Replace the delimiter
+  Replace the delimiter:
 
   If the --output-delimiter option is provided, the argument used for
   it will replace the delimiter character in each line printed. This is
   useful for transforming tabular data - e.g. to convert a CSV to a
   TSV (tab-separated file)
 
-  ### Line endings
+  Line endings:
 
   When the --zero-terminated (-z) option is used, cut sees \\0 (null) as the
   'line ending' character (both for the purposes of reading lines and

--- a/src/uu/cut/locales/fr-FR.ftl
+++ b/src/uu/cut/locales/fr-FR.ftl
@@ -3,7 +3,7 @@ cut-usage = cut OPTION... [FICHIER]...
 cut-after-help = Chaque appel doit spécifier un mode (quoi utiliser pour les colonnes),
   une séquence (quelles colonnes afficher), et fournir une source de données
 
-  ### Spécifier un mode
+  Spécifier un mode :
 
   Utilisez --bytes (-b) ou --characters (-c) pour spécifier le mode octet
 
@@ -11,7 +11,7 @@ cut-after-help = Chaque appel doit spécifier un mode (quoi utiliser pour les co
   champs identifiés par un caractère délimiteur. Par exemple pour un CSV typique
   vous pourriez utiliser ceci en combinaison avec la définition de la virgule comme délimiteur
 
-  ### Spécifier une séquence
+  Spécifier une séquence :
 
   Une séquence est un groupe de 1 ou plusieurs nombres ou plages inclusives séparés
   par des virgules.
@@ -40,7 +40,7 @@ cut-after-help = Chaque appel doit spécifier un mode (quoi utiliser pour les co
 
   affichera tous les champs sauf les 4ème, 5ème, et 6ème
 
-  ### Spécifier une source de données
+  Spécifier une source de données :
 
   Si aucun argument de fichier source n'est spécifié, stdin est utilisé comme source
   de lignes à afficher
@@ -53,11 +53,11 @@ cut-after-help = Chaque appel doit spécifier un mode (quoi utiliser pour les co
   Pour afficher les colonnes depuis STDIN et un argument de fichier, utilisez - (tiret) comme
   argument de fichier source pour représenter stdin.
 
-  ### Options du Mode Champ
+  Options du mode champ :
 
   Les champs dans chaque ligne sont identifiés par un délimiteur (séparateur)
 
-  #### Définir le délimiteur
+  Définir le délimiteur :
 
   Définissez le délimiteur qui sépare les champs dans le fichier en utilisant l'option
   --delimiter (-d). Définir le délimiteur est optionnel.
@@ -68,19 +68,19 @@ cut-after-help = Chaque appel doit spécifier un mode (quoi utiliser pour les co
   un Tab sauf si explicitement spécifié. Seulement une des options -d ou -w peut être spécifiée.
   Ceci est une extension adoptée de FreeBSD.
 
-  #### Filtrage optionnel basé sur le délimiteur
+  Filtrage optionnel basé sur le délimiteur :
 
   Si l'option --only-delimited (-s) est fournie, seules les lignes qui
   contiennent le délimiteur seront affichées
 
-  #### Remplacer le délimiteur
+  Remplacer le délimiteur :
 
   Si l'option --output-delimiter est fournie, l'argument utilisé pour
   elle remplacera le caractère délimiteur dans chaque ligne affichée. Ceci est
   utile pour transformer les données tabulaires - par ex. pour convertir un CSV en
   TSV (fichier séparé par tabulations)
 
-  ### Fins de ligne
+  Fins de ligne :
 
   Quand l'option --zero-terminated (-z) est utilisée, cut voit \\0 (null) comme le
   caractère de 'fin de ligne' (à la fois pour lire les lignes et

--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -1,7 +1,7 @@
 dd-about = Copy, and optionally convert, a file system resource
 dd-usage = dd [OPERAND]...
   dd OPTION
-dd-after-help = ### Operands
+dd-after-help = Operands:
 
   - bs=BYTES : read and write up to BYTES bytes at a time (default: 512);
      overwrites ibs and obs.
@@ -33,7 +33,6 @@ dd-after-help = ### Operands
 
     When unspecified, dd will print stats upon completion. An example is below.
 
-    ```plain
       6+0 records in
       16+0 records out
       8192 bytes (8.2 kB, 8.0 KiB) copied, 0.00057009 s,
@@ -55,7 +54,7 @@ dd-after-help = ### Operands
     or the USR1 signal. Setting the POSIXLY_CORRECT environment variable to any value
     (including an empty value) will cause the USR1 signal to be ignored.
 
-  ### Conversion Options
+  Conversion options:
 
   - ascii : convert from EBCDIC to ASCII. This is the inverse of the ebcdic
     option. Implies conv=unblock.
@@ -89,19 +88,19 @@ dd-after-help = ### Operands
   - fdatasync : data will be written before finishing.
   - fsync : data and metadata will be written before finishing.
 
-  ### Input flags
+  Input flags:
 
   - count_bytes : a value to count=N will be interpreted as bytes.
   - skip_bytes : a value to skip=N will be interpreted as bytes.
   - fullblock : wait for ibs bytes from each read. zero-length reads are still
     considered EOF.
 
-  ### Output flags
+  Output flags:
 
   - append : open file in append mode. Consider setting conv=notrunc as well.
   - seek_bytes : a value to seek=N will be interpreted as bytes.
 
-  ### General Flags
+  General flags:
 
   - direct : use direct I/O for data.
   - directory : fail unless the given input (if used as an iflag) or

--- a/src/uu/dd/locales/fr-FR.ftl
+++ b/src/uu/dd/locales/fr-FR.ftl
@@ -1,7 +1,7 @@
 dd-about = Copier, et optionnellement convertir, une ressource du système de fichiers
 dd-usage = dd [OPÉRANDE]...
   dd OPTION
-dd-after-help = ### Opérandes
+dd-after-help = Opérandes :
 
   - bs=OCTETS : lire et écrire jusqu'à OCTETS octets à la fois (par défaut : 512) ;
      remplace ibs et obs.
@@ -33,7 +33,6 @@ dd-after-help = ### Opérandes
 
     Quand non spécifié, dd affichera les statistiques à la fin. Un exemple est ci-dessous.
 
-    ```plain
       6+0 enregistrements en entrée
       16+0 enregistrements en sortie
       8192 octets (8.2 kB, 8.0 KiB) copiés, 0.00057009 s,
@@ -55,7 +54,7 @@ dd-after-help = ### Opérandes
     ou le signal USR1. Définir la variable d'environnement POSIXLY_CORRECT à n'importe quelle valeur
     (y compris une valeur vide) fera ignorer le signal USR1.
 
-  ### Options de conversion
+  Options de conversion :
 
   - ascii : convertir d'EBCDIC vers ASCII. C'est l'inverse de l'option ebcdic.
     Implique conv=unblock.
@@ -89,19 +88,19 @@ dd-after-help = ### Opérandes
   - fdatasync : les données seront écrites avant la fin.
   - fsync : les données et les métadonnées seront écrites avant la fin.
 
-  ### Indicateurs d'entrée
+  Indicateurs d'entrée :
 
   - count_bytes : une valeur pour count=N sera interprétée comme des octets.
   - skip_bytes : une valeur pour skip=N sera interprétée comme des octets.
   - fullblock : attendre ibs octets de chaque lecture. les lectures de longueur zéro sont toujours
     considérées comme EOF.
 
-  ### Indicateurs de sortie
+  Indicateurs de sortie :
 
   - append : ouvrir le fichier en mode ajout. Considérez définir conv=notrunc aussi.
   - seek_bytes : une valeur pour seek=N sera interprétée comme des octets.
 
-  ### Indicateurs généraux
+  Indicateurs généraux :
 
   - direct : utiliser les E/S directes pour les données.
   - directory : échouer sauf si l'entrée donnée (si utilisée comme iflag) ou

--- a/tests/by-util/test_cut.rs
+++ b/tests/by-util/test_cut.rs
@@ -56,6 +56,16 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_help_uses_plain_text_headings() {
+    new_ucmd!()
+        .arg("--help")
+        .succeeds()
+        .stdout_contains("\nSpecifying a mode:\n")
+        .stdout_contains("\nSet the delimiter:\n")
+        .stdout_does_not_contain("###");
+}
+
+#[test]
 fn test_range_error_messages() {
     // Mode-aware diagnostics for invalid ranges.
     let cases: &[(&[&str], &str)] = &[

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -107,7 +107,13 @@ fn version() {
 
 #[test]
 fn help() {
-    new_ucmd!().args(&["--help"]).succeeds();
+    new_ucmd!()
+        .arg("--help")
+        .succeeds()
+        .stdout_contains("\nOperands:\n")
+        .stdout_contains("\nConversion options:\n")
+        .stdout_does_not_contain("###")
+        .stdout_does_not_contain("```");
 }
 
 #[test]


### PR DESCRIPTION
Replace Markdown heading markers in the terminal help for cut and dd with plain text headings, and remove dd's stray code fence. Keep the English and French help in sync and add regression coverage.

Fixes #13978.