### PR TITLE
build cygwin cksum with openssl on the CI

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -4,7 +4,7 @@ name: make
 # spell-checker:ignore (jargon) deps softprops toolchain
 # spell-checker:ignore (people) dawidd
 # spell-checker:ignore (shell/tools) bsdtar nextest pacman sccache zstd
-# spell-checker:ignore (misc) bindir busytest defconfig dynamicbase DESTDIR manpages multisize noconfirm runtest testsuite toybox uutils
+# spell-checker:ignore (misc) bindir busytest defconfig dynamicbase DESTDIR libopenssl manpages multisize noconfirm runtest testsuite toybox uutils
 
 env:
   PROJECT_NAME: coreutils
@@ -312,19 +312,22 @@ jobs:
       # which causes subsequent fork() calls to fail with EAGAIN (exit code 254).
       shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail {0}'
       run: |
-        pacman -Sy --noconfirm --needed make rust base-devel
+        pacman -Sy --noconfirm --needed base-devel libopenssl make openssl-devel pkgconf rust
       env:
         CHERE_INVOKING: 1
     - name: "`(x86_64-pc-cygwin) make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n`"
       shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail {0}'
       run: |
         set -x
+        export OPENSSL_NO_VENDOR=1
+        export CARGOFLAGS="--features openssl"
         DESTDIR=/tmp/c make install PROG_PREFIX=uu- PROFILE=release-small COMPLETIONS=n MANPAGES=n LOCALES=n
-        # Check that utils are built with given profile
-        ./target/release-small/true
+        # Check that cksum is linked with openssl (e.g. msys-crypto-*.dll)
+        # Also check that utils are built with given profile
+        ldd target/release-small/cksum | grep crypto
         # Check that the progs have prefix
         test -f /tmp/c/usr/local/bin/uu-tty
-        test -f /tmp/c/usr/local/libexec/uu-coreutils/libstdbuf.*
+        test -f /tmp/c/usr/local/libexec/uu-coreutils/libstdbuf.dll
         # Check that the manpage is not present
         ! test -f /tmp/c/usr/local/share/man/man1/uu-whoami.1
         # Check that the completion is not present


### PR DESCRIPTION
No need to test both of pure Rust & openssl on the CI since there is no needs to publish both on MSYS2.