### PR TITLE
man pages: fix typo, merged lists and wrong indentations

### DIFF
--- a/src/uu/cksum/locales/en-US.ftl
+++ b/src/uu/cksum/locales/en-US.ftl
@@ -1,14 +1,15 @@
 cksum-about = Print CRC and size for each file
 cksum-usage = cksum [OPTIONS] [FILE]...
-cksum-after-help = DIGEST determines the digest algorithm and default output format:
+cksum-after-help = DIGEST determines the digest algorithm and default output
+  format:
 
-  - sysv: equivalent to sum -s
-  - bsd: equivalent to sum -r
-  - crc: equivalent to cksum
-  - crc32b: only available through cksum
-  - md5: equivalent to md5sum
-  - sha1: equivalent to sha1sum
-  - sha2: equivalent to sha{"{224,256,384,512}"}sum
-  - sha3: only available through cksum
-  - blake2b: equivalent to b2sum
-  - sm3: only available through cksum
+    - sysv: equivalent to sum -s
+    - bsd: equivalent to sum -r
+    - crc: equivalent to cksum
+    - crc32b: only available through cksum
+    - md5: equivalent to md5sum
+    - sha1: equivalent to sha1sum
+    - sha2: equivalent to sha{"{224,256,384,512}"}sum
+    - sha3: only available through cksum
+    - blake2b: equivalent to b2sum
+    - sm3: only available through cksum

--- a/src/uu/cksum/locales/en-US.ftl
+++ b/src/uu/cksum/locales/en-US.ftl
@@ -2,13 +2,13 @@ cksum-about = Print CRC and size for each file
 cksum-usage = cksum [OPTIONS] [FILE]...
 cksum-after-help = DIGEST determines the digest algorithm and default output format:
 
-  - sysv: (equivalent to sum -s)
-  - bsd: (equivalent to sum -r)
-  - crc: (equivalent to cksum)
-  - crc32b: (only available through cksum)
-  - md5: (equivalent to md5sum)
-  - sha1: (equivalent to sha1sum)
-  - sha2: (equivalent to sha{"{224,256,384,512}"}sum)
-  - sha3: (only available through cksum)
-  - blake2b: (equivalent to b2sum)
-  - sm3: (only available through cksum)
+  - sysv: equivalent to sum -s
+  - bsd: equivalent to sum -r
+  - crc: equivalent to cksum
+  - crc32b: only available through cksum
+  - md5: equivalent to md5sum
+  - sha1: equivalent to sha1sum
+  - sha2: equivalent to sha{"{224,256,384,512}"}sum
+  - sha3: only available through cksum
+  - blake2b: equivalent to b2sum
+  - sm3: only available through cksum

--- a/src/uu/cksum/locales/fr-FR.ftl
+++ b/src/uu/cksum/locales/fr-FR.ftl
@@ -1,14 +1,15 @@
 cksum-about = Afficher le CRC et la taille de chaque fichier
 cksum-usage = cksum [OPTION]... [FICHIER]...
-cksum-after-help = DIGEST détermine l'algorithme de condensé et le format de sortie par défaut :
+cksum-after-help = DIGEST détermine l'algorithme de condensé et le format de sortie
+  par défaut :
 
-  - sysv : équivalent à sum -s
-  - bsd : équivalent à sum -r
-  - crc : équivalent à cksum
-  - crc32b : disponible uniquement via cksum
-  - md5 : équivalent à md5sum
-  - sha1 : équivalent à sha1sum
-  - sha2: équivalent à sha{"{224,256,384,512}"}sum
-  - sha3 : disponible uniquement via cksum
-  - blake2b : équivalent à b2sum
-  - sm3 : disponible uniquement via cksum
+    - sysv : équivalent à sum -s
+    - bsd : équivalent à sum -r
+    - crc : équivalent à cksum
+    - crc32b : disponible uniquement via cksum
+    - md5 : équivalent à md5sum
+    - sha1 : équivalent à sha1sum
+    - sha2: équivalent à sha{"{224,256,384,512}"}sum
+    - sha3 : disponible uniquement via cksum
+    - blake2b : équivalent à b2sum
+    - sm3 : disponible uniquement via cksum

--- a/src/uu/cksum/locales/fr-FR.ftl
+++ b/src/uu/cksum/locales/fr-FR.ftl
@@ -2,13 +2,13 @@ cksum-about = Afficher le CRC et la taille de chaque fichier
 cksum-usage = cksum [OPTION]... [FICHIER]...
 cksum-after-help = DIGEST détermine l'algorithme de condensé et le format de sortie par défaut :
 
-  - sysv : (équivalent à sum -s)
-  - bsd : (équivalent à sum -r)
-  - crc : (équivalent à cksum)
-  - crc32b : (disponible uniquement via cksum)
-  - md5 : (équivalent à md5sum)
-  - sha1 : (équivalent à sha1sum)
-  - sha2: (équivalent à sha{"{224,256,384,512}"}sum)
-  - sha3 : (disponible uniquement via cksum)
-  - blake2b : (équivalent à b2sum)
-  - sm3 : (disponible uniquement via cksum)
+  - sysv : équivalent à sum -s
+  - bsd : équivalent à sum -r
+  - crc : équivalent à cksum
+  - crc32b : disponible uniquement via cksum
+  - md5 : équivalent à md5sum
+  - sha1 : équivalent à sha1sum
+  - sha2: équivalent à sha{"{224,256,384,512}"}sum
+  - sha3 : disponible uniquement via cksum
+  - blake2b : équivalent à b2sum
+  - sm3 : disponible uniquement via cksum

--- a/src/uu/cp/locales/en-US.ftl
+++ b/src/uu/cp/locales/en-US.ftl
@@ -12,9 +12,11 @@ cp-after-help = Do not copy a non-directory that has an existing destination wit
   to mirror hard links in the source. which gives more control over which existing files in the destination are
   replaced, and its value can be one of the following:
 
-  - all This is the default operation when an --update option is not specified, and results in all existing files in the destination being replaced.
-  - none This is similar to the --no-clobber option, in that no files in the destination are replaced, but also skipping a file does not induce a failure.
-  - older This is the default operation when --update is specified, and results in files being replaced if they're older than the corresponding source file.
+  - all: This is the default operation when an --update option is not specified, and results in all existing files in the destination being replaced.
+
+  - none: This is similar to the --no-clobber option, in that no files in the destination are replaced, but also skipping a file does not induce a failure.
+
+  - older: This is the default operation when --update is specified, and results in files being replaced if they're older than the corresponding source file.
 
 # Help messages
 cp-help-target-directory = copy all SOURCE arguments into target-directory

--- a/src/uu/cp/locales/fr-FR.ftl
+++ b/src/uu/cp/locales/fr-FR.ftl
@@ -12,9 +12,11 @@ cp-after-help = Ne pas copier un non-répertoire qui a une destination existante
   pour refléter les liens durs dans la source. ce qui donne plus de contrôle sur les fichiers existants dans la destination qui sont
   remplacés, et sa valeur peut être l'une des suivantes :
 
-  - all C'est l'opération par défaut lorsqu'une option --update n'est pas spécifiée, et entraîne le remplacement de tous les fichiers existants dans la destination.
-  - none Cela est similaire à l'option --no-clobber, en ce sens qu'aucun fichier dans la destination n'est remplacé, mais ignorer un fichier n'induit pas d'échec.
-  - older C'est l'opération par défaut lorsque --update est spécifié, et entraîne le remplacement des fichiers s'ils sont plus anciens que le fichier source correspondant.
+  - all : C'est l'opération par défaut lorsqu'une option --update n'est pas spécifiée, et entraîne le remplacement de tous les fichiers existants dans la destination.
+
+  - none : Cela est similaire à l'option --no-clobber, en ce sens qu'aucun fichier dans la destination n'est remplacé, mais ignorer un fichier n'induit pas d'échec.
+
+  - older : C'est l'opération par défaut lorsque --update est spécifié, et entraîne le remplacement des fichiers s'ils sont plus anciens que le fichier source correspondant.
 
 # Messages d'aide
 cp-help-target-directory = copier tous les arguments SOURCE dans le répertoire cible

--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -3,115 +3,76 @@ dd-usage = dd [OPERAND]...
   dd OPTION
 dd-after-help = Operands:
 
-  - bs=BYTES : read and write up to BYTES bytes at a time (default: 512);
-     overwrites ibs and obs.
-  - cbs=BYTES : the 'conversion block size' in bytes. Applies to the
-     conv=block, and conv=unblock operations.
-  - conv=CONVS : a comma-separated list of conversion options or (for legacy
-     reasons) file flags.
-  - count=N : stop reading input after N ibs-sized read operations rather
-     than proceeding until EOF. See iflag=count_bytes if stopping after N bytes
-     is preferred
-  - ibs=N : the size of buffer used for reads (default: 512)
-  - if=FILE : the file used for input. When not specified, stdin is used instead
-  - iflag=FLAGS : a comma-separated list of input flags which specify how the
-     input source is treated. FLAGS may be any of the input-flags or general-flags
-     specified below.
-  - skip=N (or iseek=N) : skip N ibs-sized records into input before beginning
-     copy/convert operations. See iflag=seek_bytes if seeking N bytes is preferred.
-  - obs=N : the size of buffer used for writes (default: 512)
-  - of=FILE : the file used for output. When not specified, stdout is used
-     instead
-  - oflag=FLAGS : comma separated list of output flags which specify how the
-     output source is treated. FLAGS may be any of the output flags or general
-     flags specified below
-  - seek=N (or oseek=N) : seeks N obs-sized records into output before
-     beginning copy/convert operations. See oflag=seek_bytes if seeking N bytes is
-     preferred
-  - status=LEVEL : controls whether volume and performance stats are written to
-     stderr.
+    - bs=BYTES : read and write up to BYTES bytes at a time (default: 512); overwrites ibs and obs.
+    - cbs=BYTES : the 'conversion block size' in bytes. Applies to the conv=block, and conv=unblock operations.
+    - conv=CONVS : a comma-separated list of conversion options or (for legacy reasons) file flags.
+    - count=N : stop reading input after N ibs-sized read operations rather than proceeding until EOF. See iflag=count_bytes if stopping after N bytes is preferred
+    - ibs=N : the size of buffer used for reads (default: 512)
+    - if=FILE : the file used for input. When not specified, stdin is used instead
+    - iflag=FLAGS : a comma-separated list of input flags which specify how the input source is treated. FLAGS may be any of the input-flags or general-flags specified below.
+    - skip=N (or iseek=N) : skip N ibs-sized records into input before beginning copy/convert operations. See iflag=seek_bytes if seeking N bytes is preferred.
+    - obs=N : the size of buffer used for writes (default: 512)
+    - of=FILE : the file used for output. When not specified, stdout is used instead
+    - oflag=FLAGS : comma separated list of output flags which specify how the output source is treated. FLAGS may be any of the output flags or general flags specified below
+    - seek=N (or oseek=N) : seeks N obs-sized records into output before beginning copy/convert operations. See oflag=seek_bytes if seeking N bytes is preferred
+    - status=LEVEL : controls whether volume and performance stats are written to stderr.
 
-    When unspecified, dd will print stats upon completion. An example is below.
+      When unspecified, dd will print stats upon completion. An example is below.
 
-      6+0 records in
-      16+0 records out
-      8192 bytes (8.2 kB, 8.0 KiB) copied, 0.00057009 s,
-      14.4 MB/s
+        6+0 records in
+        16+0 records out
+        8192 bytes (8.2 kB, 8.0 KiB) copied, 0.00057009 s,
+        14.4 MB/s
 
-    The first two lines are the 'volume' stats and the final line is the
-    'performance' stats.
-    The volume stats indicate the number of complete and partial ibs-sized reads,
-    or obs-sized writes that took place during the copy. The format of the volume
-    stats is <complete>+<partial>. If records have been truncated (see
-    conv=block), the volume stats will contain the number of truncated records.
+      The first two lines are the 'volume' stats and the final line is the 'performance' stats. The volume stats indicate the number of complete and partial ibs-sized reads, or obs-sized writes that took place during the copy. The format of the volume stats is <complete>+<partial>. If records have been truncated (see conv=block), the volume stats will contain the number of truncated records.
 
-    Possible LEVEL values are:
-    - progress : Print periodic performance stats as the copy proceeds.
-    - noxfer : Print final volume stats, but not performance stats.
-    - none : Do not print any stats.
+      Possible LEVEL values are:
+        - progress : Print periodic performance stats as the copy proceeds.
+        - noxfer : Print final volume stats, but not performance stats.
+        - none : Do not print any stats.
 
-    Printing performance stats is also triggered by the INFO signal (where supported),
-    or the USR1 signal. Setting the POSIXLY_CORRECT environment variable to any value
-    (including an empty value) will cause the USR1 signal to be ignored.
+      Printing performance stats is also triggered by the INFO signal (where supported), or the USR1 signal. Setting the POSIXLY_CORRECT environment variable to any value (including an empty value) will cause the USR1 signal to be ignored.
 
   Conversion options:
 
-  - ascii : convert from EBCDIC to ASCII. This is the inverse of the ebcdic
-    option. Implies conv=unblock.
-  - ebcdic : convert from ASCII to EBCDIC. This is the inverse of the ascii
-    option. Implies conv=block.
-  - ibm : convert from ASCII to EBCDIC, applying the conventions for [, ]
-    and ~ specified in POSIX. Implies conv=block.
-
-  - ucase : convert from lower-case to upper-case.
-  - lcase : convert from upper-case to lower-case.
-
-  - block : for each newline less than the size indicated by cbs=BYTES, remove
-    the newline and pad with spaces up to cbs. Lines longer than cbs are truncated.
-  - unblock : for each block of input of the size indicated by cbs=BYTES, remove
-    right-trailing spaces and replace with a newline character.
-
-  - sparse : attempts to seek the output when an obs-sized block consists of
-    only zeros.
-  - swab : swaps each adjacent pair of bytes. If an odd number of bytes is
-    present, the final byte is omitted.
-  - sync : pad each ibs-sided block with zeros. If block or unblock is
-    specified, pad with spaces instead.
-  - excl : the output file must be created. Fail if the output file is already
-    present.
-  - nocreat : the output file will not be created. Fail if the output file is
-    not already present.
-  - notrunc : the output file will not be truncated. If this option is not
-    present, output will be truncated when opened.
-  - noerror : all read errors will be ignored. If this option is not present,
-    dd will only ignore Error::Interrupted.
-  - fdatasync : data will be written before finishing.
-  - fsync : data and metadata will be written before finishing.
+    - ascii : convert from EBCDIC to ASCII. This is the inverse of the ebcdic option. Implies conv=unblock.
+    - ebcdic : convert from ASCII to EBCDIC. This is the inverse of the ascii option. Implies conv=block.
+    - ibm : convert from ASCII to EBCDIC, applying the conventions for [, ] and ~ specified in POSIX. Implies conv=block.
+    - ucase : convert from lower-case to upper-case.
+    - lcase : convert from upper-case to lower-case.
+    - block : for each newline less than the size indicated by cbs=BYTES, remove the newline and pad with spaces up to cbs. Lines longer than cbs are truncated.
+    - unblock : for each block of input of the size indicated by cbs=BYTES, remove right-trailing spaces and replace with a newline character.
+    - sparse : attempts to seek the output when an obs-sized block consists of only zeros.
+    - swab : swaps each adjacent pair of bytes. If an odd number of bytes is present, the final byte is omitted.
+    - sync : pad each ibs-sided block with zeros. If block or unblock is specified, pad with spaces instead.
+    - excl : the output file must be created. Fail if the output file is already present.
+    - nocreat : the output file will not be created. Fail if the output file is not already present.
+    - notrunc : the output file will not be truncated. If this option is not present, output will be truncated when opened.
+    - noerror : all read errors will be ignored. If this option is not present, dd will only ignore Error::Interrupted.
+    - fdatasync : data will be written before finishing.  - fsync : data and metadata will be written before finishing.
 
   Input flags:
 
-  - count_bytes : a value to count=N will be interpreted as bytes.
-  - skip_bytes : a value to skip=N will be interpreted as bytes.
-  - fullblock : wait for ibs bytes from each read. zero-length reads are still
-    considered EOF.
+    - count_bytes : a value to count=N will be interpreted as bytes.
+    - skip_bytes : a value to skip=N will be interpreted as bytes.
+    - fullblock : wait for ibs bytes from each read. zero-length reads are still considered EOF.
 
   Output flags:
 
-  - append : open file in append mode. Consider setting conv=notrunc as well.
-  - seek_bytes : a value to seek=N will be interpreted as bytes.
+    - append : open file in append mode. Consider setting conv=notrunc as well.
+    - seek_bytes : a value to seek=N will be interpreted as bytes.
 
   General flags:
 
-  - direct : use direct I/O for data.
-  - directory : fail unless the given input (if used as an iflag) or
-    output (if used as an oflag) is a directory.
-  - dsync : use synchronized I/O for data.
-  - sync : use synchronized I/O for data and metadata.
-  - nonblock : use non-blocking I/O.
-  - noatime : do not update access time.
-  - nocache : request that OS drop cache.
-  - noctty : do not assign a controlling tty.
-  - nofollow : do not follow system links.
+    - direct : use direct I/O for data.
+    - directory : fail unless the given input (if used as an iflag) or output (if used as an oflag) is a directory.
+    - dsync : use synchronized I/O for data.
+    - sync : use synchronized I/O for data and metadata.
+    - nonblock : use non-blocking I/O.
+    - noatime : do not update access time.
+    - nocache : request that OS drop cache.
+    - noctty : do not assign a controlling tty.
+    - nofollow : do not follow system links.
 
 # Common strings
 dd-standard-input = 'standard input'

--- a/src/uu/dd/locales/en-US.ftl
+++ b/src/uu/dd/locales/en-US.ftl
@@ -64,7 +64,7 @@ dd-after-help = Operands:
     and ~ specified in POSIX. Implies conv=block.
 
   - ucase : convert from lower-case to upper-case.
-  - lcase : converts from upper-case to lower-case.
+  - lcase : convert from upper-case to lower-case.
 
   - block : for each newline less than the size indicated by cbs=BYTES, remove
     the newline and pad with spaces up to cbs. Lines longer than cbs are truncated.
@@ -79,7 +79,7 @@ dd-after-help = Operands:
     specified, pad with spaces instead.
   - excl : the output file must be created. Fail if the output file is already
     present.
-  - nocreat : the output file will not be created. Fail if the output file in
+  - nocreat : the output file will not be created. Fail if the output file is
     not already present.
   - notrunc : the output file will not be truncated. If this option is not
     present, output will be truncated when opened.

--- a/src/uu/dd/locales/fr-FR.ftl
+++ b/src/uu/dd/locales/fr-FR.ftl
@@ -3,33 +3,19 @@ dd-usage = dd [OPÉRANDE]...
   dd OPTION
 dd-after-help = Opérandes :
 
-  - bs=OCTETS : lire et écrire jusqu'à OCTETS octets à la fois (par défaut : 512) ;
-     remplace ibs et obs.
-  - cbs=OCTETS : la 'taille de bloc de conversion' en octets. S'applique aux
-     opérations conv=block et conv=unblock.
-  - conv=CONVS : une liste séparée par des virgules d'options de conversion ou (pour des
-     raisons historiques) d'indicateurs de fichier.
-  - count=N : arrêter la lecture de l'entrée après N opérations de lecture de taille ibs
-     plutôt que de continuer jusqu'à EOF. Voir iflag=count_bytes si l'arrêt après N octets
-     est préféré
-  - ibs=N : la taille du tampon utilisé pour les lectures (par défaut : 512)
-  - if=FICHIER : le fichier utilisé pour l'entrée. Quand non spécifié, stdin est utilisé à la place
-  - iflag=INDICATEURS : une liste séparée par des virgules d'indicateurs d'entrée qui spécifient comment
-     la source d'entrée est traitée. INDICATEURS peut être n'importe lequel des indicateurs d'entrée ou
-     indicateurs généraux spécifiés ci-dessous.
-  - skip=N (ou iseek=N) : ignorer N enregistrements de taille ibs dans l'entrée avant de commencer
-     les opérations de copie/conversion. Voir iflag=seek_bytes si la recherche de N octets est préférée.
-  - obs=N : la taille du tampon utilisé pour les écritures (par défaut : 512)
-  - of=FICHIER : le fichier utilisé pour la sortie. Quand non spécifié, stdout est utilisé
-     à la place
-  - oflag=INDICATEURS : liste séparée par des virgules d'indicateurs de sortie qui spécifient comment la
-     source de sortie est traitée. INDICATEURS peut être n'importe lequel des indicateurs de sortie ou
-     indicateurs généraux spécifiés ci-dessous
-  - seek=N (ou oseek=N) : recherche N enregistrements de taille obs dans la sortie avant de
-     commencer les opérations de copie/conversion. Voir oflag=seek_bytes si la recherche de N octets est
-     préférée
-  - status=NIVEAU : contrôle si les statistiques de volume et de performance sont écrites sur
-     stderr.
+      - bs=OCTETS : lire et écrire jusqu'à OCTETS octets à la fois (par défaut : 512) ; remplace ibs et obs.
+      - cbs=OCTETS : la 'taille de bloc de conversion' en octets. S'applique aux opérations conv=block et conv=unblock.
+      - conv=CONVS : une liste séparée par des virgules d'options de conversion ou (pour des raisons historiques) d'indicateurs de fichier.
+      - count=N : arrêter la lecture de l'entrée après N opérations de lecture de taille ibs plutôt que de continuer jusqu'à EOF. Voir iflag=count_bytes si l'arrêt après N octets est préféré
+      - ibs=N : la taille du tampon utilisé pour les lectures (par défaut : 512)
+      - if=FICHIER : le fichier utilisé pour l'entrée. Quand non spécifié, stdin est utilisé à la place
+      - iflag=INDICATEURS : une liste séparée par des virgules d'indicateurs d'entrée qui spécifient comment la source d'entrée est traitée. INDICATEURS peut être n'importe lequel des indicateurs d'entrée ou indicateurs généraux spécifiés ci-dessous.
+      - skip=N (ou iseek=N) : ignorer N enregistrements de taille ibs dans l'entrée avant de commencer les opérations de copie/conversion. Voir iflag=seek_bytes si la recherche de N octets est préférée.
+      - obs=N : la taille du tampon utilisé pour les écritures (par défaut : 512)
+      - of=FICHIER : le fichier utilisé pour la sortie. Quand non spécifié, stdout est utilisé à la place
+      - oflag=INDICATEURS : liste séparée par des virgules d'indicateurs de sortie qui spécifient comment la source de sortie est traitée. INDICATEURS peut être n'importe lequel des indicateurs de sortie ou indicateurs généraux spécifiés ci-dessous
+      - seek=N (ou oseek=N) : recherche N enregistrements de taille obs dans la sortie avant de commencer les opérations de copie/conversion. Voir oflag=seek_bytes si la recherche de N octets est préférée
+      - status=NIVEAU : contrôle si les statistiques de volume et de performance sont écrites sur stderr.
 
     Quand non spécifié, dd affichera les statistiques à la fin. Un exemple est ci-dessous.
 
@@ -38,80 +24,56 @@ dd-after-help = Opérandes :
       8192 octets (8.2 kB, 8.0 KiB) copiés, 0.00057009 s,
       14.4 MB/s
 
-    Les deux premières lignes sont les statistiques de 'volume' et la dernière ligne est les
-    statistiques de 'performance'.
-    Les statistiques de volume indiquent le nombre de lectures complètes et partielles de taille ibs,
-    ou d'écritures de taille obs qui ont eu lieu pendant la copie. Le format des statistiques de
-    volume est <complètes>+<partielles>. Si des enregistrements ont été tronqués (voir
-    conv=block), les statistiques de volume contiendront le nombre d'enregistrements tronqués.
+    Les deux premières lignes sont les statistiques de 'volume' et la dernière ligne est les statistiques de 'performance'. Les statistiques de volume indiquent le nombre de lectures complètes et partielles de taille ibs, ou d'écritures de taille obs qui ont eu lieu pendant la copie. Le format des statistiques de volume est <complètes>+<partielles>. Si des enregistrements ont été tronqués (voir conv=block), les statistiques de volume contiendront le nombre d'enregistrements tronqués.
 
     Les valeurs possibles de NIVEAU sont :
-    - progress : Afficher les statistiques de performance périodiques pendant la copie.
-    - noxfer : Afficher les statistiques de volume finales, mais pas les statistiques de performance.
-    - none : N'afficher aucune statistique.
+      - progress : Afficher les statistiques de performance périodiques pendant la copie.
+      - noxfer : Afficher les statistiques de volume finales, mais pas les statistiques de performance.
+      - none : N'afficher aucune statistique.
 
-    L'affichage des statistiques de performance est aussi déclenché par le signal INFO (quand pris en charge),
-    ou le signal USR1. Définir la variable d'environnement POSIXLY_CORRECT à n'importe quelle valeur
-    (y compris une valeur vide) fera ignorer le signal USR1.
+    L'affichage des statistiques de performance est aussi déclenché par le signal INFO (quand pris en charge), ou le signal USR1. Définir la variable d'environnement POSIXLY_CORRECT à n'importe quelle valeur (y compris une valeur vide) fera ignorer le signal USR1.
 
   Options de conversion :
 
-  - ascii : convertir d'EBCDIC vers ASCII. C'est l'inverse de l'option ebcdic.
-    Implique conv=unblock.
-  - ebcdic : convertir d'ASCII vers EBCDIC. C'est l'inverse de l'option ascii.
-    Implique conv=block.
-  - ibm : convertir d'ASCII vers EBCDIC, en appliquant les conventions pour [, ]
-    et ~ spécifiées dans POSIX. Implique conv=block.
-
-  - ucase : convertir de minuscules vers majuscules.
-  - lcase : convertir de majuscules vers minuscules.
-
-  - block : pour chaque nouvelle ligne inférieure à la taille indiquée par cbs=OCTETS, supprimer
-    la nouvelle ligne et remplir avec des espaces jusqu'à cbs. Les lignes plus longues que cbs sont tronquées.
-  - unblock : pour chaque bloc d'entrée de la taille indiquée par cbs=OCTETS, supprimer
-    les espaces de fin à droite et remplacer par un caractère de nouvelle ligne.
-
-  - sparse : tente de rechercher la sortie quand un bloc de taille obs ne contient que
-    des zéros.
-  - swab : échange chaque paire d'octets adjacents. Si un nombre impair d'octets est
-    présent, l'octet final est omis.
-  - sync : remplit chaque bloc de taille ibs avec des zéros. Si block ou unblock est
-    spécifié, remplit avec des espaces à la place.
-  - excl : le fichier de sortie doit être créé. Échoue si le fichier de sortie est déjà
-    présent.
-  - nocreat : le fichier de sortie ne sera pas créé. Échoue si le fichier de sortie n'est
-    pas déjà présent.
-  - notrunc : le fichier de sortie ne sera pas tronqué. Si cette option n'est pas
-    présente, la sortie sera tronquée à l'ouverture.
-  - noerror : toutes les erreurs de lecture seront ignorées. Si cette option n'est pas présente,
-    dd n'ignorera que Error::Interrupted.
-  - fdatasync : les données seront écrites avant la fin.
-  - fsync : les données et les métadonnées seront écrites avant la fin.
+    - ascii : convertir d'EBCDIC vers ASCII. C'est l'inverse de l'option ebcdic. Implique conv=unblock.
+    - ebcdic : convertir d'ASCII vers EBCDIC. C'est l'inverse de l'option ascii. Implique conv=block.
+    - ibm : convertir d'ASCII vers EBCDIC, en appliquant les conventions pour [, ] et ~ spécifiées dans POSIX. Implique conv=block.
+    - ucase : convertir de minuscules vers majuscules.
+    - lcase : convertir de majuscules vers minuscules.
+    - block : pour chaque nouvelle ligne inférieure à la taille indiquée par cbs=OCTETS, supprimer la nouvelle ligne et remplir avec des espaces jusqu'à cbs. Les lignes plus longues que cbs sont tronquées.
+    - unblock : pour chaque bloc d'entrée de la taille indiquée par cbs=OCTETS, supprimer les espaces de fin à droite et remplacer par un caractère de nouvelle ligne.
+    - sparse : tente de rechercher la sortie quand un bloc de taille obs ne contient que des zéros.
+    - swab : échange chaque paire d'octets adjacents. Si un nombre impair d'octets est présent, l'octet final est omis.
+    - sync : remplit chaque bloc de taille ibs avec des zéros. Si block ou unblock est spécifié, remplit avec des espaces à la place.
+    - excl : le fichier de sortie doit être créé. Échoue si le fichier de sortie est déjà présent.
+    - nocreat : le fichier de sortie ne sera pas créé. Échoue si le fichier de sortie n'est pas déjà présent.
+    - notrunc : le fichier de sortie ne sera pas tronqué. Si cette option n'est pas présente, la sortie sera tronquée à l'ouverture.
+    - noerror : toutes les erreurs de lecture seront ignorées. Si cette option n'est pas présente, dd n'ignorera que Error::Interrupted.
+    - fdatasync : les données seront écrites avant la fin.
+    - fsync : les données et les métadonnées seront écrites avant la fin.
 
   Indicateurs d'entrée :
 
-  - count_bytes : une valeur pour count=N sera interprétée comme des octets.
-  - skip_bytes : une valeur pour skip=N sera interprétée comme des octets.
-  - fullblock : attendre ibs octets de chaque lecture. les lectures de longueur zéro sont toujours
-    considérées comme EOF.
+    - count_bytes : une valeur pour count=N sera interprétée comme des octets.
+    - skip_bytes : une valeur pour skip=N sera interprétée comme des octets.
+    - fullblock : attendre ibs octets de chaque lecture. les lectures de longueur zéro sont toujours considérées comme EOF.
 
   Indicateurs de sortie :
 
-  - append : ouvrir le fichier en mode ajout. Considérez définir conv=notrunc aussi.
-  - seek_bytes : une valeur pour seek=N sera interprétée comme des octets.
+    - append : ouvrir le fichier en mode ajout. Considérez définir conv=notrunc aussi.
+    - seek_bytes : une valeur pour seek=N sera interprétée comme des octets.
 
   Indicateurs généraux :
 
-  - direct : utiliser les E/S directes pour les données.
-  - directory : échouer sauf si l'entrée donnée (si utilisée comme iflag) ou
-    la sortie (si utilisée comme oflag) est un répertoire.
-  - dsync : utiliser les E/S synchronisées pour les données.
-  - sync : utiliser les E/S synchronisées pour les données et les métadonnées.
-  - nonblock : utiliser les E/S non-bloquantes.
-  - noatime : ne pas mettre à jour l'heure d'accès.
-  - nocache : demander au système d'exploitation de supprimer le cache.
-  - noctty : ne pas assigner un tty de contrôle.
-  - nofollow : ne pas suivre les liens système.
+    - direct : utiliser les E/S directes pour les données.
+    - directory : échouer sauf si l'entrée donnée (si utilisée comme iflag) ou la sortie (si utilisée comme oflag) est un répertoire.
+    - dsync : utiliser les E/S synchronisées pour les données.
+    - sync : utiliser les E/S synchronisées pour les données et les métadonnées.
+    - nonblock : utiliser les E/S non-bloquantes.
+    - noatime : ne pas mettre à jour l'heure d'accès.
+    - nocache : demander au système d'exploitation de supprimer le cache.
+    - noctty : ne pas assigner un tty de contrôle.
+    - nofollow : ne pas suivre les liens système.
 
 # Common strings
 dd-standard-input = 'entrée standard'

--- a/src/uu/du/locales/en-US.ftl
+++ b/src/uu/du/locales/en-US.ftl
@@ -11,9 +11,10 @@ du-after-help = Display values are in units of the first available SIZE from --b
 
   PATTERN allows some advanced exclusions. For example, the following syntaxes
   are supported:
-  ? will match only one character
-  { "*" } will match zero or more characters
-  {"{"}a,b{"}"} will match a or b
+
+    - ? will match only one character
+    - { "*" } will match zero or more characters
+    - {"{"}a,b{"}"} will match a or b
 
 # Help messages
 du-help-print-help = Print help information.

--- a/src/uu/du/locales/fr-FR.ftl
+++ b/src/uu/du/locales/fr-FR.ftl
@@ -11,9 +11,10 @@ du-after-help = Les valeurs affichées sont en unités de la première TAILLE di
 
   MOTIF permet des exclusions avancées. Par exemple, les syntaxes suivantes
   sont prises en charge :
-  ? correspondra à un seul caractère
-  { "*" } correspondra à zéro ou plusieurs caractères
-  {"{"}a,b{"}"} correspondra à a ou b
+
+    - ? correspondra à un seul caractère
+    - { "*" } correspondra à zéro ou plusieurs caractères
+    - {"{"}a,b{"}"} correspondra à a ou b
 
 # Messages d'aide
 du-help-print-help = Afficher les informations d'aide.

--- a/src/uu/echo/locales/en-US.ftl
+++ b/src/uu/echo/locales/en-US.ftl
@@ -4,18 +4,18 @@ echo-after-help = Echo the STRING(s) to standard output.
 
   If -e is in effect, the following sequences are recognized:
 
-  - \ backslash
-  - \a alert (BEL)
-  - \b backspace
-  - \c produce no further output
-  - \e escape
-  - \f form feed
-  - \n new line
-  - \r carriage return
-  - \t horizontal tab
-  - \v vertical tab
-  - \0NNN byte with octal value NNN (1 to 3 digits)
-  - \xHH byte with hexadecimal value HH (1 to 2 digits)
+    - \ backslash
+    - \a alert (BEL)
+    - \b backspace
+    - \c produce no further output
+    - \e escape
+    - \f form feed
+    - \n new line
+    - \r carriage return
+    - \t horizontal tab
+    - \v vertical tab
+    - \0NNN byte with octal value NNN (1 to 3 digits)
+    - \xHH byte with hexadecimal value HH (1 to 2 digits)
 
 echo-help-no-newline = do not output the trailing newline
 echo-help-enable-escapes = enable interpretation of backslash escapes

--- a/src/uu/echo/locales/fr-FR.ftl
+++ b/src/uu/echo/locales/fr-FR.ftl
@@ -4,18 +4,18 @@ echo-after-help = Affiche la ou les CHAÎNE(s) sur la sortie standard.
 
   Si -e est activé, les séquences suivantes sont reconnues :
 
-  - \ barre oblique inverse
-  - \a alerte (BEL)
-  - \b retour arrière
-  - \c ne produit aucune sortie supplémentaire
-  - \e échappement
-  - \f saut de page
-  - \n nouvelle ligne
-  - \r retour chariot
-  - \t tabulation horizontale
-  - \v tabulation verticale
-  - \0NNN octet avec valeur octale NNN (1 à 3 chiffres)
-  - \xHH octet avec valeur hexadécimale HH (1 à 2 chiffres)
+    - \ barre oblique inverse
+    - \a alerte (BEL)
+    - \b retour arrière
+    - \c ne produit aucune sortie supplémentaire
+    - \e échappement
+    - \f saut de page
+    - \n nouvelle ligne
+    - \r retour chariot
+    - \t tabulation horizontale
+    - \v tabulation verticale
+    - \0NNN octet avec valeur octale NNN (1 à 3 chiffres)
+    - \xHH octet avec valeur hexadécimale HH (1 à 2 chiffres)
 
 echo-help-no-newline = ne pas afficher la nouvelle ligne finale
 echo-help-enable-escapes = activer l'interprétation des séquences d'échappement

--- a/src/uu/expr/locales/en-US.ftl
+++ b/src/uu/expr/locales/en-US.ftl
@@ -6,27 +6,65 @@ expr-after-help = Print the value of EXPRESSION to standard output. A blank line
 
   EXPRESSION may be:
 
-  - ARG1 | ARG2: ARG1 if it is neither null nor 0, otherwise ARG2
-  - ARG1 & ARG2: ARG1 if neither argument is null or 0, otherwise 0
-  - ARG1 < ARG2: ARG1 is less than ARG2
-  - ARG1 <= ARG2: ARG1 is less than or equal to ARG2
-  - ARG1 = ARG2: ARG1 is equal to ARG2
-  - ARG1 != ARG2: ARG1 is unequal to ARG2
-  - ARG1 >= ARG2: ARG1 is greater than or equal to ARG2
-  - ARG1 > ARG2: ARG1 is greater than ARG2
-  - ARG1 + ARG2: arithmetic sum of ARG1 and ARG2
-  - ARG1 - ARG2: arithmetic difference of ARG1 and ARG2
-  - ARG1 * ARG2: arithmetic product of ARG1 and ARG2
-  - ARG1 / ARG2: arithmetic quotient of ARG1 divided by ARG2
-  - ARG1 % ARG2: arithmetic remainder of ARG1 divided by ARG2
-  - STRING : REGEXP: anchored pattern match of REGEXP in STRING
-  - match STRING REGEXP: same as STRING : REGEXP
-  - substr STRING POS LENGTH: substring of STRING, POS counted from 1
-  - index STRING CHARS: index in STRING where any CHARS is found, or 0
-  - length STRING: length of STRING
-  - + TOKEN: interpret TOKEN as a string, even if it is a keyword like match
-    or an operator like /
-  - ( EXPRESSION ): value of EXPRESSION
+  ARG1 | ARG2
+        ARG1 if it is neither null nor 0, otherwise ARG2
+
+  ARG1 & ARG2
+        ARG1 if neither argument is null or 0, otherwise 0
+
+  ARG1 < ARG2
+        ARG1 is less than ARG2
+
+  ARG1 <= ARG2
+        ARG1 is less than or equal to ARG2
+
+  ARG1 = ARG2
+        ARG1 is equal to ARG2
+
+  ARG1 != ARG2
+        ARG1 is unequal to ARG2
+
+  ARG1 >= ARG2
+        ARG1 is greater than or equal to ARG2
+
+  ARG1 > ARG2
+        ARG1 is greater than ARG2
+
+  ARG1 + ARG2
+        arithmetic sum of ARG1 and ARG2
+
+  ARG1 - ARG2
+        arithmetic difference of ARG1 and ARG2
+
+  ARG1 * ARG2
+        arithmetic product of ARG1 and ARG2
+
+  ARG1 / ARG2
+        arithmetic quotient of ARG1 divided by ARG2
+
+  ARG1 % ARG2
+        arithmetic remainder of ARG1 divided by ARG2
+
+  STRING : REGEXP
+        anchored pattern match of REGEXP in STRING
+
+  match STRING REGEXP
+        same as STRING : REGEXP
+
+  substr STRING POS LENGTH
+        substring of STRING, POS counted from 1
+
+  index STRING CHARS
+        index in STRING where any CHARS is found, or 0
+
+  length STRING
+        length of STRING
+
+  + TOKEN
+        interpret TOKEN as a string, even if it is a keyword like match or an operator like /
+
+  ( EXPRESSION )
+        value of EXPRESSION
 
   Beware that many operators need to be escaped or quoted for shells.
   Comparisons are arithmetic if both ARGs are numbers, else lexicographical.
@@ -39,10 +77,10 @@ expr-after-help = Print the value of EXPRESSION to standard output. A blank line
 
   Environment variables:
 
-  - EXPR_DEBUG_TOKENS=1: dump expression's tokens
-  - EXPR_DEBUG_RPN=1: dump expression represented in reverse polish notation
-  - EXPR_DEBUG_SYA_STEP=1: dump each parser step
-  - EXPR_DEBUG_AST=1: dump expression represented abstract syntax tree
+    - EXPR_DEBUG_TOKENS=1: dump expression's tokens
+    - EXPR_DEBUG_RPN=1: dump expression represented in reverse polish notation
+    - EXPR_DEBUG_SYA_STEP=1: dump each parser step
+    - EXPR_DEBUG_AST=1: dump expression represented abstract syntax tree
 
   Errors are reported with the expression echoed back and a caret under the
   offending argument whenever stderr is a terminal; anything else reading

--- a/src/uu/expr/locales/fr-FR.ftl
+++ b/src/uu/expr/locales/fr-FR.ftl
@@ -6,27 +6,65 @@ expr-after-help = Afficher la valeur de EXPRESSION sur la sortie standard. Une l
 
   EXPRESSION peut être :
 
-  - ARG1 | ARG2: ARG1 s'il n'est ni nul ni 0, sinon ARG2
-  - ARG1 & ARG2: ARG1 si aucun argument n'est nul ou 0, sinon 0
-  - ARG1 < ARG2: ARG1 est inférieur à ARG2
-  - ARG1 <= ARG2: ARG1 est inférieur ou égal à ARG2
-  - ARG1 = ARG2: ARG1 est égal à ARG2
-  - ARG1 != ARG2: ARG1 est différent de ARG2
-  - ARG1 >= ARG2: ARG1 est supérieur ou égal à ARG2
-  - ARG1 > ARG2: ARG1 est supérieur à ARG2
-  - ARG1 + ARG2: somme arithmétique de ARG1 et ARG2
-  - ARG1 - ARG2: différence arithmétique de ARG1 et ARG2
-  - ARG1 * ARG2: produit arithmétique de ARG1 et ARG2
-  - ARG1 / ARG2: quotient arithmétique de ARG1 divisé par ARG2
-  - ARG1 % ARG2: reste arithmétique de ARG1 divisé par ARG2
-  - STRING : REGEXP: correspondance de motif ancré de REGEXP dans STRING
-  - match STRING REGEXP: identique à STRING : REGEXP
-  - substr STRING POS LENGTH: sous-chaîne de STRING, POS compté à partir de 1
-  - index STRING CHARS: index dans STRING où l'un des CHARS est trouvé, ou 0
-  - length STRING: longueur de STRING
-  - + TOKEN: interpréter TOKEN comme une chaîne, même si c'est un mot-clé comme match
-    ou un opérateur comme /
-  - ( EXPRESSION ): valeur de EXPRESSION
+  ARG1 | ARG2
+        ARG1 s'il n'est ni nul ni 0, sinon ARG2
+
+  ARG1 & ARG2
+        ARG1 si aucun argument n'est nul ou 0, sinon 0
+
+  ARG1 < ARG2
+        ARG1 est inférieur à ARG2
+
+  ARG1 <= ARG2
+        ARG1 est inférieur ou égal à ARG2
+
+  ARG1 = ARG2
+        ARG1 est égal à ARG2
+
+  ARG1 != ARG2
+        ARG1 est différent de ARG2
+
+  ARG1 >= ARG2
+        ARG1 est supérieur ou égal à ARG2
+
+  ARG1 > ARG2
+        ARG1 est supérieur à ARG2
+
+  ARG1 + ARG2
+        somme arithmétique de ARG1 et ARG2
+
+  ARG1 - ARG2
+        différence arithmétique de ARG1 et ARG2
+
+  ARG1 * ARG2
+        produit arithmétique de ARG1 et ARG2
+
+  ARG1 / ARG2
+        quotient arithmétique de ARG1 divisé par ARG2
+
+  ARG1 % ARG2
+        reste arithmétique de ARG1 divisé par ARG2
+
+  STRING : REGEXP
+        correspondance de motif ancré de REGEXP dans STRING
+
+  match STRING REGEXP
+        identique à STRING : REGEXP
+
+  substr STRING POS LENGTH
+        sous-chaîne de STRING, POS compté à partir de 1
+
+  index STRING CHARS
+        index dans STRING où l'un des CHARS est trouvé, ou 0
+
+  length STRING
+        longueur de STRING
+
+  + TOKEN
+        interpréter TOKEN comme une chaîne, même si c'est un mot-clé comme match ou un opérateur comme /
+
+  ( EXPRESSION )
+        valeur de EXPRESSION
 
   Attention : de nombreux opérateurs doivent être échappés ou mis entre guillemets pour les shells.
   Les comparaisons sont arithmétiques si les deux ARG sont des nombres, sinon lexicographiques.
@@ -39,10 +77,10 @@ expr-after-help = Afficher la valeur de EXPRESSION sur la sortie standard. Une l
 
   Variables d'environnement :
 
-  - EXPR_DEBUG_TOKENS=1: afficher les jetons de l'expression
-  - EXPR_DEBUG_RPN=1: afficher l'expression représentée en notation polonaise inverse
-  - EXPR_DEBUG_SYA_STEP=1: afficher chaque étape de l'analyseur
-  - EXPR_DEBUG_AST=1: afficher l'arbre de syntaxe abstraite représentant l'expression
+    - EXPR_DEBUG_TOKENS=1: afficher les jetons de l'expression
+    - EXPR_DEBUG_RPN=1: afficher l'expression représentée en notation polonaise inverse
+    - EXPR_DEBUG_SYA_STEP=1: afficher chaque étape de l'analyseur
+    - EXPR_DEBUG_AST=1: afficher l'arbre de syntaxe abstraite représentant l'expression
 
   Les erreurs sont signalées en réaffichant l'expression avec un caret sous
   l'argument fautif dès que la sortie d'erreur est un terminal ; sinon, le

--- a/src/uu/mknod/locales/en-US.ftl
+++ b/src/uu/mknod/locales/en-US.ftl
@@ -8,9 +8,9 @@ mknod-after-help = Mandatory arguments to long options are mandatory for short o
   it is interpreted as hexadecimal; otherwise, if it begins with 0, as octal;
   otherwise, as decimal. TYPE may be:
 
-  - b create a block (buffered) special file
-  - c, u create a character (unbuffered) special file
-  - p create a FIFO
+    - b create a block (buffered) special file
+    - c, u create a character (unbuffered) special file
+    - p create a FIFO
 
   NOTE: your shell may have its own version of mknod, which usually supersedes
   the version described here. Please refer to your shell's documentation

--- a/src/uu/mknod/locales/fr-FR.ftl
+++ b/src/uu/mknod/locales/fr-FR.ftl
@@ -8,9 +8,9 @@ mknod-after-help = Les arguments obligatoires pour les options longues le sont a
   il est interprété comme hexadécimal ; sinon, s'il commence par 0, comme octal ;
   sinon, comme décimal. TYPE peut être :
 
-  - b créer un fichier spécial bloc (mis en mémoire tampon)
-  - c, u créer un fichier spécial caractère (non mis en mémoire tampon)
-  - p créer un FIFO
+    - b créer un fichier spécial bloc (mis en mémoire tampon)
+    - c, u créer un fichier spécial caractère (non mis en mémoire tampon)
+    - p créer un FIFO
 
   NOTE : votre shell peut avoir sa propre version de mknod, qui remplace généralement
   la version décrite ici. Veuillez vous référer à la documentation de votre shell

--- a/src/uu/nl/locales/en-US.ftl
+++ b/src/uu/nl/locales/en-US.ftl
@@ -2,17 +2,16 @@ nl-about = Number lines of files
 nl-usage = nl [OPTION]... [FILE]...
 nl-after-help = STYLE is one of:
 
-  - a number all lines
-  - t number only nonempty lines
-  - n number no lines
-  - pBRE number only lines that contain a match for the basic regular
-          expression, BRE
+    - a number all lines
+    - t number only nonempty lines
+    - n number no lines
+    - pBRE number only lines that contain a match for the basic regular expression, BRE
 
   FORMAT is one of:
 
-  - ln left justified, no leading zeros
-  - rn right justified, no leading zeros
-  - rz right justified, leading zeros
+    - ln left justified, no leading zeros
+    - rn right justified, no leading zeros
+    - rz right justified, leading zeros
 
 # Help messages
 nl-help-help = Print help information.

--- a/src/uu/nl/locales/fr-FR.ftl
+++ b/src/uu/nl/locales/fr-FR.ftl
@@ -2,17 +2,16 @@ nl-about = Numéroter les lignes des fichiers
 nl-usage = nl [OPTION]... [FICHIER]...
 nl-after-help = STYLE est l'un des suivants :
 
-  - a numéroter toutes les lignes
-  - t numéroter seulement les lignes non vides
-  - n ne numéroter aucune ligne
-  - pBRE numéroter seulement les lignes qui contiennent une correspondance pour
-          l'expression régulière de base, BRE
+    - a numéroter toutes les lignes
+    - t numéroter seulement les lignes non vides
+    - n ne numéroter aucune ligne
+    - pBRE numéroter seulement les lignes qui contiennent une correspondance pour l'expression régulière de base, BRE
 
   FORMAT est l'un des suivants :
 
-  - ln justifié à gauche, sans zéros en tête
-  - rn justifié à droite, sans zéros en tête
-  - rz justifié à droite, avec zéros en tête
+    - ln justifié à gauche, sans zéros en tête
+    - rn justifié à droite, sans zéros en tête
+    - rz justifié à droite, avec zéros en tête
 
 # Messages d'aide
 nl-help-help = Afficher les informations d'aide.

--- a/src/uu/numfmt/locales/en-US.ftl
+++ b/src/uu/numfmt/locales/en-US.ftl
@@ -3,6 +3,7 @@ numfmt-usage = numfmt [OPTION]... [NUMBER]...
 numfmt-after-help = UNIT options:
 
   - none: no auto-scaling is done; suffixes will trigger an error
+
   - auto: accept optional single/two letter suffix:
 
       1K = 1000, 1Ki = 1024, 1M = 1000000, 1Mi = 1048576,

--- a/src/uu/numfmt/locales/fr-FR.ftl
+++ b/src/uu/numfmt/locales/fr-FR.ftl
@@ -3,6 +3,7 @@ numfmt-usage = numfmt [OPTION]... [NOMBRE]...
 numfmt-after-help = Options d'UNITÉ :
 
   - none : aucune mise à l'échelle automatique n'est effectuée ; les suffixes déclencheront une erreur
+
   - auto : accepter un suffixe optionnel d'une/deux lettres :
 
       1K = 1000, 1Ki = 1024, 1M = 1000000, 1Mi = 1048576,

--- a/src/uu/printf/locales/en-US.ftl
+++ b/src/uu/printf/locales/en-US.ftl
@@ -155,7 +155,7 @@ printf-after-help = basic anonymous string templating:
   - %b: escaped string - the string will be checked for any escaped literals from
         the escaped literal list above, and translate them to literal characters.
         e.g. \\n will be transformed into a newline character.
-        One special rule about %b mode is that octal literals are interpreted differently
+        One special rule about %b mode is that octal literals are interpreted differently.
         In arguments passed by %b, pass octal-interpreted literals must be in the form of \\0NNN
         instead of \\NNN. (Although, for legacy reasons, octal literals in the form of \\NNN will
         still be interpreted and not throw a warning, you will have problems if you use this for a
@@ -182,7 +182,7 @@ printf-after-help = basic anonymous string templating:
 
   - %u: 64-bit unsigned integer
 
-  - %x or %X: 64-bit unsigned integer printed in Hexadecimal (base 16)
+  - %x or %X: 64-bit unsigned integer printed in Hexadecimal (base 16).
               %X instead of %x means to use uppercase letters for 'a' through 'f'
 
   - %o: 64-bit unsigned integer printed in octal (base 8)
@@ -206,15 +206,15 @@ printf-after-help = basic anonymous string templating:
         estimated or adjusted beyond input values.
 
   - %e or %E: floating point value presented in scientific notation
-              7 significant digits by default
+              7 significant digits by default.
               %E means use to use uppercase E for the mantissa.
 
   - %g or %G: floating point value presented in the shortest of decimal and scientific notation
               behaves differently from %f and %E, please see posix printf spec for full details,
               some examples of different behavior:
-              Sci Note has 6 significant digits by default
-              Trailing zeroes are removed
-              Instead of being truncated, digit after last is rounded
+              - Sci Note has 6 significant digits by default
+              - Trailing zeroes are removed
+              - Instead of being truncated, digit after last is rounded
 
   Like other behavior in this utility, the design choices of floating point
   behavior in this utility is selected to reproduce in exact

--- a/src/uu/printf/locales/en-US.ftl
+++ b/src/uu/printf/locales/en-US.ftl
@@ -18,38 +18,22 @@ printf-after-help = basic anonymous string templating:
   The following escape sequences, organized here in alphabetical order,
   will print the corresponding character literal:
 
-  - \" double quote
-
-  - \\ backslash
-
-  - \\a alert (BEL)
-
-  - \\b backspace
-
-  - \\c End-of-Input
-
-  - \\e escape
-
-  - \\f form feed
-
-  - \\n new line
-
-  - \\r carriage return
-
-  - \\t horizontal tab
-
-  - \\v vertical tab
-
-  - \\NNN byte with value expressed in octal value NNN (1 to 3 digits)
-            values greater than 256 will be treated
-
-  - \\xHH byte with value expressed in hexadecimal value NN (1 to 2 digits)
-
-  - \\uHHHH Unicode (IEC 10646) character with value expressed in hexadecimal value HHHH (4 digits)
-
-  - \\uHHHH Unicode character with value expressed in hexadecimal value HHHH (8 digits)
-
-  - %% a single %
+    - \" double quote
+    - \\ backslash
+    - \\a alert (BEL)
+    - \\b backspace
+    - \\c End-of-Input
+    - \\e escape
+    - \\f form feed
+    - \\n new line
+    - \\r carriage return
+    - \\t horizontal tab
+    - \\v vertical tab
+    - \\NNN byte with value expressed in octal value NNN (1 to 3 digits) values greater than 256 will be treated
+    - \\xHH byte with value expressed in hexadecimal value NN (1 to 2 digits)
+    - \\uHHHH Unicode (IEC 10646) character with value expressed in hexadecimal value HHHH (4 digits)
+    - \\uHHHH Unicode character with value expressed in hexadecimal value HHHH (8 digits)
+    - %% a single %
 
   ### SUBSTITUTIONS
 
@@ -57,24 +41,25 @@ printf-after-help = basic anonymous string templating:
 
   Fields
 
-  - %s: string
-  - %b: string parsed for literals second parameter is max length
+    - %s: string
+    - %b: string parsed for literals second parameter is max length
 
-  - %c: char no second parameter
+    - %c: char no second parameter
 
-  - %i or %d: 64-bit integer
-  - %u: 64 bit unsigned integer
-  - %x or %X: 64-bit unsigned integer as hex
-  - %o: 64-bit unsigned integer as octal
+    - %i or %d: 64-bit integer
+    - %u: 64 bit unsigned integer
+    - %x or %X: 64-bit unsigned integer as hex
+    - %o: 64-bit unsigned integer as octal
+
               second parameter is min-width, integer
               output below that width is padded with leading zeroes
 
-  - %q: ARGUMENT is printed in a format that can be reused as shell input, escaping non-printable
-              characters with the proposed POSIX $'' syntax.
 
-  - %f or %F: decimal floating point value
-  - %e or %E: scientific notation floating point value
-  - %g or %G: shorter of specially interpreted decimal or SciNote floating point value.
+    - %q: ARGUMENT is printed in a format that can be reused as shell input, escaping non-printable characters with the proposed POSIX $'' syntax.
+    - %f or %F: decimal floating point value
+    - %e or %E: scientific notation floating point value
+    - %g or %G: shorter of specially interpreted decimal or SciNote floating point value.
+
               second parameter is
                 -max places after decimal point for floating point output
                 -max number of significant digits for scientific notation output
@@ -105,9 +90,9 @@ printf-after-help = basic anonymous string templating:
 
   special prefixes to numeric arguments
 
-  - 0: (e.g. 010) interpret argument as octal (integer output fields only)
-  - 0x: (e.g. 0xABC) interpret argument as hex (numeric output fields only)
-  - \': (e.g. \'a) interpret argument as a character constant
+    - 0: (e.g. 010) interpret argument as octal (integer output fields only)
+    - 0x: (e.g. 0xABC) interpret argument as hex (numeric output fields only)
+    - \': (e.g. \'a) interpret argument as a character constant
 
   #### HOW TO USE SUBSTITUTIONS
 
@@ -130,9 +115,9 @@ printf-after-help = basic anonymous string templating:
 
   will print
 
-  it is 22 F in Portland
-  it is 25 F in Boston
-  it is 27 F in Boston
+      it is 22 F in Portland
+      it is 25 F in Boston
+      it is 27 F in Boston
 
   If a format string is printed but there are less arguments remaining
   than there are substitution fields, substitution fields without
@@ -153,24 +138,24 @@ printf-after-help = basic anonymous string templating:
   - %s: string
 
   - %b: escaped string - the string will be checked for any escaped literals from
-        the escaped literal list above, and translate them to literal characters.
-        e.g. \\n will be transformed into a newline character.
-        One special rule about %b mode is that octal literals are interpreted differently.
-        In arguments passed by %b, pass octal-interpreted literals must be in the form of \\0NNN
-        instead of \\NNN. (Although, for legacy reasons, octal literals in the form of \\NNN will
-        still be interpreted and not throw a warning, you will have problems if you use this for a
-        literal whose code begins with zero, as it will be viewed as in \\0NNN form.)
+  the escaped literal list above, and translate them to literal characters.
+  e.g. \\n will be transformed into a newline character.
+  One special rule about %b mode is that octal literals are interpreted differently.
+  In arguments passed by %b, pass octal-interpreted literals must be in the form of \\0NNN
+  instead of \\NNN. (Although, for legacy reasons, octal literals in the form of \\NNN will
+  still be interpreted and not throw a warning, you will have problems if you use this for a
+  literal whose code begins with zero, as it will be viewed as in \\0NNN form.)
 
   - %q: escaped string - the string in a format that can be reused as input by most shells.
-        Non-printable characters are escaped with the POSIX proposed ‘$''’ syntax,
-        and shell meta-characters are quoted appropriately.
-        This is an equivalent format to ls --quoting=shell-escape output.
+  Non-printable characters are escaped with the POSIX proposed ‘$''’ syntax,
+  and shell meta-characters are quoted appropriately.
+  This is an equivalent format to ls --quoting=shell-escape output.
 
   #### CHAR SUBSTITUTIONS
 
   The character field does not have a secondary parameter.
 
-  - %c: a single character
+    - %c: a single character
 
   #### INTEGER SUBSTITUTIONS
 
@@ -178,14 +163,10 @@ printf-after-help = basic anonymous string templating:
   %.4i means an integer which if it is less than 4 digits in length,
   is padded with leading zeros until it is 4 digits in length.
 
-  - %d or %i: 64-bit integer
-
-  - %u: 64-bit unsigned integer
-
-  - %x or %X: 64-bit unsigned integer printed in Hexadecimal (base 16).
-              %X instead of %x means to use uppercase letters for 'a' through 'f'
-
-  - %o: 64-bit unsigned integer printed in octal (base 8)
+    - %d or %i: 64-bit integer
+    - %u: 64-bit unsigned integer
+    - %x or %X: 64-bit unsigned integer printed in Hexadecimal (base 16). %X instead of %x means to use uppercase letters for 'a' through 'f'
+    - %o: 64-bit unsigned integer printed in octal (base 8)
 
   #### FLOATING POINT SUBSTITUTIONS
 
@@ -202,19 +183,20 @@ printf-after-help = basic anonymous string templating:
   18th decimal place of +/- 1
 
   - %f: floating point value presented in decimal, truncated and displayed to 6 decimal places by
-        default. There is not past-double behavior parity with Coreutils printf, values are not
-        estimated or adjusted beyond input values.
+  default. There is not past-double behavior parity with Coreutils printf, values are not
+  estimated or adjusted beyond input values.
 
   - %e or %E: floating point value presented in scientific notation
-              7 significant digits by default.
-              %E means use to use uppercase E for the mantissa.
+  7 significant digits by default.
+  %E means use to use uppercase E for the mantissa.
 
   - %g or %G: floating point value presented in the shortest of decimal and scientific notation
-              behaves differently from %f and %E, please see posix printf spec for full details,
-              some examples of different behavior:
-              - Sci Note has 6 significant digits by default
-              - Trailing zeroes are removed
-              - Instead of being truncated, digit after last is rounded
+  behaves differently from %f and %E, please see posix printf spec for full details,
+  some examples of different behavior:
+
+    - Sci Note has 6 significant digits by default
+    - Trailing zeroes are removed
+    - Instead of being truncated, digit after last is rounded
 
   Like other behavior in this utility, the design choices of floating point
   behavior in this utility is selected to reproduce in exact

--- a/src/uu/printf/locales/fr-FR.ftl
+++ b/src/uu/printf/locales/fr-FR.ftl
@@ -155,7 +155,7 @@ printf-after-help = templating de chaîne anonyme de base :
   - %b: chaîne échappée - la chaîne sera vérifiée pour tout littéral échappé de
         la liste de littéraux échappés ci-dessus, et les traduire en caractères littéraux.
         ex. \\n sera transformé en caractère de nouvelle ligne.
-        Une règle spéciale sur le mode %b est que les littéraux octaux sont interprétés différemment
+        Une règle spéciale sur le mode %b est que les littéraux octaux sont interprétés différemment.
         Dans les arguments passés par %b, les littéraux interprétés en octal doivent être sous la forme \\0NNN
         au lieu de \\NNN. (Bien que, pour des raisons d'héritage, les littéraux octaux sous la forme \\NNN seront
         toujours interprétés et ne lanceront pas d'avertissement, vous aurez des problèmes si vous utilisez cela pour un
@@ -182,7 +182,7 @@ printf-after-help = templating de chaîne anonyme de base :
 
   - %u: entier non signé 64 bits
 
-  - %x ou %X: entier non signé 64 bits affiché en hexadécimal (base 16)
+  - %x ou %X: entier non signé 64 bits affiché en hexadécimal (base 16).
               %X au lieu de %x signifie utiliser des lettres majuscules pour 'a' à 'f'
 
   - %o: entier non signé 64 bits affiché en octal (base 8)
@@ -206,15 +206,15 @@ printf-after-help = templating de chaîne anonyme de base :
         estimées ou ajustées au-delà des valeurs d'entrée.
 
   - %e ou %E: valeur en virgule flottante présentée en notation scientifique
-              7 chiffres significatifs par défaut
+              7 chiffres significatifs par défaut.
               %E signifie utiliser E majuscule pour la mantisse.
 
   - %g ou %G: valeur en virgule flottante présentée dans la plus courte des notations décimale et scientifique
               se comporte différemment de %f et %E, veuillez voir la spécification posix printf pour tous les détails,
               quelques exemples de comportement différent :
-              Sci Note a 6 chiffres significatifs par défaut
-              Les zéros de fin sont supprimés
-              Au lieu d'être tronqué, le chiffre après le dernier est arrondi
+              - Sci Note a 6 chiffres significatifs par défaut
+              - Les zéros de fin sont supprimés
+              - Au lieu d'être tronqué, le chiffre après le dernier est arrondi
 
   Comme d'autres comportements dans cet utilitaire, les choix de conception du comportement en virgule flottante
   dans cet utilitaire sont sélectionnés pour reproduire exactement

--- a/src/uu/printf/locales/fr-FR.ftl
+++ b/src/uu/printf/locales/fr-FR.ftl
@@ -18,38 +18,22 @@ printf-after-help = templating de chaîne anonyme de base :
   Les séquences d'échappement suivantes, organisées ici par ordre alphabétique,
   afficheront le littéral de caractère correspondant :
 
-  - \" guillemet double
-
-  - \\ barre oblique inverse
-
-  - \\a alerte (BEL)
-
-  - \\b retour arrière
-
-  - \\c Fin d'entrée
-
-  - \\e échappement
-
-  - \\f saut de page
-
-  - \\n nouvelle ligne
-
-  - \\r retour chariot
-
-  - \\t tabulation horizontale
-
-  - \\v tabulation verticale
-
-  - \\NNN octet avec valeur exprimée en valeur octale NNN (1 à 3 chiffres)
-            les valeurs supérieures à 256 seront traitées
-
-  - \\xHH octet avec valeur exprimée en valeur hexadécimale NN (1 à 2 chiffres)
-
-  - \\uHHHH caractère Unicode (IEC 10646) avec valeur exprimée en valeur hexadécimale HHHH (4 chiffres)
-
-  - \\uHHHH caractère Unicode avec valeur exprimée en valeur hexadécimale HHHH (8 chiffres)
-
-  - %% un seul %
+    - \" guillemet double
+    - \\ barre oblique inverse
+    - \\a alerte (BEL)
+    - \\b retour arrière
+    - \\c Fin d'entrée
+    - \\e échappement
+    - \\f saut de page
+    - \\n nouvelle ligne
+    - \\r retour chariot
+    - \\t tabulation horizontale
+    - \\v tabulation verticale
+    - \\NNN octet avec valeur exprimée en valeur octale NNN (1 à 3 chiffres) les valeurs supérieures à 256 seront traitées
+    - \\xHH octet avec valeur exprimée en valeur hexadécimale NN (1 à 2 chiffres)
+    - \\uHHHH caractère Unicode (IEC 10646) avec valeur exprimée en valeur hexadécimale HHHH (4 chiffres)
+    - \\uHHHH caractère Unicode avec valeur exprimée en valeur hexadécimale HHHH (8 chiffres)
+    - %% un seul %
 
   ### SUBSTITUTIONS
 
@@ -57,24 +41,24 @@ printf-after-help = templating de chaîne anonyme de base :
 
   Champs
 
-  - %s: chaîne
-  - %b: chaîne analysée pour les littéraux, le deuxième paramètre est la longueur max
+    - %s: chaîne
+    - %b: chaîne analysée pour les littéraux, le deuxième paramètre est la longueur max
 
-  - %c: caractère, pas de deuxième paramètre
+    - %c: caractère, pas de deuxième paramètre
 
-  - %i ou %d: entier 64 bits
-  - %u: entier non signé 64 bits
-  - %x ou %X: entier non signé 64 bits en hexadécimal
-  - %o: entier non signé 64 bits en octal
+    - %i ou %d: entier 64 bits
+    - %u: entier non signé 64 bits
+    - %x ou %X: entier non signé 64 bits en hexadécimal
+    - %o: entier non signé 64 bits en octal
+
               le deuxième paramètre est la largeur min, entier
               la sortie en dessous de cette largeur est remplie avec des zéros en tête
 
-  - %q: ARGUMENT est affiché dans un format qui peut être réutilisé comme entrée shell, en échappant les
-              caractères non imprimables avec la syntaxe POSIX $'' proposée.
+    - %q: ARGUMENT est affiché dans un format qui peut être réutilisé comme entrée shell, en échappant les caractères non imprimables avec la syntaxe POSIX $'' proposée.
+    - %f ou %F: valeur en virgule flottante décimale
+    - %e ou %E: valeur en virgule flottante en notation scientifique
+    - %g ou %G: plus courte des valeurs en virgule flottante décimale ou SciNote interprétées spécialement.
 
-  - %f ou %F: valeur en virgule flottante décimale
-  - %e ou %E: valeur en virgule flottante en notation scientifique
-  - %g ou %G: plus courte des valeurs en virgule flottante décimale ou SciNote interprétées spécialement.
               le deuxième paramètre est
                 -max places après la virgule pour la sortie en virgule flottante
                 -max nombre de chiffres significatifs pour la sortie en notation scientifique
@@ -105,9 +89,9 @@ printf-after-help = templating de chaîne anonyme de base :
 
   préfixes spéciaux pour les arguments numériques
 
-  - 0: (ex. 010) interpréter l'argument comme octal (champs de sortie entiers uniquement)
-  - 0x: (ex. 0xABC) interpréter l'argument comme hexadécimal (champs de sortie numériques uniquement)
-  - \': (ex. \'a) interpréter l'argument comme une constante de caractère
+    - 0: (ex. 010) interpréter l'argument comme octal (champs de sortie entiers uniquement)
+    - 0x: (ex. 0xABC) interpréter l'argument comme hexadécimal (champs de sortie numériques uniquement)
+    - \': (ex. \'a) interpréter l'argument comme une constante de caractère
 
   #### COMMENT UTILISER LES SUBSTITUTIONS
 
@@ -130,9 +114,9 @@ printf-after-help = templating de chaîne anonyme de base :
 
   affichera
 
-  il fait 22 F à Portland
-  il fait 25 F à Boston
-  il fait 27 F à Boston
+      il fait 22 F à Portland
+      il fait 25 F à Boston
+      il fait 27 F à Boston
 
   Si une chaîne de format est affichée mais qu'il reste moins d'arguments
   qu'il n'y a de champs de substitution, les champs de substitution sans
@@ -153,24 +137,24 @@ printf-after-help = templating de chaîne anonyme de base :
   - %s: chaîne
 
   - %b: chaîne échappée - la chaîne sera vérifiée pour tout littéral échappé de
-        la liste de littéraux échappés ci-dessus, et les traduire en caractères littéraux.
-        ex. \\n sera transformé en caractère de nouvelle ligne.
-        Une règle spéciale sur le mode %b est que les littéraux octaux sont interprétés différemment.
-        Dans les arguments passés par %b, les littéraux interprétés en octal doivent être sous la forme \\0NNN
-        au lieu de \\NNN. (Bien que, pour des raisons d'héritage, les littéraux octaux sous la forme \\NNN seront
-        toujours interprétés et ne lanceront pas d'avertissement, vous aurez des problèmes si vous utilisez cela pour un
-        littéral dont le code commence par zéro, car il sera vu comme étant sous forme \\0NNN.)
+  la liste de littéraux échappés ci-dessus, et les traduire en caractères littéraux.
+  ex. \\n sera transformé en caractère de nouvelle ligne.
+  Une règle spéciale sur le mode %b est que les littéraux octaux sont interprétés différemment.
+  Dans les arguments passés par %b, les littéraux interprétés en octal doivent être sous la forme \\0NNN
+  au lieu de \\NNN. (Bien que, pour des raisons d'héritage, les littéraux octaux sous la forme \\NNN seront
+  toujours interprétés et ne lanceront pas d'avertissement, vous aurez des problèmes si vous utilisez cela pour un
+  littéral dont le code commence par zéro, car il sera vu comme étant sous forme \\0NNN.)
 
   - %q: chaîne échappée - la chaîne dans un format qui peut être réutilisé comme entrée par la plupart des shells.
-        Les caractères non imprimables sont échappés avec la syntaxe POSIX proposée '$''',
-        et les méta-caractères shell sont cités de manière appropriée.
-        C'est un format équivalent à la sortie ls --quoting=shell-escape.
+  Les caractères non imprimables sont échappés avec la syntaxe POSIX proposée '$''',
+  et les méta-caractères shell sont cités de manière appropriée.
+  C'est un format équivalent à la sortie ls --quoting=shell-escape.
 
   #### SUBSTITUTIONS DE CARACTÈRES
 
   Le champ caractère n'a pas de paramètre secondaire.
 
-  - %c: un seul caractère
+    - %c: un seul caractère
 
   #### SUBSTITUTIONS D'ENTIERS
 
@@ -178,14 +162,10 @@ printf-after-help = templating de chaîne anonyme de base :
   %.4i signifie un entier qui s'il fait moins de 4 chiffres de longueur,
   est rempli avec des zéros en tête jusqu'à ce qu'il fasse 4 chiffres de longueur.
 
-  - %d ou %i: entier 64 bits
-
-  - %u: entier non signé 64 bits
-
-  - %x ou %X: entier non signé 64 bits affiché en hexadécimal (base 16).
-              %X au lieu de %x signifie utiliser des lettres majuscules pour 'a' à 'f'
-
-  - %o: entier non signé 64 bits affiché en octal (base 8)
+    - %d ou %i: entier 64 bits
+    - %u: entier non signé 64 bits
+    - %x ou %X: entier non signé 64 bits affiché en hexadécimal (base 16). %X au lieu de %x signifie utiliser des lettres majuscules pour 'a' à 'f'
+    - %o: entier non signé 64 bits affiché en octal (base 8)
 
   #### SUBSTITUTIONS EN VIRGULE FLOTTANTE
 
@@ -202,19 +182,20 @@ printf-after-help = templating de chaîne anonyme de base :
   18ème place décimale de +/- 1
 
   - %f: valeur en virgule flottante présentée en décimal, tronquée et affichée à 6 places décimales par
-        défaut. Il n'y a pas de parité de comportement post-double avec Coreutils printf, les valeurs ne sont pas
-        estimées ou ajustées au-delà des valeurs d'entrée.
+  défaut. Il n'y a pas de parité de comportement post-double avec Coreutils printf, les valeurs ne sont pas
+  estimées ou ajustées au-delà des valeurs d'entrée.
 
   - %e ou %E: valeur en virgule flottante présentée en notation scientifique
-              7 chiffres significatifs par défaut.
-              %E signifie utiliser E majuscule pour la mantisse.
+  7 chiffres significatifs par défaut.
+  %E signifie utiliser E majuscule pour la mantisse.
 
   - %g ou %G: valeur en virgule flottante présentée dans la plus courte des notations décimale et scientifique
-              se comporte différemment de %f et %E, veuillez voir la spécification posix printf pour tous les détails,
-              quelques exemples de comportement différent :
-              - Sci Note a 6 chiffres significatifs par défaut
-              - Les zéros de fin sont supprimés
-              - Au lieu d'être tronqué, le chiffre après le dernier est arrondi
+  se comporte différemment de %f et %E, veuillez voir la spécification posix printf pour tous les détails,
+  quelques exemples de comportement différent :
+
+    - Sci Note a 6 chiffres significatifs par défaut
+    - Les zéros de fin sont supprimés
+    - Au lieu d'être tronqué, le chiffre après le dernier est arrondi
 
   Comme d'autres comportements dans cet utilitaire, les choix de conception du comportement en virgule flottante
   dans cet utilitaire sont sélectionnés pour reproduire exactement

--- a/src/uu/split/locales/en-US.ftl
+++ b/src/uu/split/locales/en-US.ftl
@@ -8,12 +8,12 @@ split-after-help = Output fixed-size pieces of INPUT to PREFIXaa, PREFIXab, ...;
 
   CHUNKS may be:
 
-  - N split into N files based on size of input
-  - K/N output Kth of N to stdout
-  - l/N split into N files without splitting lines/records
-  - l/K/N output Kth of N to stdout without splitting lines/records
-  - r/N like 'l' but use round robin distribution
-  - r/K/N likewise but only output Kth of N to stdout
+    - N split into N files based on size of input
+    - K/N output Kth of N to stdout
+    - l/N split into N files without splitting lines/records
+    - l/K/N output Kth of N to stdout without splitting lines/records
+    - r/N like 'l' but use round robin distribution
+    - r/K/N likewise but only output Kth of N to stdout
 
 # messages
 split-creating-file = creating file { $file }

--- a/src/uu/split/locales/fr-FR.ftl
+++ b/src/uu/split/locales/fr-FR.ftl
@@ -8,12 +8,12 @@ split-after-help = Sortir des morceaux de taille fixe d'ENTRÉE vers PREFIXEaa, 
 
   CHUNKS peut être:
 
-  - N diviser en N fichiers basé sur la taille de l'entrée
-  - K/N sortir le Kème de N vers stdout
-  - l/N diviser en N fichiers sans diviser les lignes/enregistrements
-  - l/K/N sortir le Kème de N vers stdout sans diviser les lignes/enregistrements
-  - r/N comme 'l' mais utiliser la distribution round robin
-  - r/K/N pareillement mais ne sortir que le Kème de N vers stdout
+    - N diviser en N fichiers basé sur la taille de l'entrée
+    - K/N sortir le Kème de N vers stdout
+    - l/N diviser en N fichiers sans diviser les lignes/enregistrements
+    - l/K/N sortir le Kème de N vers stdout sans diviser les lignes/enregistrements
+    - r/N comme 'l' mais utiliser la distribution round robin
+    - r/K/N pareillement mais ne sortir que le Kème de N vers stdout
 
 # Messages d'erreur
 split-error-suffix-not-parsable = longueur de suffixe invalide : { $value }

--- a/src/uu/stat/locales/en-US.ftl
+++ b/src/uu/stat/locales/en-US.ftl
@@ -2,52 +2,51 @@ stat-about = Display file or file system status.
 stat-usage = stat [OPTION]... FILE...
 stat-after-help = Valid format sequences for files (without `--file-system`):
 
-  -`%a`: access rights in octal (note '#' and '0' printf flags)
-  -`%A`: access rights in human readable form
-  -`%b`: number of blocks allocated (see %B)
-  -`%B`: the size in bytes of each block reported by %b
-  -`%C`: SELinux security context string
-  -`%d`: device number in decimal
-  -`%D`: device number in hex
-  -`%f`: raw mode in hex
-  -`%F`: file type
-  -`%g`: group ID of owner
-  -`%G`: group name of owner
-  -`%h`: number of hard links
-  -`%i`: inode number
-  -`%m`: mount point
-  -`%n`: file name
-  -`%N`: quoted file name with dereference (follow) if symbolic link
-  -`%o`: optimal I/O transfer size hint
-  -`%s`: total size, in bytes
-  -`%t`: major device type in hex, for character/block device special files
-  -`%T`: minor device type in hex, for character/block device special files
-  -`%u`: user ID of owner
-  -`%U`: user name of owner
-  -`%w`: time of file birth, human-readable; - if unknown
-  -`%W`: time of file birth, seconds since Epoch; 0 if unknown
-  -`%x`: time of last access, human-readable
-  -`%X`: time of last access, seconds since Epoch
-  -`%y`: time of last data modification, human-readable
-
-  -`%Y`: time of last data modification, seconds since Epoch
-  -`%z`: time of last status change, human-readable
-  -`%Z`: time of last status change, seconds since Epoch
+    -`%a`: access rights in octal (note '#' and '0' printf flags)
+    -`%A`: access rights in human readable form
+    -`%b`: number of blocks allocated (see %B)
+    -`%B`: the size in bytes of each block reported by %b
+    -`%C`: SELinux security context string
+    -`%d`: device number in decimal
+    -`%D`: device number in hex
+    -`%f`: raw mode in hex
+    -`%F`: file type
+    -`%g`: group ID of owner
+    -`%G`: group name of owner
+    -`%h`: number of hard links
+    -`%i`: inode number
+    -`%m`: mount point
+    -`%n`: file name
+    -`%N`: quoted file name with dereference (follow) if symbolic link
+    -`%o`: optimal I/O transfer size hint
+    -`%s`: total size, in bytes
+    -`%t`: major device type in hex, for character/block device special files
+    -`%T`: minor device type in hex, for character/block device special files
+    -`%u`: user ID of owner
+    -`%U`: user name of owner
+    -`%w`: time of file birth, human-readable; - if unknown
+    -`%W`: time of file birth, seconds since Epoch; 0 if unknown
+    -`%x`: time of last access, human-readable
+    -`%X`: time of last access, seconds since Epoch
+    -`%y`: time of last data modification, human-readable
+    -`%Y`: time of last data modification, seconds since Epoch
+    -`%z`: time of last status change, human-readable
+    -`%Z`: time of last status change, seconds since Epoch
 
   Valid format sequences for file systems:
 
-  -`%a`: free blocks available to non-superuser
-  -`%b`: total data blocks in file system
-  -`%c`: total file nodes in file system
-  -`%d`: free file nodes in file system
-  -`%f`: free blocks in file system
-  -`%i`: file system ID in hex
-  -`%l`: maximum length of filenames
-  -`%n`: file name
-  -`%s`: block size (for faster transfers)
-  -`%S`: fundamental block size (for block counts)
-  -`%t`: file system type in hex
-  -`%T`: file system type in human readable form
+    -`%a`: free blocks available to non-superuser
+    -`%b`: total data blocks in file system
+    -`%c`: total file nodes in file system
+    -`%d`: free file nodes in file system
+    -`%f`: free blocks in file system
+    -`%i`: file system ID in hex
+    -`%l`: maximum length of filenames
+    -`%n`: file name
+    -`%s`: block size (for faster transfers)
+    -`%S`: fundamental block size (for block counts)
+    -`%t`: file system type in hex
+    -`%T`: file system type in human readable form
 
   NOTE: your shell may have its own version of stat, which usually supersedes
   the version described here.  Please refer to your shell's documentation

--- a/src/uu/stat/locales/fr-FR.ftl
+++ b/src/uu/stat/locales/fr-FR.ftl
@@ -2,51 +2,51 @@ stat-about = afficher le statut du fichier ou du système de fichiers.
 stat-usage = stat [OPTION]... FICHIER...
 stat-after-help = Séquences de format valides pour les fichiers (sans `--file-system`) :
 
-  -`%a` : droits d'accès en octal (note : drapeaux printf '#' et '0')
-  -`%A` : droits d'accès en format lisible
-  -`%b` : nombre de blocs alloués (voir %B)
-  -`%B` : la taille en octets de chaque bloc rapporté par %b
-  -`%C` : chaîne de contexte de sécurité SELinux
-  -`%d` : numéro de périphérique en décimal
-  -`%D` : numéro de périphérique en hexadécimal
-  -`%f` : mode brut en hexadécimal
-  -`%F` : type de fichier
-  -`%g` : ID de groupe du propriétaire
-  -`%G` : nom de groupe du propriétaire
-  -`%h` : nombre de liens physiques
-  -`%i` : numéro d'inode
-  -`%m` : point de montage
-  -`%n` : nom de fichier
-  -`%N` : nom de fichier avec guillemets et déréférencement (suivi) si lien symbolique
-  -`%o` : suggestion de taille optimale de transfert E/S
-  -`%s` : taille totale, en octets
-  -`%t` : type de périphérique majeur en hex, pour les fichiers spéciaux caractère/bloc
-  -`%T` : type de périphérique mineur en hex, pour les fichiers spéciaux caractère/bloc
-  -`%u` : ID utilisateur du propriétaire
-  -`%U` : nom d'utilisateur du propriétaire
-  -`%w` : heure de création du fichier, lisible ; - si inconnue
-  -`%W` : heure de création du fichier, secondes depuis l'Époque ; 0 si inconnue
-  -`%x` : heure du dernier accès, lisible
-  -`%X` : heure du dernier accès, secondes depuis l'Époque
-  -`%y` : heure de la dernière modification de données, lisible
-  -`%Y` : heure de la dernière modification de données, secondes depuis l'Époque
-  -`%z` : heure du dernier changement de statut, lisible
-  -`%Z` : heure du dernier changement de statut, secondes depuis l'Époque
+    -`%a` : droits d'accès en octal (note : drapeaux printf '#' et '0')
+    -`%A` : droits d'accès en format lisible
+    -`%b` : nombre de blocs alloués (voir %B)
+    -`%B` : la taille en octets de chaque bloc rapporté par %b
+    -`%C` : chaîne de contexte de sécurité SELinux
+    -`%d` : numéro de périphérique en décimal
+    -`%D` : numéro de périphérique en hexadécimal
+    -`%f` : mode brut en hexadécimal
+    -`%F` : type de fichier
+    -`%g` : ID de groupe du propriétaire
+    -`%G` : nom de groupe du propriétaire
+    -`%h` : nombre de liens physiques
+    -`%i` : numéro d'inode
+    -`%m` : point de montage
+    -`%n` : nom de fichier
+    -`%N` : nom de fichier avec guillemets et déréférencement (suivi) si lien symbolique
+    -`%o` : suggestion de taille optimale de transfert E/S
+    -`%s` : taille totale, en octets
+    -`%t` : type de périphérique majeur en hex, pour les fichiers spéciaux caractère/bloc
+    -`%T` : type de périphérique mineur en hex, pour les fichiers spéciaux caractère/bloc
+    -`%u` : ID utilisateur du propriétaire
+    -`%U` : nom d'utilisateur du propriétaire
+    -`%w` : heure de création du fichier, lisible ; - si inconnue
+    -`%W` : heure de création du fichier, secondes depuis l'Époque ; 0 si inconnue
+    -`%x` : heure du dernier accès, lisible
+    -`%X` : heure du dernier accès, secondes depuis l'Époque
+    -`%y` : heure de la dernière modification de données, lisible
+    -`%Y` : heure de la dernière modification de données, secondes depuis l'Époque
+    -`%z` : heure du dernier changement de statut, lisible
+    -`%Z` : heure du dernier changement de statut, secondes depuis l'Époque
 
   Séquences de format valides pour les systèmes de fichiers :
 
-  -`%a` : blocs libres disponibles pour les non-superutilisateurs
-  -`%b` : blocs de données totaux dans le système de fichiers
-  -`%c` : nœuds de fichiers totaux dans le système de fichiers
-  -`%d` : nœuds de fichiers libres dans le système de fichiers
-  -`%f` : blocs libres dans le système de fichiers
-  -`%i` : ID du système de fichiers en hexadécimal
-  -`%l` : longueur maximale des noms de fichiers
-  -`%n` : nom de fichier
-  -`%s` : taille de bloc (pour des transferts plus rapides)
-  -`%S` : taille de bloc fondamentale (pour les comptes de blocs)
-  -`%t` : type de système de fichiers en hexadécimal
-  -`%T` : type de système de fichiers en format lisible
+    -`%a` : blocs libres disponibles pour les non-superutilisateurs
+    -`%b` : blocs de données totaux dans le système de fichiers
+    -`%c` : nœuds de fichiers totaux dans le système de fichiers
+    -`%d` : nœuds de fichiers libres dans le système de fichiers
+    -`%f` : blocs libres dans le système de fichiers
+    -`%i` : ID du système de fichiers en hexadécimal
+    -`%l` : longueur maximale des noms de fichiers
+    -`%n` : nom de fichier
+    -`%s` : taille de bloc (pour des transferts plus rapides)
+    -`%S` : taille de bloc fondamentale (pour les comptes de blocs)
+    -`%t` : type de système de fichiers en hexadécimal
+    -`%T` : type de système de fichiers en format lisible
 
   NOTE : votre shell peut avoir sa propre version de stat, qui remplace généralement
   la version décrite ici. Veuillez vous référer à la documentation de votre shell


### PR DESCRIPTION
The first commits are small and fix some typos, remove unneeded parenthesis, separate values and descriptions, and add missing dots and dashes. The last one is bigger.

The extra section (`after-help`) is currently not interpreted as markdown, but as plain text. Lines are then merged, except if they are indented. This was causing issues in various manpages being very hard to read, e.g. for the stat manpage:

Before: 
<img width="838" height="219" alt="image" src="https://github.com/user-attachments/assets/6652f086-1610-4a89-bb37-a0ac1b124ae1" />

After: 
<img width="473" height="399" alt="image" src="https://github.com/user-attachments/assets/96869e94-25d1-4f14-b8ce-63cbb4b70ba2" />

Here, a simple correction is done -- similar to what was done in #10737 with only the test manpage: adapt the indentations and avoid new lines in (indented) list items not to force rendering new lines.