### PR TITLE
pr: treat a page length of exactly 10 as omitting the header

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -867,7 +867,10 @@ fn build_options(
         });
     }
 
-    let page_length_le_ht = page_length < (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE);
+    // `pr --help` states the rule twice: a page length of 10 or less implies
+    // `-t`. At exactly 10 the old `<` left the header and trailer in place and
+    // subtracted them from the page, so the page had no room for content at all.
+    let page_length_le_ht = page_length <= (HEADER_LINES_PER_PAGE + TRAILER_LINES_PER_PAGE);
 
     let display_header_and_trailer = !page_length_le_ht
         && !matches.get_flag(options::OMIT_HEADER)

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1173,6 +1173,34 @@ fn test_zero_page_width() {
 }
 
 #[test]
+fn test_page_length_ten_implies_omit_header() {
+    // `pr --help` states it twice: a page length of 10 or less implies `-t`.
+    // At exactly 10 the header and trailer were kept and then subtracted from
+    // the page, which left no room for content: `-h` printed empty pages and
+    // `-t` printed nothing at all.
+    new_ucmd!()
+        .args(&["-l", "10", "-h", "hdr"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\nc\n");
+
+    new_ucmd!()
+        .args(&["-l", "10", "-t"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\nc\n");
+}
+
+#[test]
+fn test_page_length_eleven_keeps_header() {
+    new_ucmd!()
+        .args(&["-l", "11", "-h", "hdr"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_contains("hdr");
+}
+
+#[test]
 fn test_zero_length() {
     new_ucmd!()
         .args(&["-l", "0"])


### PR DESCRIPTION
`pr --help` states the rule twice, under `-l` and under `-t`: a page length of
10 or less implies `-t`. `pr` applies it at `< 10` instead, so a page length of
exactly 10 keeps the header and the trailer and then subtracts them from the
page, leaving zero lines for content.

With three lines of input, against GNU coreutils 9.7:

| command | GNU | before | after |
| --- | --- | --- | --- |
| `pr -l 10 -h hdr` | the 3 lines | 3 empty pages, 30 lines, no content | the 3 lines |
| `pr -l 10 -t` | the 3 lines | nothing at all | the 3 lines |
| `pr -l 10 -T` | the 3 lines | nothing at all | the 3 lines |
| `pr -l 9` or `pr -l 11` | unchanged | unchanged | unchanged |

The `-t` case drops the input on the floor and still exits 0.

The variable already carries the intended rule in its name, `page_length_le_ht`,
so this is the comparison catching up with it.

Two differences at `-l 10` are not part of this and are still there afterwards:
`-F` emits a trailing form feed that GNU does not, and `-2` lays the columns out
differently. Both reproduce without any `-l` at all.

Checked against GNU for page lengths 1, 2, 5, 9, 10, 11, 12, 20 and 66, with
`-h`, `-t`, `-T`, `-n`, `-d` and `-m`, on a 3 line and a 40 line input.
