### PR TITLE
join: let -o accumulate fields across occurrences like GNU

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -784,28 +784,36 @@ fn parse_settings(matches: &clap::ArgMatches, diag_args: Option<&[OsString]>) ->
     if let Some(value_os) = matches.get_one::<OsString>("t") {
         settings.separator = parse_separator(value_os)?;
     }
-    if let Some(format) = matches.get_one::<String>("o") {
-        if format == "auto" {
+    if let Some(formats) = matches.get_many::<String>("o") {
+        let formats: Vec<&String> = formats.collect();
+        // GNU lets `-o` repeat and accumulates the fields. Auto mode applies only
+        // when every value is exactly `auto`; otherwise each `auto` is ignored.
+        if formats.iter().all(|f| *f == "auto") {
             settings.autoformat = true;
         } else {
             let mut specs = vec![];
-            // `-o` has no long form.
-            let option = OptionValue::with_names(format.clone(), Some('o'), None);
-            // Each field carries its place in the value, so that the caret can
-            // take the one that is at fault out of a long list.
-            for (part, span) in uucore::diagnostics::list_items(format, &[' ', ',', '\t']) {
-                specs.push(Spec::parse(part).map_err(|error| {
-                    let message = error.to_string();
-                    uucore::diagnostics::error_after_report(diag_args, error, |args, _| {
-                        uucore::diagnostics::Snapshot::with_program(args).render_option(
-                            &option,
-                            span,
-                            &message,
-                            None,
-                            Some(&translate!("join-diag-help-format")),
-                        )
-                    })
-                })?);
+            for format in formats {
+                if format == "auto" {
+                    continue;
+                }
+                // `-o` has no long form.
+                let option = OptionValue::with_names(format.clone(), Some('o'), None);
+                // Each field carries its place in the value, so that the caret can
+                // take the one that is at fault out of a long list.
+                for (part, span) in uucore::diagnostics::list_items(format, &[' ', ',', '\t']) {
+                    specs.push(Spec::parse(part).map_err(|error| {
+                        let message = error.to_string();
+                        uucore::diagnostics::error_after_report(diag_args, error, |args, _| {
+                            uucore::diagnostics::Snapshot::with_program(args).render_option(
+                                &option,
+                                span,
+                                &message,
+                                None,
+                                Some(&translate!("join-diag-help-format")),
+                            )
+                        })
+                    })?);
+                }
             }
             settings.format = specs;
         }
@@ -919,6 +927,8 @@ pub fn uu_app() -> Command {
             Arg::new("o")
                 .short('o')
                 .value_name("FORMAT")
+                .action(ArgAction::Append)
+                .num_args(1)
                 .help(translate!("join-help-o")),
         )
         .arg(

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -254,6 +254,34 @@ fn default_format() {
 }
 
 #[test]
+fn repeated_o_accumulates_fields() {
+    // GNU lets -o repeat; the fields accumulate, so this matches a single -o.
+    new_ucmd!()
+        .arg("fields_1.txt")
+        .arg("fields_2.txt")
+        .arg("-o")
+        .arg("1.1")
+        .arg("-o")
+        .arg("2.2")
+        .succeeds()
+        .stdout_only_fixture("default.expected");
+}
+
+#[test]
+fn repeated_o_ignores_auto_when_mixed() {
+    // When -o is repeated and not every value is `auto`, each `auto` is ignored.
+    new_ucmd!()
+        .arg("fields_1.txt")
+        .arg("fields_2.txt")
+        .arg("-o")
+        .arg("auto")
+        .arg("-o")
+        .arg("1.1 2.2")
+        .succeeds()
+        .stdout_only_fixture("default.expected");
+}
+
+#[test]
 fn unpaired_lines_format() {
     new_ucmd!()
         .arg("fields_2.txt")

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -255,28 +255,44 @@ fn default_format() {
 
 #[test]
 fn repeated_o_accumulates_fields() {
-    // GNU lets -o repeat; the fields accumulate, so this matches a single -o.
+    // GNU lets -o repeat; the fields accumulate in the order they appear,
+    // here giving the reverse of the default format.
     new_ucmd!()
         .arg("fields_1.txt")
         .arg("fields_2.txt")
         .arg("-o")
-        .arg("1.1")
-        .arg("-o")
         .arg("2.2")
+        .arg("-o")
+        .arg("1.1")
         .succeeds()
-        .stdout_only_fixture("default.expected");
+        .stdout_only("a 1\nb 2\nc 3\ne 5\nh 8\n");
 }
 
 #[test]
 fn repeated_o_ignores_auto_when_mixed() {
-    // When -o is repeated and not every value is `auto`, each `auto` is ignored.
+    // When -o is repeated and not every value is `auto`, each `auto` is
+    // ignored: only the explicit fields are printed, repeats included.
     new_ucmd!()
         .arg("fields_1.txt")
         .arg("fields_2.txt")
         .arg("-o")
         .arg("auto")
         .arg("-o")
-        .arg("1.1 2.2")
+        .arg("2.2 2.2 1.1")
+        .succeeds()
+        .stdout_only("a a 1\nb b 2\nc c 3\ne e 5\nh h 8\n");
+}
+
+#[test]
+fn repeated_o_auto_stays_auto() {
+    // `auto` still applies when every -o value is `auto`.
+    new_ucmd!()
+        .arg("fields_1.txt")
+        .arg("fields_2.txt")
+        .arg("-o")
+        .arg("auto")
+        .arg("-o")
+        .arg("auto")
         .succeeds()
         .stdout_only_fixture("default.expected");
 }


### PR DESCRIPTION
GNU `join` lets `-o FORMAT` appear more than once; the field specs from every occurrence accumulate in order. uutils rejects a repeated `-o` with a hard error:

```
$ join -o 1.1 -o 1.2 -o 2.2 file1 file2
join: the argument '-o <FORMAT>' cannot be used multiple times
# GNU accumulates the fields and prints 1.1 1.2 2.2
```

This makes several `-o` accumulate, matching GNU, including the `auto` corner cases: `auto` mode applies only when every `-o` value is exactly `auto`, otherwise each `auto` is ignored and the real specs accumulate. It uses the existing `ArgAction::Append` idiom (as `-a` and `-v` already do). Single-`-o` behavior and the per-field diagnostics are unchanged.
