### PR TITLE
unexpand: accept a blank as a tab-list separator like GNU

### DIFF
--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -48,7 +48,8 @@ fn parse_tab_num(word: &str, allow_zero: bool) -> Result<usize, ParseError> {
 }
 
 fn parse_tabstops(s: &str) -> Result<TabConfig, ParseError> {
-    let words = s.split(',');
+    // GNU accepts a blank (space or tab) or a comma as tab-list separators.
+    let words = s.split([' ', '\t', ',']);
 
     let mut nums = Vec::new();
     let mut increment_size: Option<usize> = None;

--- a/tests/by-util/test_unexpand.rs
+++ b/tests/by-util/test_unexpand.rs
@@ -271,6 +271,18 @@ fn test_comma_separated_tabs_shortcut() {
 }
 
 #[test]
+fn test_blank_separated_tabs() {
+    // GNU accepts a space or a tab as a tab-list separator, just like a comma.
+    for sep in [" ", "\t"] {
+        new_ucmd!()
+            .args(&["-a", "-t", &format!("3{sep}9")])
+            .pipe_in("a  b     c")
+            .succeeds()
+            .stdout_is("a\tb\tc");
+    }
+}
+
+#[test]
 fn test_tabs_cannot_be_zero() {
     new_ucmd!()
         .arg("--tabs=0")


### PR DESCRIPTION
GNU `unexpand` accepts both a comma and a blank between tab stops in `-t`/`--tabs`, so `unexpand -t '2 3'` behaves like `unexpand -t '2,3'`. uutils only splits on a comma, so the space form is rejected:

```
$ printf '  a   b\n' | unexpand -t '2 3' -a
unexpand: tab size contains invalid character(s): ' 3'
```

uutils' own `expand` already accepts both separators via an `is_space_or_comma` helper; only `unexpand` was inconsistent. This splits the tab list on a space or a comma too, mirroring `expand`. Verified byte for byte against GNU `unexpand` in the C locale for `'2 3'`, `' 2 3'`, `'2  3'`, `'2, 3'` and `'1 4 7'`; invalid values like `-t x` still error as before.
