### PR TITLE
printf: use plain text help headings

### DIFF
--- a/src/uu/printf/locales/en-US.ftl
+++ b/src/uu/printf/locales/en-US.ftl
@@ -13,7 +13,7 @@ printf-after-help = basic anonymous string templating:
   literally, with the exception of the below
   escaped character sequences, and the substitution sequences described further down.
 
-  ### ESCAPE SEQUENCES
+  ESCAPE SEQUENCES:
 
   The following escape sequences, organized here in alphabetical order,
   will print the corresponding character literal:
@@ -51,9 +51,9 @@ printf-after-help = basic anonymous string templating:
 
   - %% a single %
 
-  ### SUBSTITUTIONS
+  SUBSTITUTIONS:
 
-  #### SUBSTITUTION QUICK REFERENCE
+  SUBSTITUTION QUICK REFERENCE:
 
   Fields
 
@@ -109,7 +109,7 @@ printf-after-help = basic anonymous string templating:
   - 0x: (e.g. 0xABC) interpret argument as hex (numeric output fields only)
   - \': (e.g. \'a) interpret argument as a character constant
 
-  #### HOW TO USE SUBSTITUTIONS
+  HOW TO USE SUBSTITUTIONS:
 
   Substitutions are used to pass additional argument(s) into the FORMAT string, to be formatted a
   particular way. E.g.
@@ -139,13 +139,13 @@ printf-after-help = basic anonymous string templating:
   an argument will default to empty strings, or for numeric fields
   the value 0
 
-  #### AVAILABLE SUBSTITUTIONS
+  AVAILABLE SUBSTITUTIONS:
 
   This program, like GNU coreutils printf,
   interprets a modified subset of the POSIX C printf spec,
   a quick reference to substitutions is below.
 
-  #### STRING SUBSTITUTIONS
+  STRING SUBSTITUTIONS:
 
   All string fields have a 'max width' parameter
   %.3s means 'print no more than three characters of the original input'
@@ -166,13 +166,13 @@ printf-after-help = basic anonymous string templating:
         and shell meta-characters are quoted appropriately.
         This is an equivalent format to ls --quoting=shell-escape output.
 
-  #### CHAR SUBSTITUTIONS
+  CHAR SUBSTITUTIONS:
 
   The character field does not have a secondary parameter.
 
   - %c: a single character
 
-  #### INTEGER SUBSTITUTIONS
+  INTEGER SUBSTITUTIONS:
 
   All integer fields have a 'pad with zero' parameter
   %.4i means an integer which if it is less than 4 digits in length,
@@ -187,7 +187,7 @@ printf-after-help = basic anonymous string templating:
 
   - %o: 64-bit unsigned integer printed in octal (base 8)
 
-  #### FLOATING POINT SUBSTITUTIONS
+  FLOATING POINT SUBSTITUTIONS:
 
   All floating point fields have a 'max decimal places / max significant digits' parameter
   %.10f means a decimal floating point with 7 decimal places past 0
@@ -220,7 +220,7 @@ printf-after-help = basic anonymous string templating:
   behavior in this utility is selected to reproduce in exact
   the behavior of GNU coreutils' printf from an inputs and outputs standpoint.
 
-  ### USING PARAMETERS
+  USING PARAMETERS:
 
   Most substitution fields can be parameterized using up to 2 numbers that can
   be passed to the field, between the % sign and the field letter.
@@ -231,7 +231,7 @@ printf-after-help = basic anonymous string templating:
   The 2nd parameter is proceeded by a dot.
   You do not have to use parameters
 
-  ### SPECIAL FORMS OF INPUT
+  SPECIAL FORMS OF INPUT:
 
   For numeric input, the following additional forms of input are accepted besides decimal:
 

--- a/src/uu/printf/locales/fr-FR.ftl
+++ b/src/uu/printf/locales/fr-FR.ftl
@@ -13,7 +13,7 @@ printf-after-help = templating de chaîne anonyme de base :
   littéralement, à l'exception de ce qui suit
   séquences de caractères échappés, et les séquences de substitution décrites plus loin.
 
-  ### SÉQUENCES D'ÉCHAPPEMENT
+  SÉQUENCES D'ÉCHAPPEMENT :
 
   Les séquences d'échappement suivantes, organisées ici par ordre alphabétique,
   afficheront le littéral de caractère correspondant :
@@ -51,9 +51,9 @@ printf-after-help = templating de chaîne anonyme de base :
 
   - %% un seul %
 
-  ### SUBSTITUTIONS
+  SUBSTITUTIONS :
 
-  #### RÉFÉRENCE RAPIDE DES SUBSTITUTIONS
+  RÉFÉRENCE RAPIDE DES SUBSTITUTIONS :
 
   Champs
 
@@ -109,7 +109,7 @@ printf-after-help = templating de chaîne anonyme de base :
   - 0x: (ex. 0xABC) interpréter l'argument comme hexadécimal (champs de sortie numériques uniquement)
   - \': (ex. \'a) interpréter l'argument comme une constante de caractère
 
-  #### COMMENT UTILISER LES SUBSTITUTIONS
+  COMMENT UTILISER LES SUBSTITUTIONS :
 
   Les substitutions sont utilisées pour passer des argument(s) supplémentaire(s) dans la chaîne FORMAT, pour être formatés d'une
   manière particulière. Par ex.
@@ -139,13 +139,13 @@ printf-after-help = templating de chaîne anonyme de base :
   argument auront par défaut des chaînes vides, ou pour les champs numériques
   la valeur 0
 
-  #### SUBSTITUTIONS DISPONIBLES
+  SUBSTITUTIONS DISPONIBLES :
 
   Ce programme, comme GNU coreutils printf,
   interprète un sous-ensemble modifié de la spécification printf C POSIX,
   une référence rapide aux substitutions est ci-dessous.
 
-  #### SUBSTITUTIONS DE CHAÎNES
+  SUBSTITUTIONS DE CHAÎNES :
 
   Tous les champs de chaîne ont un paramètre 'largeur max'
   %.3s signifie 'afficher pas plus de trois caractères de l'entrée originale'
@@ -166,13 +166,13 @@ printf-after-help = templating de chaîne anonyme de base :
         et les méta-caractères shell sont cités de manière appropriée.
         C'est un format équivalent à la sortie ls --quoting=shell-escape.
 
-  #### SUBSTITUTIONS DE CARACTÈRES
+  SUBSTITUTIONS DE CARACTÈRES :
 
   Le champ caractère n'a pas de paramètre secondaire.
 
   - %c: un seul caractère
 
-  #### SUBSTITUTIONS D'ENTIERS
+  SUBSTITUTIONS D'ENTIERS :
 
   Tous les champs entiers ont un paramètre 'remplir avec zéro'
   %.4i signifie un entier qui s'il fait moins de 4 chiffres de longueur,
@@ -187,7 +187,7 @@ printf-after-help = templating de chaîne anonyme de base :
 
   - %o: entier non signé 64 bits affiché en octal (base 8)
 
-  #### SUBSTITUTIONS EN VIRGULE FLOTTANTE
+  SUBSTITUTIONS EN VIRGULE FLOTTANTE :
 
   Tous les champs en virgule flottante ont un paramètre 'max places décimales / max chiffres significatifs'
   %.10f signifie une virgule flottante décimale avec 7 places décimales après 0
@@ -220,7 +220,7 @@ printf-after-help = templating de chaîne anonyme de base :
   dans cet utilitaire sont sélectionnés pour reproduire exactement
   le comportement de printf de GNU coreutils du point de vue des entrées et sorties.
 
-  ### UTILISATION DES PARAMÈTRES
+  UTILISATION DES PARAMÈTRES :
 
   La plupart des champs de substitution peuvent être paramétrés en utilisant jusqu'à 2 nombres qui peuvent
   être passés au champ, entre le signe % et la lettre du champ.
@@ -231,7 +231,7 @@ printf-after-help = templating de chaîne anonyme de base :
   Le 2ème paramètre est précédé d'un point.
   Vous n'êtes pas obligé d'utiliser des paramètres
 
-  ### FORMES SPÉCIALES D'ENTRÉE
+  FORMES SPÉCIALES D'ENTRÉE :
 
   Pour l'entrée numérique, les formes d'entrée supplémentaires suivantes sont acceptées en plus du décimal :
 


### PR DESCRIPTION
`printf --help` printed raw Markdown headings (`### ESCAPE SEQUENCES`, `#### SUBSTITUTION QUICK REFERENCE`, ...) leaked from the after-help text, which the terminal shows verbatim.

Convert the Markdown headings to plain-text headings ending in a colon, matching the fix already applied to cut and dd in #13982. Updates both the en-US and fr-FR locale strings.

Fixes #13988