### PR TITLE
fix(deps): refactor RustCrypto crates package configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,12 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common 0.2.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -506,14 +506,14 @@ z85 = "3.0.5"
 zip = { version = "8.0.0", default-features = false, features = ["deflate"] }
 
 hex = "0.4.3"
-md-5 = "0.11.0"
-sha1 = "0.11.0"
-sha2 = "0.11.0"
-sha3 = "0.12.0"
+md-5 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+sha1 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+sha3 = { version = "0.12.0", default-features = false, features = ["alloc"] }
 shake = "0.1.0"
 blake2b_simd = "1.0.2"
 blake3 = "1.5.1"
-sm3 = "0.5.0"
+sm3 = { version = "0.5.0", default-features = false, features = ["alloc"] }
 crc-fast = { version = "1.5.0", default-features = false }
 digest = "0.11.0"
 openssl = { version = "0.10", features = ["vendored"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -310,12 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,7 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common 0.2.2",
 ]
 


### PR DESCRIPTION
Drop the unused transitive `const-oid` dependency.