### PR TITLE
uptime: exclude Android from utmpx paths

### DIFF
--- a/src/uu/uptime/src/platform/unix.rs
+++ b/src/uu/uptime/src/platform/unix.rs
@@ -13,11 +13,11 @@ use clap::{Arg, ArgAction, ArgMatches, Command, ValueHint, builder::ValueParser}
 use std::ffi::OsString;
 use std::io::{Write, stdout};
 use uucore::error::UResult;
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "android")))]
 use uucore::libc::time_t;
 use uucore::translate;
 use uucore::uptime::get_uptime;
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "android")))]
 use uucore::utmpx::{BOOT_TIME, USER_PROCESS, Utmpx};
 
 use crate::{UptimeError, options, print_loadavg, print_nusers, print_time, print_uptime};
@@ -47,12 +47,12 @@ pub(crate) fn maybe_uptime_from_file(matches: &ArgMatches) -> Option<UResult<()>
 /// `BOOT_TIME` record where utmpx is available (on OpenBSD, from
 /// [`get_uptime`] directly).
 pub(crate) fn system_uptime_seconds() -> UResult<i64> {
-    #[cfg(not(target_os = "openbsd"))]
+    #[cfg(not(any(target_os = "openbsd", target_os = "android")))]
     {
         let (boot_time, _) = process_utmpx(None);
         get_uptime(boot_time)
     }
-    #[cfg(target_os = "openbsd")]
+    #[cfg(any(target_os = "openbsd", target_os = "android"))]
     get_uptime(None)
 }
 
@@ -114,7 +114,7 @@ fn uptime_with_file(file_path: &OsString) -> UResult<()> {
     print_time()?;
     let user_count;
 
-    #[cfg(not(target_os = "openbsd"))]
+    #[cfg(not(any(target_os = "openbsd", target_os = "android")))]
     {
         let (boot_time, count) = process_utmpx(Some(file_path));
         if let Some(time) = boot_time {
@@ -128,7 +128,7 @@ fn uptime_with_file(file_path: &OsString) -> UResult<()> {
         user_count = count;
     }
 
-    #[cfg(target_os = "openbsd")]
+    #[cfg(any(target_os = "openbsd", target_os = "android"))]
     {
         let upsecs = get_uptime(None)?;
         if upsecs >= 0 {
@@ -139,8 +139,15 @@ fn uptime_with_file(file_path: &OsString) -> UResult<()> {
 
             write!(stdout(), "{}", translate!("uptime-output-unknown-uptime"))?;
         }
-        user_count =
-            uucore::uptime::get_nusers(file_path.to_str().expect("invalid utmp path file"));
+        #[cfg(target_os = "openbsd")]
+        {
+            user_count =
+                uucore::uptime::get_nusers(file_path.to_str().expect("invalid utmp path file"));
+        }
+        #[cfg(target_os = "android")]
+        {
+            user_count = 0;
+        }
     }
 
     print_nusers(Some(user_count))?;
@@ -149,7 +156,7 @@ fn uptime_with_file(file_path: &OsString) -> UResult<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "android")))]
 fn process_utmpx(file: Option<&OsString>) -> (Option<time_t>, usize) {
     let mut nusers = 0;
     let mut boot_time = None;


### PR DESCRIPTION
Android does not expose `utmpx`, so `uucore::utmpx` is gated behind `not(target_os = "android")`. The Unix platform module for `uptime` was only excluding OpenBSD, causing a build failure on Android (`feat_os_unix_android`):

```
error[E0432]: unresolved import `uucore::utmpx`
  --> src/uu/uptime/src/platform/unix.rs:21:13
note: found an item that was configured out
   --> src/uucore/src/lib/lib.rs:124:26
    |
118 |     not(target_os = "android"),
```

Fix: add `target_os = "android"` to all cfg guards that gate utmpx usage. On Android, `system_uptime_seconds` falls through to `get_uptime(None)` (via `/proc/uptime`) and the file-operand path reports 0 users (no utmp on Android).