### PR TITLE
expr: remove redundant about text from after-help

### DIFF
--- a/src/uu/expr/locales/en-US.ftl
+++ b/src/uu/expr/locales/en-US.ftl
@@ -1,8 +1,7 @@
 expr-about = Print the value of EXPRESSION to standard output
 expr-usage = expr [EXPRESSION]
   expr [OPTIONS]
-expr-after-help = Print the value of EXPRESSION to standard output. A blank line below
-  separates increasing precedence groups.
+expr-after-help = A blank line below separates increasing precedence groups.
 
   EXPRESSION may be:
 

--- a/src/uu/expr/locales/fr-FR.ftl
+++ b/src/uu/expr/locales/fr-FR.ftl
@@ -1,8 +1,7 @@
 expr-about = Afficher la valeur de EXPRESSION sur la sortie standard
 expr-usage = expr [EXPRESSION]
   expr [OPTIONS]
-expr-after-help = Afficher la valeur de EXPRESSION sur la sortie standard. Une ligne vide ci-dessous
-  sépare les groupes de précédence croissante.
+expr-after-help = Une ligne vide ci-dessous sépare les groupes de précédence croissante.
 
   EXPRESSION peut être :
 


### PR DESCRIPTION
Fixes #13983.

The `expr` utility showed its about text twice in `--help` output:
once from the `about` field and again at the start of `after-help`.

Remove the duplicated first sentence from `expr-after-help` in both
en-US and fr-FR locales so the help text reads naturally.

Before:
```
Print the value of EXPRESSION to standard output

Usage: expr [EXPRESSION]
       expr [OPTIONS]
...

Print the value of EXPRESSION to standard output. A blank line below
separates increasing precedence groups.
```

After:
```
Print the value of EXPRESSION to standard output

Usage: expr [EXPRESSION]
       expr [OPTIONS]
...

A blank line below
separates increasing precedence groups.
```
