### PR TITLE
nl: avoid OOM on 32-bit when -w i32::MAX is used

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -391,8 +391,10 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
     let mut writer = BufWriter::new(stdout());
     let mut current_numbering_style = &settings.body_numbering;
     let mut line = Vec::new();
-    // Written before every unnumbered line; hoisted so it is not reallocated per line.
-    let blank_prefix = vec![b' '; settings.number_width + 1];
+    // Written before every unnumbered line. Capped to avoid OOM on 32-bit targets
+    // when -w i32::MAX is passed (allocating 2 GiB would panic).
+    let blank_width = settings.number_width + 1;
+    let space_buf = vec![b' '; blank_width.min(4096)];
 
     loop {
         line.clear();
@@ -464,9 +466,14 @@ fn nl<T: Read>(reader: &mut BufReader<T>, stats: &mut Stats, settings: &Settings
                     .map_err_context(|| translate!("nl-error-could-not-write"))?;
                 stats.line_number = line_number.checked_add(settings.line_increment);
             } else {
-                writer
-                    .write_all(&blank_prefix)
-                    .map_err_context(|| translate!("nl-error-could-not-write"))?;
+                let mut remaining = blank_width;
+                while remaining > 0 {
+                    let chunk = remaining.min(space_buf.len());
+                    writer
+                        .write_all(&space_buf[..chunk])
+                        .map_err_context(|| translate!("nl-error-could-not-write"))?;
+                    remaining -= chunk;
+                }
             }
             write_line(&mut writer, &line)
                 .map_err_context(|| translate!("nl-error-could-not-write"))?;


### PR DESCRIPTION
On 32-bit targets (i686, wasm32), `settings.number_width` is a `usize` (32-bit), so `vec![b ; settings.number_width + 1]` with `-w 2147483647` (i32::MAX) attempts to allocate ~2 GiB, which panics.

Fix: cap the pre-allocated space buffer at 4096 bytes and write the blank prefix in chunks inside the loop.

Fixes `test_nl::test_number_width_max_i32` on i686-linux, i686-windows, and wasm32.