### PR TITLE
cp: honor --reflink=never on macOS

### DIFF
--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -54,7 +54,11 @@ pub(crate) fn copy_on_write(
     let raw_pfn = unsafe { libc::dlsym(libc::RTLD_NEXT, clonefile.as_ptr()) };
 
     let mut error = 0;
-    if !raw_pfn.is_null() {
+    // `--reflink=never` must not clone: clonefile(2) COW-shares the source's blocks and copies
+    // its metadata (including mtime), so skip it here and fall through to a normal byte copy
+    // below, matching GNU/BSD `cp` (and the Linux path's ReflinkMode::Never handling).
+    let attempt_clone = !raw_pfn.is_null() && reflink_mode != ReflinkMode::Never;
+    if attempt_clone {
         // Call clonefile(2).
         // Safety: Casting a C function pointer to a rust function value is one of the few
         // blessed uses of `transmute()`.
@@ -95,7 +99,7 @@ pub(crate) fn copy_on_write(
         }
     }
 
-    if raw_pfn.is_null() || error != 0 {
+    if !attempt_clone || error != 0 {
         // clonefile(2) is either not supported or it errored out (possibly because the FS does not
         // support COW).
         if reflink_mode == ReflinkMode::Always {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2786,6 +2786,32 @@ fn test_cp_reflink_never() {
     }
 }
 
+// Regression test for #14052: on macOS, `cp` used to call clonefile(2) unconditionally, so
+// `--reflink=never` still cloned — and clonefile copies the source's metadata, including mtime.
+// A real (non-clone) copy stamps the destination with its own mtime, so after `--reflink=never`
+// the destination must NOT inherit the source's (old) mtime.
+#[test]
+#[cfg(target_os = "macos")]
+fn test_cp_reflink_never_does_not_clonefile() {
+    use filetime::FileTime;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("src", "reflink never contents");
+    // Stamp the source with a mtime well in the past; a clonefile would copy it verbatim.
+    let past = FileTime::from_unix_time(1_000_000_000, 0); // 2001-09-09
+    filetime::set_file_times(at.plus("src"), past, past).unwrap();
+
+    ucmd.arg("--reflink=never").arg("src").arg("dst").succeeds();
+
+    assert_eq!(at.read("dst"), "reflink never contents");
+    let src_mtime = FileTime::from_last_modification_time(&at.metadata("src"));
+    let dst_mtime = FileTime::from_last_modification_time(&at.metadata("dst"));
+    assert_ne!(
+        dst_mtime, src_mtime,
+        "--reflink=never must copy (not clonefile), so dst must not inherit the source's mtime"
+    );
+}
+
 #[test]
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 fn test_cp_reflink_bad() {


### PR DESCRIPTION
  On macOS, `copy_on_write()` called `clonefile(2)` unconditionally and never consulted
  `reflink_mode`, so `--reflink=never` still cloned. Because `clonefile(2)` COW-shares the
  source's blocks and copies its metadata (including mtime), a plain `cp` on APFS gave the
  destination the *source's* mtime, where GNU and BSD `cp` stamp the copy's own time.
  
  This is the same class as #13064; the fix in #13065 only touched `platform/linux.rs`, leaving
  the macOS path uncovered.
  
  Fix: skip the `clonefile(2)` attempt when `reflink_mode` is `Never` and fall through to the
  existing byte-copy path, mirroring the Linux `ReflinkMode::Never` handling.
  
  Verified on APFS: with `--reflink=never`, a 40 MB copy now consumes ~40 MB and the destination
  gets its own mtime; default `cp` still clones (no regression to the fast path). Added a macOS
  regression test asserting `--reflink=never` does not leave the destination with the source's mtime.
  
  Fixes #14052