### PR TITLE
ptx: reduce per-word allocation overhead and speedup line scans

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -181,11 +181,11 @@ impl WordFilter {
 #[derive(Debug, PartialOrd, PartialEq, Eq, Ord)]
 struct WordRef {
     word: String,
-    global_line_nr: usize,
+    file_index: usize,
     local_line_nr: usize,
     position: usize,
     position_end: usize,
-    filename: OsString,
+    char_start: usize,
 }
 
 fn get_config(matches: &mut clap::ArgMatches) -> UResult<Config> {
@@ -257,14 +257,12 @@ fn get_config(matches: &mut clap::ArgMatches) -> UResult<Config> {
 struct FileContent {
     lines: Vec<String>,
     chars_lines: Vec<Vec<char>>,
-    offset: usize,
 }
 
 type FileMap = Vec<(OsString, FileContent)>;
 
 fn read_input(input_files: &[OsString], config: &Config) -> UResult<FileMap> {
     let mut file_map: FileMap = FileMap::new();
-    let mut offset: usize = 0;
 
     let sentence_splitter = config
         .sentence_regex
@@ -288,16 +286,7 @@ fn read_input(input_files: &[OsString], config: &Config) -> UResult<FileMap> {
         // Indexing UTF-8 string requires walking from the beginning, which can hurts performance badly when the line is long.
         // Since we will be jumping around the line a lot, we dump the content into a Vec<char>, which can be indexed in constant time.
         let chars_lines: Vec<Vec<char>> = lines.iter().map(|x| x.chars().collect()).collect();
-        let size = lines.len();
-        file_map.push((
-            filename.clone(),
-            FileContent {
-                lines,
-                chars_lines,
-                offset,
-            },
-        ));
-        offset += size;
+        file_map.push((filename.clone(), FileContent { lines, chars_lines }));
     }
     Ok(file_map)
 }
@@ -330,15 +319,16 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
     };
 
     let mut word_set: BTreeSet<WordRef> = BTreeSet::new();
-    for (file, lines) in file_map {
+    for (file_index, (_, lines)) in file_map.iter().enumerate() {
         let mut count: usize = 0;
-        let offs = lines.offset;
         for line in &lines.lines {
             // if -r, exclude reference from word set
             let (ref_beg, ref_end) = match ref_reg.find(line) {
                 Some(x) => (x.start(), x.end()),
                 None => (0, 0),
             };
+            let mut last_counted_byte = 0;
+            let mut char_start = 0;
             // match words with given regex
             for mat in reg.find_iter(line) {
                 let (mut beg, end) = (mat.start(), mat.end());
@@ -367,13 +357,17 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
                 if config.ignore_case {
                     word = word.to_uppercase();
                 }
+
+                // Count from the previous match to avoid rescanning the line prefix.
+                char_start += line[last_counted_byte..beg].chars().count();
+                last_counted_byte = beg;
                 word_set.insert(WordRef {
                     word,
-                    filename: file.clone(),
-                    global_line_nr: offs + count,
+                    file_index,
                     local_line_nr: count,
                     position: beg,
                     position_end: end,
+                    char_start,
                 });
             }
             count += 1;
@@ -382,16 +376,18 @@ fn create_word_set(config: &Config, filter: &WordFilter, file_map: &FileMap) -> 
     word_set
 }
 
-fn get_reference(config: &Config, word_ref: &WordRef, line: &str, context_reg: &Regex) -> String {
+fn get_reference(
+    config: &Config,
+    word_ref: &WordRef,
+    filename: &OsStr,
+    line: &str,
+    context_reg: &Regex,
+) -> String {
     if config.auto_ref {
-        if word_ref.filename == "-" {
+        if filename == "-" {
             format!(":{}", word_ref.local_line_nr + 1)
         } else {
-            format!(
-                "{}:{}",
-                word_ref.filename.maybe_quote(),
-                word_ref.local_line_nr + 1
-            )
+            format!("{}:{}", filename.maybe_quote(), word_ref.local_line_nr + 1)
         }
     } else if config.input_ref {
         let (beg, end) = match context_reg.find(line) {
@@ -735,9 +731,7 @@ fn prepare_line_chunks(
     chars_line: &[char],
     reference: &str,
 ) -> (String, String, String, String, String) {
-    // Convert byte positions to character positions
-    let ref_char_position = line[..word_ref.position].chars().count();
-    let char_position_end = ref_char_position
+    let char_position_end = word_ref.char_start
         + line[word_ref.position..word_ref.position_end]
             .chars()
             .count();
@@ -745,16 +739,11 @@ fn prepare_line_chunks(
     // Extract the text before the keyword
     let all_before = if config.input_ref {
         let before = &line[..word_ref.position];
-        let before_char_count = before.chars().count();
-        let trimmed_char_count = before
-            .trim_start_matches(reference)
-            .trim_start()
-            .chars()
-            .count();
-        let trim_offset = before_char_count - trimmed_char_count;
-        &chars_line[trim_offset..before_char_count]
+        let stripped = before.trim_start_matches(reference).trim_start();
+        let trim_offset = before[..before.len() - stripped.len()].chars().count();
+        &chars_line[trim_offset..word_ref.char_start]
     } else {
-        &chars_line[..ref_char_position]
+        &chars_line[..word_ref.char_start]
     };
 
     // Extract the keyword and text after it
@@ -786,7 +775,7 @@ fn write_traditional_output(
 
     if !config.right_ref {
         let max_ref_len = if config.auto_ref {
-            get_auto_max_reference_len(words)
+            get_auto_max_reference_len(words, file_map)
         } else {
             0
         };
@@ -796,26 +785,12 @@ fn write_traditional_output(
     }
 
     for word_ref in words {
-        // Since `ptx` accepts duplicate file arguments (e.g., `ptx file file`),
-        // simply looking up by filename is ambiguous.
-        // We use the `global_line_nr` (which is unique across the entire input stream)
-        // to identify which file covers this line.
-        let (_, file_map_value) = file_map
-            .iter()
-            .find(|(name, content)| {
-                name == &word_ref.filename
-                    && word_ref.global_line_nr >= content.offset
-                    && word_ref.global_line_nr < content.offset + content.lines.len()
-            })
-            .expect("Missing file in file map");
-        let FileContent {
-            ref lines,
-            ref chars_lines,
-            offset: _,
-        } = *(file_map_value);
+        let (filename, file_map_value) = &file_map[word_ref.file_index];
+        let FileContent { lines, chars_lines } = file_map_value;
         let reference = get_reference(
             config,
             word_ref,
+            filename,
             &lines[word_ref.local_line_nr],
             &context_reg,
         );
@@ -853,7 +828,7 @@ fn write_traditional_output(
     Ok(())
 }
 
-fn get_auto_max_reference_len(words: &BTreeSet<WordRef>) -> usize {
+fn get_auto_max_reference_len(words: &BTreeSet<WordRef>, file_map: &FileMap) -> usize {
     //Get the maximum length of the reference field
     let line_num = words
         .iter()
@@ -869,8 +844,9 @@ fn get_auto_max_reference_len(words: &BTreeSet<WordRef>) -> usize {
 
     let filename_len = words
         .iter()
-        .filter(|w| w.filename != "-")
-        .map(|w| w.filename.maybe_quote().to_string().len())
+        .map(|w| &file_map[w.file_index].0)
+        .filter(|filename| *filename != "-")
+        .map(|filename| filename.maybe_quote().to_string().len())
         .max()
         .unwrap_or(0);
 


### PR DESCRIPTION
While working on a research project involving testing open-source programs, I noticed that uutils ptx was relatively slow when processing long lines. In this PR, I explored a few optimizations.

Currently, `ptx` clones the filename into every word reference and repeatedly scans line prefixes to convert byte positions into character positions. This adds unnecessary allocations and repeated work, especially for inputs with long lines or many indexed words. This change stores a file index instead of a filename and global line offset, uses direct `FileMap` lookups, and calculates character positions incrementally by keeping a running count while scanning each line. 

Any feedback is appreciated!