### PR TITLE
nl: drop unused translation

### DIFF
--- a/src/uu/nl/locales/en-US.ftl
+++ b/src/uu/nl/locales/en-US.ftl
@@ -33,7 +33,6 @@ nl-error-invalid-arguments = Invalid arguments supplied.
 nl-error-could-not-read-line = could not read line
 nl-error-could-not-write = could not write output
 nl-error-line-number-overflow = line number overflow
-nl-error-invalid-line-width = Invalid line number field width: ‘{ $value }’: Numerical result out of range
 nl-error-invalid-regex = invalid regular expression
 nl-error-invalid-numbering-style = invalid numbering style: '{ $style }'
 nl-error-is-directory = { $path }: Is a directory

--- a/src/uu/nl/locales/fr-FR.ftl
+++ b/src/uu/nl/locales/fr-FR.ftl
@@ -33,7 +33,6 @@ nl-error-invalid-arguments = Arguments fournis invalides.
 nl-error-could-not-read-line = impossible de lire la ligne
 nl-error-could-not-write = impossible d'écrire la sortie
 nl-error-line-number-overflow = débordement du numéro de ligne
-nl-error-invalid-line-width = Largeur de champ de numéro de ligne invalide : ‘{ $value }’ : Résultat numérique hors limites
 nl-error-invalid-regex = expression régulière invalide
 nl-error-invalid-numbering-style = style de numérotation invalide : '{ $style }'
 nl-error-is-directory = { $path } : Est un répertoire


### PR DESCRIPTION
https://github.com/uutils/coreutils/pull/13348 provided an error message better than GNU with actual range.

Closes https://github.com/uutils/coreutils/pull/14066 (duplicated PR)