### PR TITLE
gnu tests: limit make jobs to nproc output

### DIFF
--- a/util/run-gnu-test.sh
+++ b/util/run-gnu-test.sh
@@ -28,9 +28,20 @@ echo "path_UUTILS='${path_UUTILS}'"
 echo "path_GNU='${path_GNU}'"
 
 # Use GNU nproc for *BSD
-NPROC=$(command -v ${path_GNU}/src/nproc||command -v nproc)
-MAKEFLAGS="${MAKEFLAGS} -j ${NPROC}"
+if NPROC_COMMAND=$(command -v "${path_GNU}/src/nproc" || command -v nproc); then
+    JOBS=$("${NPROC_COMMAND}")
+else
+    JOBS=2
+fi
+case "${JOBS}" in
+    '' | 0* | *[!0-9]*)
+        echo "Error: invalid make job count: '${JOBS}'" >&2
+        exit 1
+        ;;
+esac
+MAKEFLAGS="${MAKEFLAGS:+${MAKEFLAGS} }-j${JOBS}"
 export MAKEFLAGS
+echo "GNU test make job count: ${JOBS}"
 ###
 
 cd "${path_GNU}" && echo "[ pwd:'${PWD}' ]"


### PR DESCRIPTION
`run-gnu-test.sh` passed the `nproc` executable path after a bare `-j`,
which enabled unlimited make parallelism and treated the path as a target.

Execute `nproc`, validate its output, and pass the count as an attached `-j`
argument. Add an end-to-end regression test for the effective `MAKEFLAGS`.
