### PR TITLE
sort: refuse a random source shorter than the salt

### DIFF
--- a/src/uu/sort/locales/en-US.ftl
+++ b/src/uu/sort/locales/en-US.ftl
@@ -24,6 +24,7 @@ sort-file-operands-combined = extra operand {$file}
 sort-multiple-output-files = multiple output files specified
 sort-minus-in-stdin = when reading file names from standard input, no file name of '-' allowed
 sort-no-input-from = no input from {$file}
+sort-random-source-end-of-file = {$path}: end of file
 sort-invalid-zero-length-filename = {$file}:{$line_num}: invalid zero-length file name
 sort-options-incompatible = options '-{$opt1}{$opt2}' are incompatible
 sort-invalid-key = invalid key {$key}

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -181,6 +181,9 @@ pub enum SortError {
     #[error("{}", translate!("sort-no-input-from", "file" => format!("{}", .file.quote())))]
     EmptyInputFile { file: PathBuf },
 
+    #[error("{}", translate!("sort-random-source-end-of-file", "path" => format!("{}", .path.quote())))]
+    RandomSourceEndOfFile { path: PathBuf },
+
     #[error("{}", translate!("sort-invalid-zero-length-filename", "file" => .file.maybe_quote(), "line_num" => .line_num))]
     ZeroLengthFileName { file: PathBuf, line_num: usize },
 }
@@ -3083,6 +3086,10 @@ const U64_LEN: usize = 8;
 const RANDOM_SOURCE_TAG: &[u8] = b"uutils-sort-random-source"; // Domain separation tag
 
 /// Create a 128-bit salt by hashing up to 1 MiB from the given file.
+///
+/// The file has to hold at least [`SALT_LEN`] bytes. GNU asks for the same 128
+/// bits and reports `end of file` when the source cannot supply them, rather
+/// than shuffling with whatever it managed to read.
 fn salt_from_random_source(path: &Path) -> UResult<[u8; SALT_LEN]> {
     let mut reader = open_with_open_failed_error(path)?;
     let mut buf = [0u8; BUF_LEN];
@@ -3104,6 +3111,13 @@ fn salt_from_random_source(path: &Path) -> UResult<[u8; SALT_LEN]> {
         if take < n {
             break;
         }
+    }
+
+    if total < SALT_LEN {
+        return Err(SortError::RandomSourceEndOfFile {
+            path: path.to_owned(),
+        }
+        .into());
     }
 
     let first = hasher.finish();

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -390,6 +390,56 @@ fn test_random_shuffle_two_runs_not_the_same() {
 }
 
 #[test]
+fn test_random_source_shorter_than_the_salt() {
+    // GNU wants 128 bits out of the source and reports end of file below that,
+    // instead of shuffling with whatever it could read.
+    for len in [0, 1, 15] {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.write_bytes("source", &vec![b'x'; len]);
+        at.write("input", "b\na\nc\n");
+
+        ucmd.args(&["-R", "--random-source=source", "input"])
+            .fails_with_code(2)
+            .no_stdout()
+            .stderr_is("sort: 'source': end of file\n");
+    }
+}
+
+#[test]
+fn test_random_source_of_exactly_the_salt_length() {
+    use uutests::util_name;
+
+    let ts = TestScenario::new(util_name!());
+    ts.fixtures.write_bytes("source", &[b'x'; 16]);
+    ts.fixtures.write("input", "b\na\nc\n");
+
+    let first = ts
+        .ucmd()
+        .args(&["-R", "--random-source=source", "input"])
+        .succeeds()
+        .stdout_move_str();
+    let second = ts
+        .ucmd()
+        .args(&["-R", "--random-source=source", "input"])
+        .succeeds()
+        .stdout_move_str();
+
+    assert_eq!(first, second);
+    assert_eq!(first.lines().count(), 3);
+}
+
+#[test]
+fn test_random_source_is_not_read_without_random_sort() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write_bytes("source", b"");
+    at.write("input", "b\na\nc\n");
+
+    ucmd.args(&["--random-source=source", "input"])
+        .succeeds()
+        .stdout_is("a\nb\nc\n");
+}
+
+#[test]
 fn test_random_ignore_case() {
     let input = "ABC\nABc\nAbC\nAbc\naBC\naBc\nabC\nabc\n";
     new_ucmd!()


### PR DESCRIPTION
GNU refuses to shuffle when `--random-source` cannot give it the 128 bits it wants:

```console
$ printf 'b\na\nc\n' > in
$ head -c 15 /dev/urandom > src
$ sort -R --random-source=src in
sort: 'src': end of file
$ echo $?
2
```

uutils takes whatever is in the file and shuffles anyway:

```console
$ ./target/debug/sort -R --random-source=src in
c
a
b
$ echo $?
0
```

An empty source behaves the same. The salt then comes out of a file that never supplied it, and reproducing the shuffle from that file is the only reason to pass the flag.

`salt_from_random_source` in `src/uu/sort/src/sort.rs` hashes what it reads without looking at how much it read. Its salt is 128 bits (`SALT_LEN`) and GNU wants the same 128: 15 bytes is an error, 16 bytes is enough, and the threshold does not move with the size of the input. I checked that with 5 lines and with 200000.

So this adds the length check and an error carrying the GNU text and exit status. `shuf` already stops on a short source (`shuf: end of random source`), which left `sort` as the odd one out.

## Tests

Three in `tests/by-util/test_sort.rs`:

- sources of 0, 1 and 15 bytes fail with `sort: 'source': end of file` and code 2
- a source of exactly 16 bytes succeeds and gives the same order on two runs
- `--random-source` without `-R` still succeeds and does not read the source, as GNU does

Only the first fails on main. `cargo test --features sort --no-default-features test_sort` gives 192 passing on this branch, and 191 passing with 1 failing when I revert `sort.rs` and the string and keep the tests.

`cargo fmt --all -- --check` is clean, and `moz-fluent-lint` passes on `src/uu/sort/locales`. `cargo clippy -p uu_sort --all-targets -- -D warnings` fails the same way here and on a clean main, on the `unfulfilled lint expectation` in the generated `embedded_locales.rs` of uucore.

The string goes into `en-US.ftl` only. `fr-FR.ftl` is 15 keys behind already and falls back.
