### PR TITLE
Cargo.lock: remove `arrayref`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,12 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
I forgot to do a rebase between the merging of https://github.com/uutils/coreutils/pull/14035 and https://github.com/uutils/coreutils/pull/14036 and `arrayref` remained in `Cargo.lock`, even though it is no longer used by any dependency.

This PR removes `arrayref` from `Cargo.lock`. <del>In addition, it bumps `blake3` and `blake2b_simd` in `fuzz` to remove `arrayref` from `fuzz/Cargo.lock`, too.</del>