### PR TITLE
join: report the field number the user gave

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -1121,14 +1121,6 @@ fn exec<Sep: Separator>(
     Ok(())
 }
 
-/// Render a zero-based field index as its one-based equivalent.
-///
-/// `parse_field_number` clamps an out-of-range field to `usize::MAX`, so the
-/// increment has to saturate rather than overflow.
-fn one_based(k: usize) -> usize {
-    k.saturating_add(1)
-}
-
 /// Check that keys for both files and for a particular file are not
 /// contradictory and return the key index.
 fn get_field_number(keys: Option<usize>, key: Option<usize>) -> UResult<usize> {
@@ -1136,10 +1128,12 @@ fn get_field_number(keys: Option<usize>, key: Option<usize>) -> UResult<usize> {
         // Show zero-based field numbers as one-based.
         (Some(k1), Some(k2)) if k1 != k2 => Err(USimpleError::new(
             1,
+            // `parse_field_number` clamps an out-of-range field to `usize::MAX`,
+            // so the one-based increment has to saturate rather than overflow.
             translate!(
                 "join-error-incompatible-fields",
-                "field1" => one_based(k1),
-                "field2" => one_based(k2)
+                "field1" => k1.saturating_add(1),
+                "field2" => k2.saturating_add(1)
             ),
         )),
         (Some(k), _) | (_, Some(k)) => Ok(k),

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -1121,6 +1121,14 @@ fn exec<Sep: Separator>(
     Ok(())
 }
 
+/// Render a zero-based field index as its one-based equivalent.
+///
+/// `parse_field_number` clamps an out-of-range field to `usize::MAX`, so the
+/// increment has to saturate rather than overflow.
+fn one_based(k: usize) -> usize {
+    k.saturating_add(1)
+}
+
 /// Check that keys for both files and for a particular file are not
 /// contradictory and return the key index.
 fn get_field_number(keys: Option<usize>, key: Option<usize>) -> UResult<usize> {
@@ -1128,7 +1136,11 @@ fn get_field_number(keys: Option<usize>, key: Option<usize>) -> UResult<usize> {
         // Show zero-based field numbers as one-based.
         (Some(k1), Some(k2)) if k1 != k2 => Err(USimpleError::new(
             1,
-            translate!("join-error-incompatible-fields", "field1" => (k1 + 1), "field2" => (k2 + 1)),
+            translate!(
+                "join-error-incompatible-fields",
+                "field1" => one_based(k1),
+                "field2" => one_based(k2)
+            ),
         )),
         (Some(k), _) | (_, Some(k)) => Ok(k),
         (None, None) => Ok(0),

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -514,6 +514,28 @@ pub fn get_message(id: &str) -> String {
 /// let message = get_message_with_args("notification", args);
 /// println!("{message}");
 /// ```
+/// The value as an `i64` when Fluent can represent it exactly, else `None`.
+#[doc(hidden)]
+pub fn exact_fluent_integer(s: &str) -> Option<i64> {
+    // Fluent stores numbers as f64, which represents integers exactly only up
+    // to 2^53. Anything beyond that has to travel as a string.
+    const MAX_EXACT: i64 = 1 << 53;
+    match s.parse::<i64>() {
+        Ok(n) if (-MAX_EXACT..=MAX_EXACT).contains(&n) => Some(n),
+        _ => None,
+    }
+}
+
+/// Whether `s` is a plain decimal integer literal, with an optional sign.
+///
+/// Used by [`translate!`] to tell an integer that Fluent cannot hold exactly
+/// from a genuine float, so the former can bypass Fluent's number type.
+#[doc(hidden)]
+pub fn is_integer_literal(s: &str) -> bool {
+    let digits = s.strip_prefix(['-', '+']).unwrap_or(s);
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
 pub fn get_message_with_args(id: &str, ftl_args: FluentArgs) -> String {
     get_message_internal(id, Some(ftl_args))
 }
@@ -796,8 +818,13 @@ macro_rules! translate {
             let mut args = fluent::FluentArgs::new();
             $(
                 let value_str = $value.to_string();
-                if let Ok(num_val) = value_str.parse::<i64>() {
+                if let Some(num_val) = $crate::locale::exact_fluent_integer(&value_str) {
                     args.set($key, num_val);
+                } else if $crate::locale::is_integer_literal(&value_str) {
+                    // An integer Fluent cannot hold exactly. Its number type is
+                    // f64-backed, so setting it as a number would round it; keep
+                    // the exact decimal string instead.
+                    args.set($key, value_str);
                 } else if let Ok(float_val) = value_str.parse::<f64>() {
                     args.set($key, float_val);
                 } else {
@@ -815,6 +842,27 @@ pub use {translate, translate_text};
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn integers_beyond_f64_precision_stay_exact() {
+        // Fluent's number type is f64-backed, so values past 2^53 must travel
+        // as strings to survive intact.
+        assert_eq!(exact_fluent_integer("3"), Some(3));
+        assert_eq!(exact_fluent_integer("-3"), Some(-3));
+        assert_eq!(exact_fluent_integer("9007199254740992"), Some(1 << 53));
+        assert_eq!(exact_fluent_integer("9007199254740993"), None);
+        assert_eq!(exact_fluent_integer("-9007199254740993"), None);
+        assert_eq!(exact_fluent_integer("18446744073709551615"), None);
+        assert_eq!(exact_fluent_integer("1.5"), None);
+
+        assert!(is_integer_literal("18446744073709551615"));
+        assert!(is_integer_literal("-7"));
+        assert!(is_integer_literal("+7"));
+        assert!(!is_integer_literal("1.5"));
+        assert!(!is_integer_literal(""));
+        assert!(!is_integer_literal("-"));
+        assert!(!is_integer_literal("12a"));
+    }
+
     use super::*;
     use std::env;
     use std::fs;

--- a/src/uucore/src/lib/mods/locale.rs
+++ b/src/uucore/src/lib/mods/locale.rs
@@ -514,6 +514,10 @@ pub fn get_message(id: &str) -> String {
 /// let message = get_message_with_args("notification", args);
 /// println!("{message}");
 /// ```
+pub fn get_message_with_args(id: &str, ftl_args: FluentArgs) -> String {
+    get_message_internal(id, Some(ftl_args))
+}
+
 /// The value as an `i64` when Fluent can represent it exactly, else `None`.
 #[doc(hidden)]
 pub fn exact_fluent_integer(s: &str) -> Option<i64> {
@@ -534,10 +538,6 @@ pub fn exact_fluent_integer(s: &str) -> Option<i64> {
 pub fn is_integer_literal(s: &str) -> bool {
     let digits = s.strip_prefix(['-', '+']).unwrap_or(s);
     !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
-}
-
-pub fn get_message_with_args(id: &str, ftl_args: FluentArgs) -> String {
-    get_message_internal(id, Some(ftl_args))
 }
 
 /// Function to detect system locale from environment variables
@@ -842,6 +842,12 @@ pub use {translate, translate_text};
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
     #[test]
     fn integers_beyond_f64_precision_stay_exact() {
         // Fluent's number type is f64-backed, so values past 2^53 must travel
@@ -862,12 +868,6 @@ mod tests {
         assert!(!is_integer_literal("-"));
         assert!(!is_integer_literal("12a"));
     }
-
-    use super::*;
-    use std::env;
-    use std::fs;
-    use std::path::PathBuf;
-    use tempfile::TempDir;
 
     /// Test-specific helper function to create a bundle from test directory only
     #[cfg(test)]

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -713,10 +713,10 @@ fn test_incompatible_fields_reports_exact_field_number() {
     // one-based increment. Field numbers past 2^53 also used to be rounded on
     // their way through the localization layer.
     //
-    // `parse_field_number` uses `usize` (matching GNU join's `size_t`), so a
-    // value at or above `usize::MAX` saturates to it. The saturation ceiling is
-    // therefore pointer-width dependent, and the expected text is built from
-    // `usize::MAX` rather than a hard-coded 64-bit literal.
+    // `parse_field_number` uses `usize`, so a value at or above `usize::MAX`
+    // saturates to it. The saturation ceiling is therefore pointer-width
+    // dependent, and the expected text is built from `usize::MAX` rather than a
+    // hard-coded 64-bit literal.
     let max_field = usize::MAX.to_string();
 
     // A small field number takes the i64 number path through the localization
@@ -734,7 +734,7 @@ fn test_incompatible_fields_reports_exact_field_number() {
         new_ucmd!()
             .args(&["-j", field, "-1", "5", "/dev/null", "/dev/null"])
             .fails()
-            .stderr_contains(&format!("incompatible join fields {max_field}, 5"));
+            .stderr_contains(format!("incompatible join fields {max_field}, 5"));
     }
 
     // A value above f64 precision (2^53) but below `usize::MAX` is reported
@@ -745,9 +745,16 @@ fn test_incompatible_fields_reports_exact_field_number() {
     #[cfg(not(target_pointer_width = "64"))]
     let expected_above: String = max_field.clone();
     new_ucmd!()
-        .args(&["-j", "9007199254740993", "-1", "5", "/dev/null", "/dev/null"])
+        .args(&[
+            "-j",
+            "9007199254740993",
+            "-1",
+            "5",
+            "/dev/null",
+            "/dev/null",
+        ])
         .fails()
-        .stderr_contains(&format!("incompatible join fields {expected_above}, 5"));
+        .stderr_contains(format!("incompatible join fields {expected_above}, 5"));
 }
 
 #[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -712,26 +712,42 @@ fn test_incompatible_fields_reports_exact_field_number() {
     // An out-of-range field clamps to usize::MAX, which used to overflow the
     // one-based increment. Field numbers past 2^53 also used to be rounded on
     // their way through the localization layer.
-    for (field, expected) in [
-        ("3", "incompatible join fields 3, 5"),
-        (
-            "9007199254740993",
-            "incompatible join fields 9007199254740993, 5",
-        ),
-        (
-            "18446744073709551615",
-            "incompatible join fields 18446744073709551615, 5",
-        ),
-        (
-            "99999999999999999999999",
-            "incompatible join fields 18446744073709551615, 5",
-        ),
-    ] {
+    //
+    // `parse_field_number` uses `usize` (matching GNU join's `size_t`), so a
+    // value at or above `usize::MAX` saturates to it. The saturation ceiling is
+    // therefore pointer-width dependent, and the expected text is built from
+    // `usize::MAX` rather than a hard-coded 64-bit literal.
+    let max_field = usize::MAX.to_string();
+
+    // A small field number takes the i64 number path through the localization
+    // layer and is platform-independent.
+    new_ucmd!()
+        .args(&["-j", "3", "-1", "5", "/dev/null", "/dev/null"])
+        .fails()
+        .stderr_contains("incompatible join fields 3, 5");
+
+    // Values at or above `usize::MAX` saturate to `usize::MAX` on every
+    // platform; the localization layer must carry that ceiling as an exact
+    // decimal string rather than rounding it through Fluent's f64-backed number
+    // type.
+    for field in ["18446744073709551615", "99999999999999999999999"] {
         new_ucmd!()
             .args(&["-j", field, "-1", "5", "/dev/null", "/dev/null"])
             .fails()
-            .stderr_contains(expected);
+            .stderr_contains(&format!("incompatible join fields {max_field}, 5"));
     }
+
+    // A value above f64 precision (2^53) but below `usize::MAX` is reported
+    // exactly on 64-bit (where `usize` holds it); on 32-bit it saturates to
+    // `usize::MAX` like the cases above.
+    #[cfg(target_pointer_width = "64")]
+    let expected_above: String = "9007199254740993".to_string();
+    #[cfg(not(target_pointer_width = "64"))]
+    let expected_above: String = max_field.clone();
+    new_ucmd!()
+        .args(&["-j", "9007199254740993", "-1", "5", "/dev/null", "/dev/null"])
+        .fails()
+        .stderr_contains(&format!("incompatible join fields {expected_above}, 5"));
 }
 
 #[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -707,6 +707,33 @@ fn test_locale_collation() {
         .stdout_contains("ab:d 1 x");
 }
 
+#[test]
+fn test_incompatible_fields_reports_exact_field_number() {
+    // An out-of-range field clamps to usize::MAX, which used to overflow the
+    // one-based increment. Field numbers past 2^53 also used to be rounded on
+    // their way through the localization layer.
+    for (field, expected) in [
+        ("3", "incompatible join fields 3, 5"),
+        (
+            "9007199254740993",
+            "incompatible join fields 9007199254740993, 5",
+        ),
+        (
+            "18446744073709551615",
+            "incompatible join fields 18446744073709551615, 5",
+        ),
+        (
+            "99999999999999999999999",
+            "incompatible join fields 18446744073709551615, 5",
+        ),
+    ] {
+        new_ucmd!()
+            .args(&["-j", field, "-1", "5", "/dev/null", "/dev/null"])
+            .fails()
+            .stderr_contains(expected);
+    }
+}
+
 #[cfg(all(feature = "feat_diagnostics", not(wasi_runner)))]
 mod diagnostics {
     use super::*;


### PR DESCRIPTION
Fixes #13376.

Both halves of the issue come down to the reported field number not matching the input.

**The `k + 1` overflow.** `parse_field_number` deliberately clamps an out-of-range field to `usize::MAX`, and `get_field_number` then renders it one-based with `k + 1`. That aborts under overflow-checks and wraps to `0` in a normal build. Now saturates.

**The rounding.** This one is not join-specific, so I fixed it where it lives. `translate!` stringifies a value, re-parses it as `i64` or `f64`, and sets it on Fluent as a number — but `FluentNumber` is f64-backed, so anything past 2^53 rounds. Note that taking the `i64` branch is not enough to stay exact; `-j 9007199254740993` parses fine as `i64` and still comes out as `…992`. So the check is whether f64 can hold the value exactly, not whether `i64` can:

- exactly representable → still set as a number, so plural rules and number formatting are untouched
- an integer past that → passed through as its exact decimal string
- anything else → unchanged

That also fixes the `csplit` case you mentioned:

```console
$ printf 'a\nb\nc\n' | csplit - 9007199254740995 9007199254740995
csplit: warning: line number '9007199254740995' is the same as preceding line number
```

All the values from the issue now match GNU, including `18446744073709551615` for the clamped case.

Tests: unit tests in `locale.rs` for the representability boundary, and an integration test in `test_join.rs` covering the four field values above.

Since this touches `uucore`, I ran the suites for csplit, nl, split, head, expr, seq, tail, wc, fold and sort as well as join — 982 tests, all passing.