### PR TITLE
pathchk: reject an empty file name in portability modes to match GNU

### DIFF
--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -127,6 +127,11 @@ pub fn uu_app() -> Command {
 
 /// check a path, given as a slice of it's components and an operating mode
 fn check_path(mode: &Mode, path: &[String]) -> bool {
+    // GNU rejects an empty file name in any portability mode before touching the filesystem.
+    if !matches!(mode, Mode::Default) && path.join("/").is_empty() {
+        show_error!("{}", translate!("pathchk-error-empty-file-name"));
+        return false;
+    }
     match *mode {
         Mode::Basic => check_basic(path),
         Mode::Extra => check_default(path) && check_extra(path),

--- a/tests/by-util/test_pathchk.rs
+++ b/tests/by-util/test_pathchk.rs
@@ -175,6 +175,23 @@ fn test_posix_all() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_empty_path_portability_message() {
+    // In every portability mode (-p, -P, --portability) GNU reports an empty
+    // file name with the program-name prefix and before any filesystem check.
+    for flag in ["-p", "-P", "--portability"] {
+        new_ucmd!()
+            .args(&[flag, ""])
+            .fails()
+            .stderr_only("pathchk: empty file name\n");
+    }
+    new_ucmd!()
+        .args(&["-p", "-P", ""])
+        .fails()
+        .stderr_only("pathchk: empty file name\n");
+}
+
+#[test]
 #[cfg(target_os = "linux")]
 fn test_pathchk_non_utf8_paths() {
     let filename = std::ffi::OsString::from_vec(vec![0xFF, 0xFE]);


### PR DESCRIPTION
In `pathchk`'s portability modes (`-p`, `-P`, `--portability`), an empty file name diverges from GNU:

- `-P` prints `pathchk: '': No such file or directory` (it runs the filesystem check first and never reaches the empty-name check).
- `-p` and `--portability` print `empty file name` without the `pathchk: ` prefix.

GNU rejects an empty file name in any portability mode before touching the filesystem, always as `pathchk: empty file name`:

```
$ pathchk -P ''             # pathchk: '': No such file or directory   (GNU: pathchk: empty file name)
$ pathchk -p ''             # empty file name                          (GNU: pathchk: empty file name)
$ pathchk --portability ''  # empty file name                          (GNU: pathchk: empty file name)
```

This adds the early empty-name check (using the existing localized string) for all portability modes. Default mode (`pathchk ''`) is unchanged.
