### PR TITLE
clippy: add deprecation comment for `from_iter_instead_of_collect` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,6 +584,7 @@ implicit_hasher = "allow"
 doc_link_with_quotes = "allow"
 format_push_string = "allow"
 flat_map_option = "allow"
+# TODO lint is deprecated since Rust 1.98, can be removed when we have a MSRV >= 1.98
 from_iter_instead_of_collect = "allow"
 large_types_passed_by_value = "allow"
 


### PR DESCRIPTION
This PR <del>removes the `from_iter_instead_of_collect` lint from `Cargo.toml`</del>adds a deprecation comment for the `from_iter_instead_of_collect` lint as it has been deprecated upstream (https://github.com/rust-lang/rust-clippy/pull/17208).