### PR TITLE
head: propagate a write error from the -v filename header

### DIFF
--- a/src/uu/head/src/head.rs
+++ b/src/uu/head/src/head.rs
@@ -461,7 +461,7 @@ fn uu_head(options: &HeadOptions) -> UResult<()> {
                         writeln!(stdout)?;
                     }
                     write!(stdout, "==> ")?;
-                    print_verbatim(file).unwrap();
+                    print_verbatim(file)?;
                     writeln!(stdout, " <==")?;
                     first = false;
                 }

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1050,6 +1050,31 @@ fn test_unreadable_file_prints_no_header() {
         .stderr_contains("cannot open 'unreadable' for reading: Permission denied");
 }
 
+/// Regression for #13887: writing the `==> filename <==` verbose header to a
+/// full/closed stdout must surface the write error instead of panicking inside
+/// `print_verbatim(...).unwrap()`. A filename longer than the stdout buffer
+/// forces the header write to flush mid-write so the failure surfaces inside
+/// the filename write rather than at the next checked one.
+#[test]
+#[cfg(target_os = "linux")]
+#[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/dev) not visible")]
+fn test_verbose_header_write_error_long_filename() {
+    use std::fs::File;
+
+    let dev_full =
+        File::create("/dev/full").expect("Failed to open /dev/full - test must run on Linux");
+
+    let long_path = format!("/dev/{}null", "./".repeat(512));
+
+    new_ucmd!()
+        .arg("-v")
+        .arg(long_path)
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1)
+        .stderr_contains("No space left on device");
+}
+
 /// Regression for #11972: head must reject directories detected on the
 /// open fd, not via a separate `Path::is_dir()` call. A symlink that
 /// resolves to a directory must still be rejected — verifying the fd
@@ -1074,29 +1099,6 @@ fn test_head_rejects_directory_through_symlink() {
 /// Regression for #11972: a symlink that points to a regular file must
 /// still be readable by head (the fd-based check must distinguish the
 /// fd's mode, not the symlink's).
-#[test]
-#[cfg(target_os = "linux")]
-#[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/dev) not visible")]
-fn test_verbose_header_write_error_long_filename() {
-    use std::fs::File;
-
-    let dev_full =
-        File::create("/dev/full").expect("Failed to open /dev/full - test must run on Linux");
-
-    // A filename longer than the stdout buffer forces the header write to flush
-    // mid-write, so the failure surfaces inside the filename write rather than
-    // at the next checked one.
-    let long_path = format!("/dev/{}null", "./".repeat(512));
-
-    new_ucmd!()
-        .arg("-v")
-        .arg(long_path)
-        .set_stdout(dev_full)
-        .fails()
-        .code_is(1)
-        .stderr_contains("No space left on device");
-}
-
 #[test]
 #[cfg(unix)]
 fn test_head_follows_symlink_to_regular_file() {

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1075,6 +1075,29 @@ fn test_head_rejects_directory_through_symlink() {
 /// still be readable by head (the fd-based check must distinguish the
 /// fd's mode, not the symlink's).
 #[test]
+#[cfg(target_os = "linux")]
+#[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/dev) not visible")]
+fn test_verbose_header_write_error_long_filename() {
+    use std::fs::File;
+
+    let dev_full =
+        File::create("/dev/full").expect("Failed to open /dev/full - test must run on Linux");
+
+    // A filename longer than the stdout buffer forces the header write to flush
+    // mid-write, so the failure surfaces inside the filename write rather than
+    // at the next checked one.
+    let long_path = format!("/dev/{}null", "./".repeat(512));
+
+    new_ucmd!()
+        .arg("-v")
+        .arg(long_path)
+        .set_stdout(dev_full)
+        .fails()
+        .code_is(1)
+        .stderr_contains("No space left on device");
+}
+
+#[test]
 #[cfg(unix)]
 fn test_head_follows_symlink_to_regular_file() {
     use std::os::unix::fs::symlink;


### PR DESCRIPTION
Fixes #13264.

`print_verbatim(file).unwrap()` was the only unchecked write in `print_header` — the `==> ` and ` <==` around it already use `?`. Switched it to `?` so the error travels the same way.

The length threshold in the issue is what makes this reachable: a short filename stays in the stdout buffer and its write error surfaces later at a `?`-checked flush, so only a name longer than the buffer forces a flush inside the `unwrap`.

```console
$ LONG="/dev/$(python3 -c "print('./'*512)")null"
$ head -v "$LONG" > /dev/full
```

Now reports the write error and exits 1 instead of aborting.

Tests: an integration test following the `/dev/full` pattern already used in `test_paste.rs`, gated to Linux for the same reason.

Worth being upfront: I develop on macOS, where `/dev/full` is not writable, so I could not execute that test locally. I did verify it compiles and runs by temporarily widening the `cfg` — it reaches the `/dev/full` open and fails only there — so CI is the real check on the assertion.