### PR TITLE
base32/base64/basenc: accept a -w value starting with - to match GNU

### DIFF
--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -124,6 +124,7 @@ pub fn base_app(about: String, usage: String) -> Command {
                 .short('w')
                 .long(options::WRAP)
                 .value_name("COLS")
+                .allow_hyphen_values(true)
                 .help(translate!("base-common-help-wrap", "default" => WRAP_DEFAULT))
                 .overrides_with(options::WRAP),
         )

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -220,6 +220,18 @@ fn test_wrap_bad_arg() {
 }
 
 #[test]
+fn test_wrap_negative_arg() {
+    // GNU treats the token after -w as the wrap size even if it starts with '-'.
+    for arg in ["-5", "-d"] {
+        new_ucmd!()
+            .arg("-w")
+            .arg(arg)
+            .fails()
+            .stderr_only(format!("base64: invalid wrap size: '{arg}'\n"));
+    }
+}
+
+#[test]
 fn test_base64_extra_operand() {
     // Expect a failure when multiple files are specified.
     new_ucmd!()


### PR DESCRIPTION
`base64 -w -5` (and any `-w` value that starts with `-`, e.g. `-w -d`) was rejected by the argument parser with `unexpected argument '-5' found`, while GNU takes the token after `-w` as the wrap size and reports `invalid wrap size`:

```
$ printf abc | base64 -w -5
error: unexpected argument '-5' found
$ printf abc | gbase64 -w -5
gbase64: invalid wrap size: '-5'
```

Adding `allow_hyphen_values(true)` to the `-w`/`--wrap` argument lets the value reach the existing wrap-size parser, which already emits the GNU-matching message. Verified against GNU for `-w -5`, `-w -d`, `-w -x` (all `invalid wrap size`), with valid values (`-w 5`, `-w0`, `--wrap=5`) and decoding unchanged. The shared `base_common.rs` covers base32, base64 and basenc.
