### PR TITLE
numfmt: name the only conversion in a bad --format directive

### DIFF
--- a/src/uu/numfmt/locales/en-US.ftl
+++ b/src/uu/numfmt/locales/en-US.ftl
@@ -84,9 +84,20 @@ numfmt-debug-grouping-no-effect = grouping has no effect in this locale
 numfmt-debug-failed-to-convert = failed to convert some of the input numbers
 numfmt-debug-header-ignored = --header ignored with command-line input
 
-# Diagnostic labels: what the caret points at in a --format string
+# Diagnostic labels and help lines: what the caret points at, and the advice under it
 numfmt-diag-label-number-overflow = this number is too large
 numfmt-diag-label-stray-percent = a literal % must be written %%
+numfmt-diag-label-bad-conversion = f is the only conversion numfmt has; %d, %e, %g and the other C conversions are not accepted
 numfmt-diag-help-format-syntax = a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in "%'-10.2f"
+numfmt-diag-label-auto-from-only = auto guesses the unit of the input, so only --from takes it
+numfmt-diag-help-unit = --from and --to take none, si, iec or iec-i, and --from also takes auto
+numfmt-diag-label-zero-unit-size = a unit size must be at least 1
+numfmt-diag-help-unit-size = a unit size is a number, a K, M, G, T, P or E multiplier, or both, as in 512, K or 2Ki
+numfmt-diag-label-zero-padding = a padding is a width in characters, so 0 asks for nothing
+numfmt-diag-help-padding = --padding takes a non-zero whole number; a negative one left-aligns, as in --padding=-10
+numfmt-diag-label-zero-header = leave --header out to convert every line
+numfmt-diag-help-header = --header takes the number of leading lines to pass through unchanged, at least 1
+numfmt-diag-help-input-no-from = without --from a number must be plain; --from=auto reads a K, M or Gi suffix
+numfmt-diag-help-input-suffixes = the suffixes are K, M, G, T, P, E, Z, Y, R and Q, with an optional i under --from=auto or iec-i
 numfmt-diag-label-zero-field = fields are numbered from 1
 numfmt-diag-help-field-syntax = --field takes N, N-M, N- or -M, separated by commas, as in --field=1,3-5

--- a/src/uu/numfmt/locales/fr-FR.ftl
+++ b/src/uu/numfmt/locales/fr-FR.ftl
@@ -83,9 +83,20 @@ numfmt-debug-grouping-no-effect = le groupement n'a aucun effet dans cette local
 numfmt-debug-failed-to-convert = échec de conversion d'une partie des nombres en entrée
 numfmt-debug-header-ignored = --header ignoré avec une entrée en ligne de commande
 
-# Étiquettes de diagnostic : ce que le caret désigne dans une chaîne --format
+# Étiquettes de diagnostic et aides : ce que le caret désigne, et le conseil en dessous
 numfmt-diag-label-number-overflow = ce nombre est trop grand
 numfmt-diag-label-stray-percent = un % littéral doit s'écrire %%
+numfmt-diag-label-bad-conversion = f est la seule conversion de numfmt ; %d, %e, %g et les autres conversions C ne sont pas acceptées
 numfmt-diag-help-format-syntax = un format s'écrit [PRÉFIXE]%[0]['][-][LARGEUR][.PRÉCISION]f[SUFFIXE], comme "%'-10.2f"
+numfmt-diag-label-auto-from-only = auto devine l'unité de l'entrée, seul --from le prend donc
+numfmt-diag-help-unit = --from et --to prennent none, si, iec ou iec-i, et --from prend aussi auto
+numfmt-diag-label-zero-unit-size = une taille d'unité doit valoir au moins 1
+numfmt-diag-help-unit-size = une taille d'unité est un nombre, un multiplicateur K, M, G, T, P ou E, ou les deux, comme 512, K ou 2Ki
+numfmt-diag-label-zero-padding = un remplissage est une largeur en caractères, 0 ne demande donc rien
+numfmt-diag-help-padding = --padding prend un entier non nul ; un entier négatif aligne à gauche, comme --padding=-10
+numfmt-diag-label-zero-header = omettez --header pour convertir toutes les lignes
+numfmt-diag-help-header = --header prend le nombre de lignes de tête à laisser telles quelles, au moins 1
+numfmt-diag-help-input-no-from = sans --from un nombre doit être simple ; --from=auto lit un suffixe K, M ou Gi
+numfmt-diag-help-input-suffixes = les suffixes sont K, M, G, T, P, E, Z, Y, R et Q, avec un i optionnel sous --from=auto ou iec-i
 numfmt-diag-label-zero-field = les champs sont numérotés à partir de 1
 numfmt-diag-help-field-syntax = --field prend N, N-M, N- ou -M, séparés par des virgules, comme --field=1,3-5

--- a/src/uu/numfmt/src/diagnostics.rs
+++ b/src/uu/numfmt/src/diagnostics.rs
@@ -3,17 +3,20 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! Maps a [`FormatError`] onto the part of the `--format` string it came from,
-//! so that [`uucore::diagnostics`] can render it with a caret. A bad `--field`
+//! Maps an error onto the part of the command line it came from, so that
+//! [`uucore::diagnostics`] can render it with a caret: a [`FormatError`], an
+//! [`OptionValueError`], or a number that does not convert. A bad `--field`
 //! list goes through [`RangeError`], which knows how to render itself.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 
 use uucore::diagnostics::Snapshot;
 use uucore::ranges::RangeError;
 use uucore::translate;
 
-use crate::options::{FormatError, FormatErrorKind};
+use crate::format::{holds_number, invalid_span};
+use crate::options::{FormatError, FormatErrorKind, NumfmtOptions, OptionValueError};
+use crate::units::Unit;
 
 /// Render `err`, raised while parsing `format`, against `args` — the whole
 /// argument list, program name included.
@@ -25,6 +28,7 @@ pub fn render(args: &[OsString], format: &str, err: &FormatError) -> bool {
     // in `uucore::diagnostics`.
     let label = match err.kind {
         FormatErrorKind::MissingDirective | FormatErrorKind::UnexpectedCharacter => None,
+        FormatErrorKind::UnexpectedConversion => Some("numfmt-diag-label-bad-conversion"),
         FormatErrorKind::NumberOverflow => Some("numfmt-diag-label-number-overflow"),
         FormatErrorKind::StrayPercent => Some("numfmt-diag-label-stray-percent"),
     };
@@ -40,6 +44,143 @@ pub fn render(args: &[OsString], format: &str, err: &FormatError) -> bool {
         &err.message,
         label.map(|label| translate!(label)).as_deref(),
         Some(&translate!("numfmt-diag-help-format-syntax")),
+    )
+}
+
+/// Long options whose value can be a separate argument, and the short options
+/// that do the same. `--header` requires an `=`, so its value never is one.
+const VALUE_OPTIONS: &[&str] = &[
+    "delimiter",
+    "field",
+    "format",
+    "from",
+    "from-unit",
+    "invalid",
+    "padding",
+    "round",
+    "suffix",
+    "to",
+    "to-unit",
+    "unit-separator",
+];
+const VALUE_SHORTS: &[char] = &['d'];
+
+/// Whether `arg` is an option that takes the argument after it as its value.
+///
+/// `infer_long_args` is on, so an unambiguous abbreviation names an option just
+/// as its full spelling does; an ambiguous one never reaches here, clap having
+/// refused it first.
+fn takes_separate_value(arg: &str) -> bool {
+    if let Some(long) = arg.strip_prefix("--") {
+        if long.contains('=') {
+            return false;
+        }
+        return VALUE_OPTIONS.iter().any(|name| name.starts_with(long));
+    }
+    // In a run of short options, only the last one can carry the value.
+    arg.strip_prefix('-')
+        .and_then(|cluster| cluster.chars().next_back())
+        .is_some_and(|last| VALUE_SHORTS.contains(&last))
+}
+
+/// Index in `args` — program name included — of the `n`-th operand.
+///
+/// [`Snapshot::index_of`] would match the first argument with the operand's
+/// text, which may be the detached value of an earlier option rather than the
+/// operand itself, and [`Snapshot::index_of_positional`] would count that value
+/// as a positional. Options and the values they take are skipped here instead.
+fn index_of_operand(args: &[OsString], n: usize) -> Option<usize> {
+    let mut options_ended = false;
+    let mut skip_value = false;
+    let mut rank = 0;
+    for (index, arg) in args.iter().enumerate().skip(1) {
+        if skip_value {
+            skip_value = false;
+            continue;
+        }
+        if !options_ended {
+            if arg.as_encoded_bytes() == b"--" {
+                options_ended = true;
+                continue;
+            }
+            // A lone `-` is an operand, and so is an argument that is not
+            // UTF-8, which no option spelling can be.
+            if let Some(text) = arg.to_str()
+                && text.starts_with('-')
+                && text != "-"
+            {
+                skip_value = takes_separate_value(text);
+                continue;
+            }
+        }
+        if rank == n {
+            return Some(index);
+        }
+        rank += 1;
+    }
+    None
+}
+
+/// Render `message`, raised while converting `input` — the `n`-th number given
+/// on the command line — against `args`.
+///
+/// Returns `false` when the number cannot be pointed at, in which case the
+/// caller should fall back to the plain one-line message.
+pub fn render_input(
+    args: &[OsString],
+    input: &[u8],
+    n: usize,
+    message: &str,
+    options: &NumfmtOptions,
+) -> bool {
+    // With fields, the offsets below are of the whole line, not the number.
+    if options.delimiter.is_some() {
+        return false;
+    }
+    let Ok(input) = std::str::from_utf8(input) else {
+        return false;
+    };
+    if input.split_whitespace().count() > 1 {
+        return false;
+    }
+
+    let snapshot = Snapshot::with_program(args);
+    let Some(index) = index_of_operand(args, n).or_else(|| snapshot.index_of(OsStr::new(input)))
+    else {
+        return false;
+    };
+    let span = invalid_span(input, options);
+    // Without --from there is no suffix to spell out, only the option to reach
+    // for; an input with no number in it at all is not a suffix question, and
+    // neither is one whose leading part only looks like the start of one.
+    let help = match options.transform.from {
+        _ if !holds_number(input) => None,
+        Unit::None => Some("numfmt-diag-help-input-no-from"),
+        _ => Some("numfmt-diag-help-input-suffixes"),
+    };
+    snapshot.render_inside_at(
+        index,
+        input,
+        span,
+        message,
+        None,
+        help.map(|help| translate!(help)).as_deref(),
+    )
+}
+
+/// Render `err`, an option value that is wrong from end to end, against `args`.
+///
+/// Returns `false` when no argument carries the value, in which case the caller
+/// should fall back to the plain one-line message.
+pub fn render_value(args: &[OsString], err: &OptionValueError) -> bool {
+    Snapshot::with_program(args).render_option_value(
+        &err.value,
+        None,
+        Some(err.option),
+        0..err.value.len(),
+        &err.message,
+        err.label.map(|label| translate!(label)).as_deref(),
+        Some(&translate!(err.help)),
     )
 }
 
@@ -59,4 +200,54 @@ pub fn render_field(args: &[OsString], fields: &str, err: &RangeError) -> bool {
         &translate!("numfmt-diag-label-zero-field"),
         &translate!("numfmt-diag-help-field-syntax"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::index_of_operand;
+    use std::ffi::OsString;
+
+    fn args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn operand_is_found_past_a_detached_option_value() {
+        let args = args(&["numfmt", "--suffix", "q", "--from", "si", "q"]);
+        assert_eq!(index_of_operand(&args, 0), Some(5));
+        assert_eq!(index_of_operand(&args, 1), None);
+    }
+
+    #[test]
+    fn operands_are_counted_in_order() {
+        let args = args(&["numfmt", "1", "-d", ",", "--grouping", "2", "-z", "3"]);
+        for (n, index) in [(0, 1), (1, 5), (2, 7)] {
+            assert_eq!(index_of_operand(&args, n), Some(index), "operand {n}");
+        }
+    }
+
+    #[test]
+    fn a_dash_and_everything_past_a_double_dash_is_an_operand() {
+        let args = args(&["numfmt", "-", "--", "-1", "--from=si"]);
+        for (n, index) in [(0, 1), (1, 3), (2, 4)] {
+            assert_eq!(index_of_operand(&args, n), Some(index), "operand {n}");
+        }
+    }
+
+    #[test]
+    fn an_attached_value_does_not_swallow_the_operand() {
+        for args in [
+            args(&["numfmt", "--suffix=q", "q"]),
+            args(&["numfmt", "-d,", "q"]),
+            args(&["numfmt", "--header=2", "q"]),
+        ] {
+            assert_eq!(index_of_operand(&args, 0), Some(2), "in {args:?}");
+        }
+    }
+
+    #[test]
+    fn an_abbreviated_long_option_still_takes_its_value() {
+        let args = args(&["numfmt", "--suf", "q", "q"]);
+        assert_eq!(index_of_operand(&args, 0), Some(3));
+    }
 }

--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -100,6 +100,65 @@ fn valid_end_with_unit_separator(
     Some(valid_part.len() + unit_separator.len() + suffix_len)
 }
 
+/// Length of the leading part of `s` that reads as a number, suffix included.
+fn valid_prefix_len(s: &str, unit: Unit, unit_separator: &str) -> usize {
+    let Some(number_prefix) = find_valid_number_with_suffix(s, unit) else {
+        return 0;
+    };
+
+    // When a unit separator is in use, the valid part may extend beyond the
+    // contiguous number+suffix found by find_valid_number_with_suffix.
+    // For example "5 K Field2" with unit_separator=" " has number_prefix="5" but
+    // the real valid prefix is "5 K"; the trailing " Field2" is the garbage.
+    if !unit_separator.is_empty() && number_prefix == find_numeric_beginning(s).unwrap_or("") {
+        valid_end_with_unit_separator(s, number_prefix, unit, unit_separator)
+            .unwrap_or(number_prefix.len())
+    } else {
+        number_prefix.len()
+    }
+}
+
+/// Byte range of the part of a refused `input` a caret should point at: what
+/// follows the number that could be read, or the whole of it when there is
+/// none. Surrounding whitespace, reproduced rather than converted, is left out.
+pub fn invalid_span(input: &str, options: &NumfmtOptions) -> std::ops::Range<usize> {
+    let start = input.len() - input.trim_start().len();
+    let mut end = input.trim_end().len();
+
+    // Whitespace only: there is no number to point past, and the two offsets
+    // above have crossed — `start` is the whole length, `end` is zero.
+    if start >= end {
+        return 0..input.len();
+    }
+
+    // A declared --suffix is stripped before parsing, so it is not at fault.
+    if let Some(suffix) = &options.suffix
+        && !suffix.is_empty()
+        && let Some(stripped) = input[start..end].strip_suffix(suffix.as_str())
+    {
+        end = start + stripped.len();
+    }
+
+    let valid = valid_prefix_len(
+        &input[start..end],
+        options.transform.from,
+        &options.unit_separator,
+    );
+    start + valid..end.max(start + valid)
+}
+
+/// Whether `input` begins with something that reads as a number, so that advice
+/// about what may follow one is only given where there is one. A lone sign or
+/// decimal separator is the leading part of a number, but not yet a number.
+pub fn holds_number(input: &str) -> bool {
+    find_numeric_beginning(input.trim_start()).is_some_and(|number| {
+        number
+            .replace(locale_decimal_separator(), ".")
+            .parse::<f64>()
+            .is_ok()
+    })
+}
+
 fn detailed_error_message(s: &str, unit: Unit, unit_separator: &str) -> Option<String> {
     if s.is_empty() {
         return Some(translate!("numfmt-error-invalid-number-empty"));
@@ -117,19 +176,7 @@ fn detailed_error_message(s: &str, unit: Unit, unit_separator: &str) -> Option<S
         return Some(translate!("numfmt-error-invalid-number", "input" => s.quote()));
     }
 
-    // When a unit separator is in use, the valid part may extend beyond the
-    // contiguous number+suffix found by find_valid_number_with_suffix.
-    // For example "5 K Field2" with unit_separator=" " has number_prefix="5" but
-    // the real valid prefix is "5 K"; the trailing " Field2" is the garbage.
-    let valid_end =
-        if !unit_separator.is_empty() && number_prefix == find_numeric_beginning(s).unwrap_or("") {
-            valid_end_with_unit_separator(s, number_prefix, unit, unit_separator)
-                .unwrap_or(number_prefix.len())
-        } else {
-            number_prefix.len()
-        };
-
-    let valid_part = &s[..valid_end];
+    let valid_part = &s[..valid_prefix_len(s, unit, unit_separator)];
 
     if valid_part != s && valid_part.parse::<f64>().is_ok() {
         return match s.chars().nth(valid_part.len()) {

--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -9,8 +9,8 @@ use crate::format::{escape_line, write_formatted_with_delimiter, write_formatted
 use crate::options::{
     DEBUG, DELIMITER, FIELD, FIELD_DEFAULT, FORMAT, FROM, FROM_DEFAULT, FROM_UNIT,
     FROM_UNIT_DEFAULT, FormatOptions, GROUPING, HEADER, HEADER_DEFAULT, INVALID, InvalidModes,
-    NUMBER, NumfmtOptions, PADDING, ParseError, ROUND, RoundMethod, SUFFIX, TO, TO_DEFAULT,
-    TO_UNIT, TO_UNIT_DEFAULT, TransformOptions, UNIT_SEPARATOR, ZERO_TERMINATED,
+    NUMBER, NumfmtOptions, OptionValueError, PADDING, ParseError, ROUND, RoundMethod, SUFFIX, TO,
+    TO_DEFAULT, TO_UNIT, TO_UNIT_DEFAULT, TransformOptions, UNIT_SEPARATOR, ZERO_TERMINATED,
 };
 use crate::units::{Result, Unit};
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser, parser::ValueSource};
@@ -114,13 +114,30 @@ fn format_and_write<W: std::io::Write>(
 
 /// Process command-line number arguments.
 ///
+/// `snapshot` is the command line as typed, for the caret under a number that
+/// does not convert, and `None` when diagnostics are off.
+///
 /// Returns `true` if any line contained invalid input.
-fn handle_args<'a>(args: impl Iterator<Item = &'a [u8]>, options: &NumfmtOptions) -> UResult<bool> {
+fn handle_args<'a>(
+    args: impl Iterator<Item = &'a [u8]>,
+    options: &NumfmtOptions,
+    snapshot: Option<&[OsString]>,
+) -> UResult<bool> {
     let mut stdout = std::io::stdout().lock();
     let terminator = if options.zero_terminated { 0u8 } else { b'\n' };
     let mut saw_invalid = false;
-    for l in args {
-        saw_invalid |= format_and_write(&mut stdout, l, options, Some(terminator))?;
+    for (n, l) in args.enumerate() {
+        match format_and_write(&mut stdout, l, options, Some(terminator)) {
+            Ok(invalid) => saw_invalid |= invalid,
+            // Only this mode stops on the first bad number; the others carry
+            // on, where a report per line would bury the output.
+            Err(error) => {
+                let reported = snapshot.is_some_and(|args| {
+                    diagnostics::render_input(args, l, n, &error.to_string(), options)
+                });
+                return Err(quiet_if_reported(reported, error));
+            }
+        }
     }
     Ok(saw_invalid)
 }
@@ -170,22 +187,28 @@ fn handle_buffer<R: BufRead>(mut input: R, options: &NumfmtOptions) -> UResult<b
     Ok(saw_invalid)
 }
 
-fn parse_unit(s: &str, opt: &str) -> Result<Unit> {
+fn parse_unit(s: &str, opt: &'static str) -> std::result::Result<Unit, ParseError> {
     match s {
         "auto" if opt != TO => Ok(Unit::Auto),
         "si" => Ok(Unit::Si),
         "iec" => Ok(Unit::Iec(false)),
         "iec-i" => Ok(Unit::Iec(true)),
         "none" => Ok(Unit::None),
-        value => Err(
-            translate!("numfmt-error-invalid-unit-argument", "arg" => value, "opt" => format!("--{opt}")),
-        ),
+        value => Err(OptionValueError {
+            message: translate!("numfmt-error-invalid-unit-argument", "arg" => value, "opt" => format!("--{opt}")),
+            option: opt,
+            value: value.to_string(),
+            // `auto` is a real unit, just not one --to can scale to.
+            label: (value == "auto").then_some("numfmt-diag-label-auto-from-only"),
+            help: "numfmt-diag-help-unit",
+        }
+        .into()),
     }
 }
 
 /// Parses a unit size. Suffixes are turned into their integer representations. For example, 'K'
 /// will return `Ok(1000)`, and '2K' will return `Ok(2000)`.
-fn parse_unit_size(s: &str) -> Result<usize> {
+fn parse_unit_size(s: &str, opt: &'static str) -> std::result::Result<usize, ParseError> {
     let split = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
     let (number, suffix) = s.split_at(split);
 
@@ -204,7 +227,17 @@ fn parse_unit_size(s: &str) -> Result<usize> {
         }
     }
 
-    Err(translate!("numfmt-error-invalid-unit-size", "size" => s.quote()))
+    Err(OptionValueError {
+        message: translate!("numfmt-error-invalid-unit-size", "size" => s.quote()),
+        option: opt,
+        value: s.to_string(),
+        // A zero size is spelled like a valid one; the rest the help covers.
+        // An unknown suffix is what is wrong about "0x", not the zero.
+        label: (all_zero && parse_unit_size_suffix(suffix).is_some())
+            .then_some("numfmt-diag-label-zero-unit-size"),
+        help: "numfmt-diag-help-unit-size",
+    }
+    .into())
 }
 
 /// Parses a suffix of a unit size and returns the corresponding multiplier. For example,
@@ -248,8 +281,8 @@ fn parse_delimiter(arg: &OsString) -> Result<Vec<u8>> {
 fn parse_options(args: &ArgMatches) -> std::result::Result<NumfmtOptions, ParseError> {
     let from = parse_unit(args.get_one::<String>(FROM).unwrap(), FROM)?;
     let to = parse_unit(args.get_one::<String>(TO).unwrap(), TO)?;
-    let from_unit = parse_unit_size(args.get_one::<String>(FROM_UNIT).unwrap())?;
-    let to_unit = parse_unit_size(args.get_one::<String>(TO_UNIT).unwrap())?;
+    let from_unit = parse_unit_size(args.get_one::<String>(FROM_UNIT).unwrap(), FROM_UNIT)?;
+    let to_unit = parse_unit_size(args.get_one::<String>(TO_UNIT).unwrap(), TO_UNIT)?;
 
     let transform = TransformOptions {
         from,
@@ -266,7 +299,14 @@ fn parse_options(args: &ArgMatches) -> std::result::Result<NumfmtOptions, ParseE
                 0 => Err(s),
                 _ => Ok(n),
             })
-            .map_err(|s| translate!("numfmt-error-invalid-padding", "value" => s.quote())),
+            .map_err(|s| OptionValueError {
+                message: translate!("numfmt-error-invalid-padding", "value" => s.quote()),
+                option: PADDING,
+                value: s.clone(),
+                // A zero parses fine and only fails on meaning.
+                label: (s == "0").then_some("numfmt-diag-label-zero-padding"),
+                help: "numfmt-diag-help-padding",
+            }),
         None => Ok(0),
     }?;
 
@@ -280,7 +320,13 @@ fn parse_options(args: &ArgMatches) -> std::result::Result<NumfmtOptions, ParseE
                 0 => Err(value),
                 _ => Ok(n),
             })
-            .map_err(|value| translate!("numfmt-error-invalid-header", "value" => value.quote()))
+            .map_err(|value| OptionValueError {
+                message: translate!("numfmt-error-invalid-header", "value" => value.quote()),
+                option: HEADER,
+                value: value.clone(),
+                label: (value == "0").then_some("numfmt-diag-label-zero-header"),
+                help: "numfmt-diag-help-header",
+            })
     } else {
         Ok(0)
     }?;
@@ -417,6 +463,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 NumfmtError::IllegalArgument(error.message),
             ));
         }
+        // An option value that is wrong as a whole: underline it where typed.
+        Err(ParseError::Value(error)) => {
+            let reported = format_args
+                .as_ref()
+                .is_some_and(|args| diagnostics::render_value(args, &error));
+            return Err(quiet_if_reported(
+                reported,
+                NumfmtError::IllegalArgument(error.message),
+            ));
+        }
         Err(ParseError::Other(message)) => {
             return Err(NumfmtError::IllegalArgument(message).into());
         }
@@ -431,7 +487,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .map(|s| os_str_as_bytes(s).map_err(|e| e.to_string()))
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(NumfmtError::IllegalArgument)?;
-        handle_args(byte_args.into_iter(), &options)
+        handle_args(byte_args.into_iter(), &options, format_args.as_deref())
     } else {
         let stdin = std::io::stdin();
         handle_buffer(stdin.lock(), &options)
@@ -598,8 +654,9 @@ mod tests {
     use uucore::error::get_exit_code;
 
     use super::{
-        FormatOptions, InvalidModes, NumfmtOptions, Range, RoundMethod, TransformOptions, Unit,
-        handle_args, handle_buffer, parse_unit_size, parse_unit_size_suffix,
+        FROM_UNIT, FormatOptions, InvalidModes, NumfmtOptions, Range, RoundMethod,
+        TransformOptions, Unit, handle_args, handle_buffer, parse_unit_size,
+        parse_unit_size_suffix,
     };
     use std::io::{BufReader, Error, ErrorKind, Read};
     struct MockBuffer {}
@@ -727,7 +784,7 @@ mod tests {
         let input_value = [b"5".as_slice(), b"4Q"].into_iter();
         let mut options = get_valid_options();
         options.invalid = InvalidModes::Fail;
-        handle_args(input_value, &options).unwrap();
+        handle_args(input_value, &options, None).unwrap();
         assert_eq!(
             get_exit_code(),
             2,
@@ -740,28 +797,28 @@ mod tests {
         let input_value = [b"5".as_slice(), b"4Q"].into_iter();
         let mut options = get_valid_options();
         options.invalid = InvalidModes::Warn;
-        let result = handle_args(input_value, &options);
+        let result = handle_args(input_value, &options, None);
         assert!(result.is_ok(), "did not return ok for invalid input");
     }
 
     #[test]
     fn test_parse_unit_size() {
-        assert_eq!(1, parse_unit_size("1").unwrap());
-        assert_eq!(1, parse_unit_size("01").unwrap());
-        assert!(parse_unit_size("1.1").is_err());
-        assert!(parse_unit_size("0").is_err());
-        assert!(parse_unit_size("-1").is_err());
-        assert!(parse_unit_size("A").is_err());
-        assert!(parse_unit_size("18446744073709551616").is_err());
+        assert_eq!(1, parse_unit_size("1", FROM_UNIT).unwrap());
+        assert_eq!(1, parse_unit_size("01", FROM_UNIT).unwrap());
+        assert!(parse_unit_size("1.1", FROM_UNIT).is_err());
+        assert!(parse_unit_size("0", FROM_UNIT).is_err());
+        assert!(parse_unit_size("-1", FROM_UNIT).is_err());
+        assert!(parse_unit_size("A", FROM_UNIT).is_err());
+        assert!(parse_unit_size("18446744073709551616", FROM_UNIT).is_err());
     }
 
     #[test]
     fn test_parse_unit_size_with_suffix() {
-        assert_eq!(1000, parse_unit_size("K").unwrap());
-        assert_eq!(1024, parse_unit_size("Ki").unwrap());
-        assert_eq!(2000, parse_unit_size("2K").unwrap());
-        assert_eq!(2048, parse_unit_size("2Ki").unwrap());
-        assert!(parse_unit_size("0K").is_err());
+        assert_eq!(1000, parse_unit_size("K", FROM_UNIT).unwrap());
+        assert_eq!(1024, parse_unit_size("Ki", FROM_UNIT).unwrap());
+        assert_eq!(2000, parse_unit_size("2K", FROM_UNIT).unwrap());
+        assert_eq!(2048, parse_unit_size("2Ki", FROM_UNIT).unwrap());
+        assert!(parse_unit_size("0K", FROM_UNIT).is_err());
     }
 
     #[test]

--- a/src/uu/numfmt/src/options.rs
+++ b/src/uu/numfmt/src/options.rs
@@ -139,6 +139,8 @@ pub enum FormatErrorKind {
     MissingDirective,
     /// A character that has no place in a directive.
     UnexpectedCharacter,
+    /// A directive ending on something other than `f`, such as `%d` or `%e`.
+    UnexpectedConversion,
     /// A width or precision that does not fit.
     NumberOverflow,
     /// A `%` in the suffix that is not part of a `%%` pair.
@@ -151,6 +153,22 @@ impl Display for FormatError {
     }
 }
 
+/// An option value that does not parse as a whole — a unit name, a unit size,
+/// a padding — so that the caret can underline it where it was typed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionValueError {
+    pub message: String,
+    /// Long name of the option the value came from, as in `from-unit`.
+    pub option: &'static str,
+    /// The value as given, which is how it is found among the arguments.
+    pub value: String,
+    /// Fluent identifier of the label under the caret, when one would add to
+    /// the message.
+    pub label: Option<&'static str>,
+    /// Fluent identifier of the line of advice under the report.
+    pub help: &'static str,
+}
+
 /// Why option parsing failed: a format error that still knows where in the
 /// format string it happened, or a plain message.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -158,7 +176,15 @@ pub enum ParseError {
     Format(FormatError),
     /// A `--field` list that does not parse, knowing where in the list.
     Field(uucore::ranges::RangeError),
+    /// An option value that is wrong from end to end.
+    Value(Box<OptionValueError>),
     Other(String),
+}
+
+impl From<OptionValueError> for ParseError {
+    fn from(error: OptionValueError) -> Self {
+        Self::Value(Box::new(error))
+    }
 }
 
 impl From<FormatError> for ParseError {
@@ -331,10 +357,18 @@ impl FromStr for FormatOptions {
         if let Some((_, 'f')) = iter.peek() {
             iter.next();
         } else {
+            // Only the character standing where the conversion belongs is at
+            // fault: whatever follows it would have been a valid suffix. At end
+            // of input there is no conversion to name, only one missing.
+            let kind = if iter.peek().is_none() {
+                FormatErrorKind::MissingDirective
+            } else {
+                FormatErrorKind::UnexpectedConversion
+            };
             return Err(error(
                 translate!("numfmt-error-invalid-format-directive", "format" => s),
                 at(&mut iter, s),
-                FormatErrorKind::UnexpectedCharacter,
+                kind,
             ));
         }
 

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1720,7 +1720,8 @@ numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
    ╭─[ numfmt:1:18 ]
    │
  1 │ numfmt --format=%q 1000
-   │                  ─
+   │                  ┬
+   │                  ╰── f is the only conversion numfmt has; %d, %e, %g and the other C conversions are not accepted
    │
    │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in \"%'-10.2f\"
 ───╯"
@@ -1799,18 +1800,260 @@ numfmt: format 'qwe' has no % directive
 
     #[cfg(unix)]
     #[test]
+    fn test_snippet_underlines_an_unknown_unit() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--from=xyz", "1000"])
+            .fails_with_code(1);
+
+        // The value is wrong as a whole, so it is underlined as a whole and
+        // the help lists what --from would have taken instead.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid argument 'xyz' for '--from'
+   ╭─[ numfmt:1:15 ]
+   │
+ 1 │ numfmt --from=xyz 1000
+   │               ───
+   │
+   │ Help: --from and --to take none, si, iec or iec-i, and --from also takes auto
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_says_auto_belongs_to_from() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--to", "auto", "1000"])
+            .fails_with_code(1);
+
+        // 'auto' exists, it is just not a unit --to can scale to; the label
+        // says so rather than leaving the help to imply it is unknown.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid argument 'auto' for '--to'
+   ╭─[ numfmt:1:13 ]
+   │
+ 1 │ numfmt --to auto 1000
+   │             ──┬─
+   │               ╰─── auto guesses the unit of the input, so only --from takes it
+   │
+   │ Help: --from and --to take none, si, iec or iec-i, and --from also takes auto
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_underlines_an_unknown_unit_size() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--from-unit=Q", "1000"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid unit size: 'Q'
+   ╭─[ numfmt:1:20 ]
+   │
+ 1 │ numfmt --from-unit=Q 1000
+   │                    ─
+   │
+   │ Help: a unit size is a number, a K, M, G, T, P or E multiplier, or both, as in 512, K or 2Ki
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_says_a_unit_size_cannot_be_zero() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--to-unit", "0", "1000"])
+            .fails_with_code(1);
+
+        // A zero is spelled like a valid size, so the label says what the
+        // syntax in the help cannot.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid unit size: '0'
+   ╭─[ numfmt:1:18 ]
+   │
+ 1 │ numfmt --to-unit 0 1000
+   │                  ┬
+   │                  ╰── a unit size must be at least 1
+   │
+   │ Help: a unit size is a number, a K, M, G, T, P or E multiplier, or both, as in 512, K or 2Ki
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_says_why_a_zero_padding_is_refused() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--padding=0", "1000"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid padding value '0'
+   ╭─[ numfmt:1:18 ]
+   │
+ 1 │ numfmt --padding=0 1000
+   │                  ┬
+   │                  ╰── a padding is a width in characters, so 0 asks for nothing
+   │
+   │ Help: --padding takes a non-zero whole number; a negative one left-aligns, as in --padding=-10
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_underlines_a_header_count() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--header=x", "1000"])
+            .fails_with_code(1);
+
+        // Nothing about 'x' is worth a label the message does not already
+        // carry, so the caret is bare and the help says what is taken.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid header value 'x'
+   ╭─[ numfmt:1:17 ]
+   │
+ 1 │ numfmt --header=x 1000
+   │                 ─
+   │
+   │ Help: --header takes the number of leading lines to pass through unchanged, at least 1
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_suffix_of_a_bad_number() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--to=si", "12abc"])
+            .fails_with_code(2);
+
+        // The number numfmt could read is left alone; the caret starts where
+        // it stopped.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid suffix in input: '12abc'
+   ╭─[ numfmt:1:18 ]
+   │
+ 1 │ numfmt --to=si 12abc
+   │                  ───
+   │
+   │ Help: without --from a number must be plain; --from=auto reads a K, M or Gi suffix
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_marks_an_input_that_is_not_a_number() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["abc"])
+            .fails_with_code(2);
+
+        // Nothing of it parsed, so all of it is marked, and advice about
+        // suffixes would be beside the point.
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid number: 'abc'
+   ╭─[ numfmt:1:8 ]
+   │
+ 1 │ numfmt abc
+   │        ───
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_points_at_the_i_a_unit_does_not_take() {
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--from=si", "1Ki"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid suffix in input '1Ki': 'i'
+   ╭─[ numfmt:1:20 ]
+   │
+ 1 │ numfmt --from=si 1Ki
+   │                    ─
+   │
+   │ Help: the suffixes are K, M, G, T, P, E, Z, Y, R and Q, with an optional i under --from=auto or iec-i
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_input_from_stdin_keeps_its_plain_message() {
+        // There is no command line to point at, so the message stays as it is.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .pipe_in("12abc\n")
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_str().trim_end(),
+            "numfmt: invalid suffix in input: '12abc'"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_a_line_of_fields_keeps_its_plain_message() {
+        // The failure is inside one field of the argument; the offsets are of
+        // the whole line, so no caret is drawn.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--field=2", "x 12abc"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_str().trim_end(),
+            "numfmt: invalid suffix in input: '12abc'"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_other_option_errors_keep_their_plain_message() {
         // The format is fine; the failure is elsewhere and must not be
         // decorated with a caret into --format. The pseudo-terminal turns the
         // newline into CRLF, hence the trim.
         let result = new_ucmd!()
             .terminal_sim_stderr()
-            .args(&["--format=%f", "--padding=0", "1000"])
+            .args(&["--format=%f", "--delimiter=ab", "1000"])
             .fails_with_code(1);
 
         assert_eq!(
             result.stderr_str().trim_end(),
-            "numfmt: invalid padding value '0'"
+            "numfmt: the delimiter must be a single character"
         );
     }
 
@@ -1831,9 +2074,149 @@ numfmt: invalid format '%q', directive must be %[0]['][-][N][.][N]f
    ╭─[ numfmt:1:33 ]
    │
  1 │ numfmt --delimiter=%q --format=%q 1000
-   │                                 ─
+   │                                 ┬
+   │                                 ╰── f is the only conversion numfmt has; %d, %e, %g and the other C conversions are not accepted
    │
    │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in \"%'-10.2f\"
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_marks_a_whitespace_only_number() {
+        // There is no number to point past, so the whitespace is marked whole
+        // rather than the two ends of it crossing.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&[" "])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid number: ''
+   ╭─[ numfmt:1:9 ]
+   │
+ 1 │ numfmt ' '
+   │         ─
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_ignores_an_option_value_with_the_number_text() {
+        // --suffix takes a detached `q`, the same text as the operand; the
+        // caret must land on the operand, not on the value that precedes it.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--suffix", "q", "--from", "si", "q"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid number: ''
+   ╭─[ numfmt:1:29 ]
+   │
+ 1 │ numfmt --suffix q --from si q
+   │                             ─
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_says_nothing_about_suffixes_without_a_number() {
+        // A lone sign is the start of a number but not one yet, so advice about
+        // what may follow a number does not apply.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--from=si", "--", "-"])
+            .fails_with_code(2);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid number: '-'
+   ╭─[ numfmt:1:21 ]
+   │
+ 1 │ numfmt --from=si -- -
+   │                     ─
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_names_no_conversion_when_the_format_has_none() {
+        // Nothing stands where the conversion belongs, so there is no
+        // conversion to name — only a directive that never ends.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--format=%10", "1000"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid format '%10', directive must be %[0]['][-][N][.][N]f
+   ╭─[ numfmt:1:17 ]
+   │
+ 1 │ numfmt --format=%10 1000
+   │                 ───
+   │
+   │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in \"%'-10.2f\"
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_leaves_the_suffix_out_of_the_bad_conversion() {
+        // What follows the conversion would have been a valid suffix, so only
+        // the character standing in for `f` is underlined.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--format=%d bytes", "1000"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid format '%d bytes', directive must be %[0]['][-][N][.][N]f
+   ╭─[ numfmt:1:19 ]
+   │
+ 1 │ numfmt '--format=%d bytes' 1000
+   │                   ┬
+   │                   ╰── f is the only conversion numfmt has; %d, %e, %g and the other C conversions are not accepted
+   │
+   │ Help: a format is [PREFIX]%[0]['][-][WIDTH][.PRECISION]f[SUFFIX], as in \"%'-10.2f\"
+───╯"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_snippet_blames_the_suffix_not_the_zero_in_a_unit_size() {
+        // `0x` fails on the unknown `x`, not on the zero, so the label about a
+        // size of at least 1 would be beside the point.
+        let result = new_ucmd!()
+            .terminal_sim_stderr()
+            .args(&["--from-unit=0x", "1"])
+            .fails_with_code(1);
+
+        assert_eq!(
+            result.stderr_as_displayed(),
+            "\
+numfmt: invalid unit size: '0x'
+   ╭─[ numfmt:1:20 ]
+   │
+ 1 │ numfmt --from-unit=0x 1
+   │                    ──
+   │
+   │ Help: a unit size is a number, a K, M, G, T, P or E multiplier, or both, as in 512, K or 2Ki
 ───╯"
         );
     }


### PR DESCRIPTION
An invalid --format directive pointed at a single character, and said nothing about what numfmt would have accepted there. Label the caret with the one conversion numfmt has, since %d, %e and the other C conversions are commonly tried there -- but only where one was actually typed: a format that ends before its conversion, as in "%10", has none to name, and only the character standing in for the f is at fault, so a valid suffix after it stays out of the underline.

The caret a refused number gets is placed the same way, and now:

  - survives a whitespace-only operand, whose leading and trailing offsets crossed and panicked when sliced;
  - lands on the operand rather than on the detached value of an earlier option that happens to carry the same text, as in `--suffix q --from si q`;
  - keeps quiet about suffixes for an input holding no number at all, a lone sign being the start of one but not yet one.

A unit size loses the "must be at least 1" label when an unknown suffix, not the zero, is what it got wrong.