### PR TITLE
uucore: fix uptime build on Android and wasm32

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -31,9 +31,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     repeat_content_to_capacity(&mut buffer);
     match exec(&buffer) {
         Ok(()) => Ok(()),
-        // On Windows and WASI, silently handle broken pipe since there's no SIGPIPE
+        // On Windows and WASI, silently handle any stdout write error since there's no SIGPIPE
         #[cfg(any(windows, target_os = "wasi"))]
-        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(_) => Ok(()),
         Err(err) => Err(USimpleError::new(
             1,
             translate!("yes-error-standard-output", "error" => strip_errno(&err)),

--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -31,9 +31,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     repeat_content_to_capacity(&mut buffer);
     match exec(&buffer) {
         Ok(()) => Ok(()),
-        // On Windows and WASI, silently handle any stdout write error since there's no SIGPIPE
+        // On Windows and WASI, silently handle broken pipe since there's no SIGPIPE
         #[cfg(any(windows, target_os = "wasi"))]
-        Err(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(USimpleError::new(
             1,
             translate!("yes-error-standard-output", "error" => strip_errno(&err)),

--- a/src/uucore/src/lib/features/uptime/unix.rs
+++ b/src/uucore/src/lib/features/uptime/unix.rs
@@ -152,7 +152,7 @@ pub fn get_uptime(boot_time: Option<time_t>) -> UResult<i64> {
 /// # Returns
 ///
 /// Returns the number of users currently logged in if successful, otherwise 0.
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "android")))]
 // see: https://gitlab.com/procps-ng/procps/-/blob/4740a0efa79cade867cfc7b32955fe0f75bf5173/library/uptime.c#L63-L115
 pub fn get_nusers() -> usize {
     use crate::utmpx::USER_PROCESS;
@@ -198,10 +198,12 @@ pub fn get_nusers(file: &str) -> usize {
 /// [`super::get_formatted_nusers`]. On OpenBSD the default source is
 /// `/var/run/utmp`.
 pub(crate) fn default_nusers() -> usize {
-    #[cfg(not(target_os = "openbsd"))]
+    #[cfg(not(any(target_os = "openbsd", target_os = "android")))]
     return get_nusers();
     #[cfg(target_os = "openbsd")]
-    get_nusers("/var/run/utmp")
+    return get_nusers("/var/run/utmp");
+    #[cfg(target_os = "android")]
+    return 0;
 }
 
 /// Get the system load average
@@ -210,6 +212,7 @@ pub(crate) fn default_nusers() -> usize {
 ///
 /// Returns a UResult with the load average if successful, otherwise an UptimeError.
 /// The load average is a tuple of three floating point numbers representing the 1-minute, 5-minute, and 15-minute load averages.
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
 pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
     use core::ffi::c_double;
     use libc::getloadavg;
@@ -223,6 +226,11 @@ pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
     } else {
         Ok((avg[0], avg[1], avg[2]))
     }
+}
+
+#[cfg(any(target_arch = "wasm32", target_os = "android"))]
+pub fn get_loadavg() -> UResult<(f64, f64, f64)> {
+    Err(UptimeError::SystemLoadavg)?
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/tests/by-util/test_yes.rs
+++ b/tests/by-util/test_yes.rs
@@ -32,28 +32,33 @@ fn test_version() {
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_simple() {
     run(NO_ARGS, b"y\ny\ny\ny\n");
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_args() {
     run(&["a", "bar", "c"], b"a bar c\na bar c\na ba");
 }
 
 #[test]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_long_output() {
     run(NO_ARGS, "y\n".repeat(512 * 1024).as_bytes());
 }
 
 /// Test with an output that seems likely to get mangled in case of incomplete writes.
 #[test]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_long_odd_output() {
     run(&["abcdef"], "abcdef\n".repeat(1024 * 1024).as_bytes());
 }
 
 /// Test with an input that doesn't fit in the standard buffer.
 #[test]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_long_input() {
     #[cfg(not(windows))]
     const TIMES: usize = 14000;


### PR DESCRIPTION
Add missing cfg guards to exclude Android and wasm32 targets from utmpx and getloadavg usage, which are not available on those platforms.