### PR TITLE
comm: compare lines with the locale collation

### DIFF
--- a/src/uu/comm/Cargo.toml
+++ b/src/uu/comm/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-uucore = { workspace = true, features = ["fs"] }
+uucore = { workspace = true, features = ["fs", "i18n-collator"] }
 fluent = { workspace = true }
 
 [lints]

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -14,6 +14,9 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::format_usage;
 use uucore::fs::{are_files_identical, paths_refer_to_same_file};
+use uucore::i18n::collator::{
+    AlternateHandling, CollatorOptions, locale_cmp, should_use_locale_collation, try_init_collator,
+};
 use uucore::line_ending::LineEnding;
 use uucore::translate;
 
@@ -53,6 +56,20 @@ struct OrderChecker {
     file_num: FileNumber,
     check_order: bool,
     has_error: bool,
+    use_locale: bool,
+}
+
+/// Compare two lines the way the input was ordered.
+///
+/// `sort` orders with the locale collation, and so do `join` and `ls`. Reading
+/// that order back with a byte comparison rejects input that is in order and
+/// puts lines in the wrong column, so `comm` has to measure it the same way.
+fn line_cmp(a: &[u8], b: &[u8], use_locale: bool) -> Ordering {
+    if use_locale {
+        locale_cmp(a, b)
+    } else {
+        a.cmp(b)
+    }
 }
 
 enum Input {
@@ -97,12 +114,13 @@ impl LineReader {
 }
 
 impl OrderChecker {
-    fn new(file_num: FileNumber, check_order: bool) -> Self {
+    fn new(file_num: FileNumber, check_order: bool, use_locale: bool) -> Self {
         Self {
             last_line: Vec::new(),
             file_num,
             check_order,
             has_error: false,
+            use_locale,
         }
     }
 
@@ -112,7 +130,7 @@ impl OrderChecker {
             return true;
         }
 
-        let is_ordered = *current_line >= *self.last_line;
+        let is_ordered = line_cmp(current_line, &self.last_line, self.use_locale) != Ordering::Less;
         if !is_ordered && !self.has_error {
             let _ = writeln!(
                 stderr(),
@@ -176,15 +194,16 @@ fn comm(
                 || are_files_identical(Path::new(filename1), Path::new(filename2))
                     .unwrap_or(false)));
 
-    let mut checker1 = OrderChecker::new(FileNumber::One, check_order);
-    let mut checker2 = OrderChecker::new(FileNumber::Two, check_order);
+    let use_locale = should_use_locale_collation();
+    let mut checker1 = OrderChecker::new(FileNumber::One, check_order, use_locale);
+    let mut checker2 = OrderChecker::new(FileNumber::Two, check_order, use_locale);
     let mut input_error = false;
 
     while na != 0 || nb != 0 {
         let ord = match (na, nb) {
             (0, _) => Ordering::Greater,
             (_, 0) => Ordering::Less,
-            (_, _) => ra.as_slice().cmp(rb.as_slice()),
+            (_, _) => line_cmp(ra, rb, use_locale),
         };
 
         match ord {
@@ -285,6 +304,11 @@ fn open_file(name: &OsString, line_ending: LineEnding) -> io::Result<LineReader>
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
+
+    let mut collator_opts = CollatorOptions::default();
+    collator_opts.alternate_handling = Some(AlternateHandling::Shifted);
+    let _ = try_init_collator(collator_opts);
+
     let line_ending = LineEnding::from_zero_flag(matches.get_flag(options::ZERO_TERMINATED));
     let filename1 = matches.get_one::<OsString>(options::FILE_1).unwrap();
     let filename2 = matches.get_one::<OsString>(options::FILE_2).unwrap();

--- a/tests/by-util/test_comm.rs
+++ b/tests/by-util/test_comm.rs
@@ -6,6 +6,8 @@
 
 use uutests::new_ucmd;
 use uutests::util::TestScenario;
+#[cfg(unix)]
+use uutests::util::is_locale_available;
 use uutests::util_name;
 
 #[test]
@@ -730,6 +732,51 @@ fn test_read_error() {
         .arg("/proc/self/mem")
         .fails()
         .stderr_contains("comm: /proc/self/mem: Input/output error");
+}
+
+#[test]
+#[cfg(unix)]
+#[cfg_attr(wasi_runner, ignore = "WASI: the guest does not inherit LC_ALL")]
+fn test_locale_collation() {
+    // In a UTF-8 locale the collation puts `a1` before `a-b` and the byte order
+    // puts them the other way round. Reading a file `sort` produced with a byte
+    // comparison rejects it as unsorted and drops the line the two files share.
+    let locale = "en_US.UTF-8";
+    if !is_locale_available(locale) {
+        return;
+    }
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.write("f1", "a1\na-b\n");
+    scene.fixtures.write("f2", "a-b\n");
+
+    scene
+        .ucmd()
+        .env("LC_ALL", locale)
+        .args(&["-12", "f1", "f2"])
+        .succeeds()
+        .stdout_only("a-b\n");
+
+    scene
+        .ucmd()
+        .env("LC_ALL", locale)
+        .args(&["-23", "f1", "f2"])
+        .succeeds()
+        .stdout_only("a1\n");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_c_locale_still_orders_by_bytes() {
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.write("f1", "a-b\na1\n");
+    scene.fixtures.write("f2", "a-b\n");
+
+    scene
+        .ucmd()
+        .env("LC_ALL", "C")
+        .args(&["-12", "f1", "f2"])
+        .succeeds()
+        .stdout_only("a-b\n");
 }
 
 #[test]


### PR DESCRIPTION
`sort` orders lines with the locale collation and `comm` reads that order back
with a byte comparison. In a UTF-8 locale where the two disagree, `comm` rejects
a file `sort` has just produced and puts lines in the wrong column.

With `LC_ALL=en_US.UTF-8`, `f1` holding `a1` then `a-b`, which is the order
`sort` gives, and `f2` holding `a-b`:

| command | GNU | before | after |
| --- | --- | --- | --- |
| `comm -12 f1 f2` | `a-b` | nothing, the shared line is dropped | `a-b` |
| `comm -13 f1 f2` | nothing | `a-b`, a line that is in both files | nothing |
| `comm -23 f1 f2` | `a1` | `a1` and `a-b` | `a1` |
| exit code | 0 | 1 | 0 |

`sort`, `join`, `ls` and `expr` already go through `uucore::i18n::collator`, and
`join`, which has the same order check, reads this input correctly today. This
gives `comm` the same comparison. In the C locale the lines are still compared
as bytes, so nothing changes there.

#12280 also touches `OrderChecker`, but for a different thing: it changes when
the warning is printed, not how the order is measured.

Fixes #12912

#12972 was closed as a duplicate of that one. It is an AOSP build failing after
45 minutes with `comm: file 1 is not in sorted order`.
