### PR TITLE
clippy: fix chunks_exact_to_as_chunks lint

### DIFF
--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -210,7 +210,7 @@ impl BytesWriter {
                     Pattern::Single(byte) => [*byte; PATTERN_BUFFER_SIZE],
                     Pattern::Multi(bytes) => {
                         let mut buf = [0; PATTERN_BUFFER_SIZE];
-                        for chunk in buf.chunks_exact_mut(PATTERN_LENGTH) {
+                        for chunk in buf.as_chunks_mut::<PATTERN_LENGTH>().0 {
                             chunk.copy_from_slice(bytes);
                         }
                         buf

--- a/src/uucore/src/lib/features/fsxattr.rs
+++ b/src/uucore/src/lib/features/fsxattr.rs
@@ -289,7 +289,7 @@ pub fn get_acl_perm_bits_from_xattr<P: AsRef<Path>>(source: P) -> u32 {
                 .copied()
                 .collect::<Vec<u8>>();
 
-            for entry in acl_entries.chunks_exact(4) {
+            for entry in acl_entries.as_chunks::<4>().0 {
                 // Third byte and fourth byte will be the perm bits
                 perm = (perm << 3) | u32::from(entry[2]) | u32::from(entry[3]);
             }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks