### PR TITLE
Replace filetime with std::fs timestamp APIs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,3 +10,6 @@ linker = "aarch64-linux-gnu-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.'cfg(target_env = "msvc")']
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[env]
+RUSTC_BOOTSTRAP = "1"

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.88.0"
+  RUST_MIN_SRV: "1.94.1"
   CARGO_INCREMENTAL: "0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,6 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "ctor",
- "filetime",
  "fluent-syntax",
  "glob",
  "hex-literal",
@@ -1013,16 +1012,6 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -3428,7 +3417,6 @@ version = "0.10.0"
 dependencies = [
  "clap",
  "codspeed-divan-compat",
- "filetime",
  "fluent",
  "indicatif",
  "libc",
@@ -4354,7 +4342,6 @@ name = "uu_touch"
 version = "0.10.0"
 dependencies = [
  "clap",
- "filetime",
  "fluent",
  "jiff",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -402,7 +402,7 @@ members = [
 [workspace.package]
 categories = ["command-line-utilities"]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.94.1"
 homepage = "https://github.com/uutils/coreutils"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 license = "MIT"
@@ -433,7 +433,6 @@ data-encoding-macro = "0.1.15"
 divan = { package = "codspeed-divan-compat", version = "5.0.0" }
 dns-lookup = { version = "4.0.0" }
 dunce = "1.0.4"
-filetime = "0.2.29"
 foldhash = "0.2.0"
 fs_extra = "1.3.0"
 fts-sys = "0.2.16"
@@ -577,6 +576,7 @@ should_panic_without_expect = "allow"        # 2
 doc_markdown = "allow"
 unused_self = "allow"
 enum_glob_use = "allow"
+duration_suboptimal_units = "allow"
 unnested_or_patterns = "allow"
 implicit_hasher = "allow"
 doc_link_with_quotes = "allow"
@@ -716,7 +716,6 @@ yes = { optional = true, version = "0.10.0", package = "uu_yes", path = "src/uu/
 
 [dev-dependencies]
 ctor.workspace = true
-filetime.workspace = true
 glob.workspace = true
 jiff.workspace = true
 libc.workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         default = pkgsFor.${system}.pkgs.mkShell {
           packages = build_deps ++ gnu_testing_deps;
 
-          RUSTC_VERSION = "1.88";
+          RUSTC_VERSION = "1.94";
           LIBCLANG_PATH = pkgsFor.${system}.lib.makeLibraryPath [pkgsFor.${system}.llvmPackages_latest.libclang.lib];
           shellHook = ''
             export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-filetime = { workspace = true }
 libc = { workspace = true }
 uucore = { workspace = true, features = [
   "backup-control",

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -5,6 +5,8 @@
 // spell-checker:ignore (ToDO) copydir fiemap ftruncate linkgs lstat nlink nlinks pathbuf pwrite reflink strs xattrs symlinked deduplicated advcpmv nushell IRWXG IRWXO IRWXU IRWXUGO IRWXU IRWXG IRWXO IRWXUGO sflag
 // spell-checker:ignore RDONLY futimens utimensat
 
+#![feature(fs_set_times)]
+
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
@@ -21,7 +23,6 @@ use uucore::fsxattr::{copy_acls, copy_xattrs_fd, copy_xattrs_skip_selinux};
 use uucore::translate;
 
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser, value_parser};
-use filetime::FileTime;
 use indicatif::{ProgressBar, ProgressStyle};
 #[cfg(unix)]
 use nix::sys::stat::{Mode, SFlag, dev_t, mknod as nix_mknod, mode_t};
@@ -1900,28 +1901,14 @@ pub(crate) fn copy_attributes(
     })?;
 
     handle_preserve(attributes.timestamps, || -> CopyResult<()> {
-        let atime = FileTime::from_last_access_time(&source_metadata);
-        let mtime = FileTime::from_last_modification_time(&source_metadata);
-        // `set_file_times` opens the destination (O_RDONLY) before calling
-        // futimens; opening a FIFO or device with no peer blocks forever, and a
-        // socket cannot be opened at all. For symlinks and these special files
-        // use the path-based, no-follow variant, which sets the times via
-        // utimensat without opening.
-        #[cfg(unix)]
-        let no_open = {
-            let ft = source_metadata.file_type();
-            dest.is_symlink()
-                || ft.is_fifo()
-                || ft.is_socket()
-                || ft.is_char_device()
-                || ft.is_block_device()
-        };
-        #[cfg(not(unix))]
-        let no_open = dest.is_symlink();
-        if no_open {
-            filetime::set_symlink_file_times(dest, atime, mtime)?;
+        let times = fs::FileTimes::new()
+            .set_accessed(source_metadata.accessed()?)
+            .set_modified(source_metadata.modified()?);
+
+        if dest.is_symlink() {
+            fs::set_times_nofollow(dest, times)?;
         } else {
-            filetime::set_file_times(dest, atime, mtime)?;
+            fs::set_times(dest, times)?;
         }
 
         Ok(())

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/touch.rs"
 doctest = false
 
 [dependencies]
-filetime = { workspace = true }
 clap = { workspace = true }
 jiff = { workspace = true }
 parse_datetime = { workspace = true }

--- a/src/uu/touch/src/error.rs
+++ b/src/uu/touch/src/error.rs
@@ -4,8 +4,8 @@
 // file that was distributed with this source code.
 
 // spell-checker:ignore (misc) uioerror
-use filetime::FileTime;
 use std::path::PathBuf;
+use std::time::SystemTime;
 use thiserror::Error;
 use uucore::display::Quotable;
 use uucore::error::{UError, UIoError};
@@ -17,8 +17,8 @@ pub enum TouchError {
     InvalidDateFormat(String),
 
     /// The source time couldn't be converted to a [`jiff::Zoned`]
-    #[error("{}", translate!("touch-error-invalid-filetime", "time" => .0))]
-    InvalidFiletime(FileTime),
+    #[error("{}", translate!("touch-error-invalid-filetime", "time" => format_time(*.0)))]
+    InvalidFiletime(SystemTime),
 
     /// The reference file's attributes could not be found or read
     #[error("{}", translate!("touch-error-reference-file-inaccessible", "path" => .0.quote(), "error" => to_uioerror(.1)))]
@@ -48,6 +48,22 @@ fn to_uioerror(err: &std::io::Error) -> UIoError {
         std::io::Error::from(err.kind())
     };
     UIoError::from(copy)
+}
+
+fn format_time(time: SystemTime) -> String {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => format!("{}.{:09}s", d.as_secs(), d.subsec_nanos()),
+        Err(e) => {
+            let d = e.duration();
+            let subsec = d.subsec_nanos();
+            let (sec_offset, nanos) = if subsec == 0 {
+                (0, 0)
+            } else {
+                (1, 1_000_000_000 - subsec)
+            };
+            format!("{}.{nanos:09}s", -(d.as_secs() as i64 + sec_offset))
+        }
+    }
 }
 
 impl UError for TouchError {}

--- a/src/uu/touch/src/platform/mod.rs
+++ b/src/uu/touch/src/platform/mod.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 #[cfg(target_os = "wasi")]
-pub use self::wasi::{pathbuf_from_stdout, set_file_times, set_symlink_file_times};
+pub use self::wasi::pathbuf_from_stdout;
 
 #[cfg(windows)]
 pub use self::windows::pathbuf_from_stdout;

--- a/src/uu/touch/src/platform/wasi.rs
+++ b/src/uu/touch/src/platform/wasi.rs
@@ -3,47 +3,16 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (ToDO) filetime utimensat
+// spell-checker:ignore (ToDO) utimensat
 
-use filetime::FileTime;
-use rustix::fs::{AtFlags, CWD, Timespec, Timestamps, utimensat};
-use std::io::{Error, Result};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use uucore::translate;
 
 use crate::error::TouchError;
 
-/// WASI replacement for `filetime::set_file_times`.
-///
-/// The `filetime` crate has an unimplemented stub on `wasm32-wasi`. WASI
-/// supports setting both atime and mtime via `utimensat`, which we reach
-/// through `rustix`.
-pub fn set_file_times(path: &Path, atime: FileTime, mtime: FileTime) -> Result<()> {
-    set_times(path, atime, mtime, AtFlags::empty())
-}
-
-/// WASI replacement for `filetime::set_symlink_file_times`.
-pub fn set_symlink_file_times(path: &Path, atime: FileTime, mtime: FileTime) -> Result<()> {
-    set_times(path, atime, mtime, AtFlags::SYMLINK_NOFOLLOW)
-}
-
-fn set_times(path: &Path, atime: FileTime, mtime: FileTime, flags: AtFlags) -> Result<()> {
-    let timestamps = Timestamps {
-        last_access: Timespec {
-            tv_sec: atime.unix_seconds(),
-            tv_nsec: atime.nanoseconds() as _,
-        },
-        last_modification: Timespec {
-            tv_sec: mtime.unix_seconds(),
-            tv_nsec: mtime.nanoseconds() as _,
-        },
-    };
-    utimensat(CWD, path, &timestamps, flags).map_err(Error::from)
-}
-
 /// WASI has no way to name the file behind stdout.
-pub fn pathbuf_from_stdout() -> std::result::Result<PathBuf, TouchError> {
+pub fn pathbuf_from_stdout() -> Result<PathBuf, TouchError> {
     Err(TouchError::UnsupportedPlatformFeature(translate!(
         "touch-error-stdout-unsupported"
     )))

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -6,16 +6,13 @@
 // spell-checker:ignore (ToDO) datelike datetime filetime mktime strtime timelike utime DATETIME UTIME futimens
 // spell-checker:ignore (FORMATS) MMDDhhmm YYYYMMDDHHMM YYMMDDHHMM YYYYMMDDHHMMS CREAT ENXIO RDONLY utimensat
 
+#![feature(fs_set_times)]
+
 pub mod error;
 mod platform;
 
 use clap::builder::{PossibleValue, ValueParser};
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
-use filetime::FileTime;
-#[cfg(all(any(not(unix), target_os = "redox"), not(target_os = "wasi")))]
-use filetime::set_file_times;
-#[cfg(not(target_os = "wasi"))]
-use filetime::set_symlink_file_times;
 use jiff::civil::Time;
 use jiff::fmt::strtime;
 use jiff::tz::TimeZone;
@@ -28,13 +25,12 @@ use rustix::fs::Timestamps;
 use rustix::fs::futimens;
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
-use std::fs;
-use std::fs::OpenOptions;
+use std::fs::{self, FileTimes, OpenOptions};
 use std::io::{Error, ErrorKind};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 #[cfg(target_os = "linux")]
@@ -46,8 +42,6 @@ use uucore::{format_usage, show};
 use crate::error::TouchError;
 #[cfg(not(unix))]
 use crate::platform::pathbuf_from_stdout;
-#[cfg(target_os = "wasi")]
-use crate::platform::{set_file_times, set_symlink_file_times};
 
 /// Options contains all the possible behaviors and flags for touch.
 ///
@@ -100,7 +94,7 @@ pub enum ChangeTimes {
 pub enum Source {
     /// Use access/modification times of given file
     Reference(PathBuf),
-    Timestamp(FileTime),
+    Timestamp(SystemTime),
     /// Use current time
     Now,
 }
@@ -140,12 +134,8 @@ mod format {
     pub(crate) const YYYYMMDDHHMM_OFFSET: &str = "%Y-%m-%d %H:%M %z";
 }
 
-fn timestamp_to_filetime(ts: Timestamp) -> FileTime {
-    FileTime::from_system_time(SystemTime::from(ts))
-}
-
-fn filetime_to_zoned(ft: &FileTime) -> Option<Zoned> {
-    let ts = Timestamp::new(ft.unix_seconds(), ft.nanoseconds() as i32).ok()?;
+fn system_time_to_zoned(st: SystemTime) -> Option<Zoned> {
+    let ts = Timestamp::try_from(st).ok()?;
     Some(Zoned::new(ts, TimeZone::system()))
 }
 
@@ -391,19 +381,7 @@ pub fn touch(files: &[InputFile], opts: &Options) -> Result<(), TouchError> {
             (atime, mtime)
         }
         Source::Now => {
-            let now: FileTime;
-            #[cfg(target_os = "linux")]
-            {
-                if opts.date.is_none() {
-                    now = FileTime::from_unix_time(0, libc::UTIME_NOW as u32);
-                } else {
-                    now = timestamp_to_filetime(Timestamp::now());
-                }
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                now = timestamp_to_filetime(Timestamp::now());
-            }
+            let now = SystemTime::now();
             (now, now)
         }
         &Source::Timestamp(ts) => (ts, ts),
@@ -412,11 +390,11 @@ pub fn touch(files: &[InputFile], opts: &Options) -> Result<(), TouchError> {
     let (atime, mtime) = if let Some(date) = &opts.date {
         (
             parse_date(
-                filetime_to_zoned(&atime).ok_or_else(|| TouchError::InvalidFiletime(atime))?,
+                system_time_to_zoned(atime).ok_or_else(|| TouchError::InvalidFiletime(atime))?,
                 date,
             )?,
             parse_date(
-                filetime_to_zoned(&mtime).ok_or_else(|| TouchError::InvalidFiletime(mtime))?,
+                system_time_to_zoned(mtime).ok_or_else(|| TouchError::InvalidFiletime(mtime))?,
                 date,
             )?,
         )
@@ -467,8 +445,8 @@ fn touch_file(
     path: &Path,
     is_stdout: bool,
     opts: &Options,
-    atime: FileTime,
-    mtime: FileTime,
+    atime: SystemTime,
+    mtime: SystemTime,
 ) -> UResult<()> {
     let filename = if is_stdout {
         OsStr::new("-")
@@ -575,8 +553,8 @@ fn update_times(
     path: &Path,
     is_stdout: bool,
     opts: &Options,
-    atime: FileTime,
-    mtime: FileTime,
+    atime: SystemTime,
+    mtime: SystemTime,
 ) -> UResult<()> {
     // If changing "only" atime or mtime, grab the existing value of the other.
     let (atime, mtime) = match opts.change_times {
@@ -599,24 +577,41 @@ fn update_times(
         ChangeTimes::Both => (atime, mtime),
     };
 
-    // sets the file access and modification times for a file or a symbolic link.
-    // The filename, access time (atime), and modification time (mtime) are provided as inputs.
+    let times = FileTimes::new().set_accessed(atime).set_modified(mtime);
 
     if opts.no_deref && !is_stdout {
-        return set_symlink_file_times(path, atime, mtime).map_err_context(
+        return fs::set_times_nofollow(path, times).map_err_context(
             || translate!("touch-error-setting-times-of-path", "path" => path.quote()),
         );
     }
 
     #[cfg(unix)]
     {
+        #[cfg(target_os = "linux")]
+        let is_now = opts.source == Source::Now && opts.date.is_none();
+        #[cfg(not(target_os = "linux"))]
+        let is_now = false;
+
+        let to_spec = |st, is_changed| {
+            if is_now && is_changed {
+                rustix::fs::Timespec {
+                    tv_sec: 0,
+                    tv_nsec: rustix::fs::UTIME_NOW,
+                }
+            } else {
+                system_time_to_timespec(st)
+            }
+        };
+
+        let timestamps = build_timestamps(
+            to_spec(atime, opts.change_times != ChangeTimes::MtimeOnly),
+            to_spec(mtime, opts.change_times != ChangeTimes::AtimeOnly),
+        );
+
         if is_stdout {
             // `touch -` operates on whatever file is open as stdout (fd 1),
             // even when it was opened read-only. Use futimens on the fd
-            // directly: it preserves the UTIME_NOW sentinel, while
-            // filetime::set_file_times would normalize it into a literal
-            // 1970 timestamp.
-            let timestamps = build_timestamps(atime, mtime);
+            // directly: it preserves the UTIME_NOW sentinel.
             return futimens(std::io::stdout(), &timestamps)
                 .map_err(|e| Error::from_raw_os_error(e.raw_os_error()))
                 .map_err_context(
@@ -625,67 +620,50 @@ fn update_times(
         }
 
         // Open write-only and use futimens to trigger IN_CLOSE_WRITE on Linux.
-        if try_futimens_via_write_fd(path, atime, mtime).is_ok() {
+        if try_futimens_via_write_fd(path, &timestamps).is_ok() {
             return Ok(());
         }
         // The write-FD approach fails on special files such as FIFOs (the
-        // write-only open returns ENXIO when there is no reader). Set the times
-        // by path with utimensat, which never opens the file and so never
-        // blocks — unlike filetime::set_file_times, which opens O_RDONLY and
-        // would hang on a reader-less FIFO.
-        set_times_by_path(path, atime, mtime)
+        // write-only open returns ENXIO when there is no reader). Fall back to
+        // the path-based `fs::set_times` (utimensat), which never opens the
+        // file and so never blocks.
     }
 
-    #[cfg(not(unix))]
-    {
-        set_file_times(path, atime, mtime).map_err_context(
-            || translate!("touch-error-setting-times-of-path", "path" => path.quote()),
-        )
+    fs::set_times(path, times)
+        .map_err_context(|| translate!("touch-error-setting-times-of-path", "path" => path.quote()))
+}
+
+#[cfg(unix)]
+fn system_time_to_timespec(st: SystemTime) -> rustix::fs::Timespec {
+    match st.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => rustix::fs::Timespec {
+            tv_sec: d.as_secs() as _,
+            tv_nsec: d.subsec_nanos().into(),
+        },
+        Err(e) => {
+            let d = e.duration();
+            let subsec = d.subsec_nanos();
+            let (sec_offset, nanos) = if subsec == 0 {
+                (0, 0)
+            } else {
+                (1, 1_000_000_000 - subsec)
+            };
+            rustix::fs::Timespec {
+                tv_sec: -((d.as_secs() + sec_offset as u64) as i128) as _,
+                tv_nsec: nanos.into(),
+            }
+        }
     }
 }
 
 #[cfg(unix)]
-/// Build a rustix `Timestamps` from the access and modification `FileTime`s,
+/// Build a rustix `Timestamps` from the access and modification `Timespec`s,
 /// preserving the `UTIME_NOW`/`UTIME_OMIT` sentinels in the nanoseconds field.
-fn build_timestamps(atime: FileTime, mtime: FileTime) -> Timestamps {
+fn build_timestamps(atime: rustix::fs::Timespec, mtime: rustix::fs::Timespec) -> Timestamps {
     Timestamps {
-        last_access: rustix::fs::Timespec {
-            tv_sec: atime.unix_seconds(),
-            tv_nsec: atime.nanoseconds() as _,
-        },
-        last_modification: rustix::fs::Timespec {
-            tv_sec: mtime.unix_seconds(),
-            tv_nsec: mtime.nanoseconds() as _,
-        },
+        last_access: atime,
+        last_modification: mtime,
     }
-}
-
-#[cfg(all(unix, not(target_os = "redox")))]
-/// Set file times by path using `utimensat`, following symlinks.
-///
-/// This never opens the file, so it does not block on special files such as
-/// FIFOs.
-fn set_times_by_path(path: &Path, atime: FileTime, mtime: FileTime) -> UResult<()> {
-    let timestamps = build_timestamps(atime, mtime);
-    rustix::fs::utimensat(
-        rustix::fs::CWD,
-        path,
-        &timestamps,
-        rustix::fs::AtFlags::empty(),
-    )
-    .map_err(|e| Error::from_raw_os_error(e.raw_os_error()))
-    .map_err_context(|| translate!("touch-error-setting-times-of-path", "path" => path.quote()))
-}
-
-#[cfg(target_os = "redox")]
-/// Set file times by path on Redox, which lacks `rustix::fs::utimensat`.
-///
-/// Falls back to `filetime::set_file_times`; unlike on other unixes this may
-/// block on a reader-less FIFO, but Redox has no FIFO support so the FIFO
-/// edge case the `utimensat` path guards against does not arise here.
-fn set_times_by_path(path: &Path, atime: FileTime, mtime: FileTime) -> UResult<()> {
-    set_file_times(path, atime, mtime)
-        .map_err_context(|| translate!("touch-error-setting-times-of-path", "path" => path.quote()))
 }
 
 #[cfg(unix)]
@@ -694,31 +672,20 @@ fn set_times_by_path(path: &Path, atime: FileTime, mtime: FileTime) -> UResult<(
 /// This opens the file write-only and uses the POSIX `futimens` call to set
 /// access and modification times on the open FD (not by path), which also
 /// triggers `IN_CLOSE_WRITE` on Linux when the FD is closed.
-fn try_futimens_via_write_fd(path: &Path, atime: FileTime, mtime: FileTime) -> std::io::Result<()> {
+fn try_futimens_via_write_fd(path: &Path, timestamps: &Timestamps) -> std::io::Result<()> {
     let file = OpenOptions::new()
         .write(true)
         // Avoid blocking on special files (e.g. FIFOs) before we can inspect metadata.
         .custom_flags(O_NONBLOCK)
         .open(path)?;
 
-    let timestamps = Timestamps {
-        last_access: rustix::fs::Timespec {
-            tv_sec: atime.unix_seconds(),
-            tv_nsec: atime.nanoseconds() as _,
-        },
-        last_modification: rustix::fs::Timespec {
-            tv_sec: mtime.unix_seconds(),
-            tv_nsec: mtime.nanoseconds() as _,
-        },
-    };
-
-    futimens(&file, &timestamps).map_err(|e| Error::from_raw_os_error(e.raw_os_error()))
+    futimens(&file, timestamps).map_err(|e| Error::from_raw_os_error(e.raw_os_error()))
 }
 
 /// Get metadata of the provided path
 /// If `follow` is `true`, the function will try to follow symlinks. Errors if the symlink is dangling, otherwise defaults to symlink metadata.
 /// If `follow` is `false`, the function will return metadata of the symlink itself
-fn stat(path: &Path, follow: bool) -> std::io::Result<(FileTime, FileTime)> {
+fn stat(path: &Path, follow: bool) -> std::io::Result<(SystemTime, SystemTime)> {
     let metadata = if follow {
         match fs::metadata(path) {
             // Successfully followed symlink
@@ -732,26 +699,10 @@ fn stat(path: &Path, follow: bool) -> std::io::Result<(FileTime, FileTime)> {
         fs::symlink_metadata(path)?
     };
 
-    // `FileTime::from_last_{access,modification}_time` is unimplemented on
-    // `wasm32-wasi`, so go through `Metadata::{accessed, modified}` (which
-    // return `SystemTime`) and convert via `FileTime::from_system_time`.
-    #[cfg(target_os = "wasi")]
-    {
-        let atime = metadata.accessed()?;
-        let mtime = metadata.modified()?;
-        Ok((
-            FileTime::from_system_time(atime),
-            FileTime::from_system_time(mtime),
-        ))
-    }
-    #[cfg(not(target_os = "wasi"))]
-    Ok((
-        FileTime::from_last_access_time(&metadata),
-        FileTime::from_last_modification_time(&metadata),
-    ))
+    Ok((metadata.accessed()?, metadata.modified()?))
 }
 
-fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
+fn parse_date(ref_zoned: Zoned, s: &str) -> Result<SystemTime, TouchError> {
     // This isn't actually compatible with GNU touch, but there doesn't seem to
     // be any simple specification for what format this parameter allows and I'm
     // not about to implement GNU parse_datetime.
@@ -770,7 +721,7 @@ fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
         .and_then(|tm| tm.to_datetime())
         .and_then(|dt| TimeZone::UTC.to_zoned(dt))
     {
-        return Ok(timestamp_to_filetime(parsed.timestamp()));
+        return Ok(SystemTime::from(parsed.timestamp()));
     }
 
     // Also support other formats found in the GNU tests like
@@ -785,35 +736,40 @@ fn parse_date(ref_zoned: Zoned, s: &str) -> Result<FileTime, TouchError> {
             .and_then(|tm| tm.to_datetime())
             .and_then(|dt| TimeZone::UTC.to_zoned(dt))
         {
-            return Ok(timestamp_to_filetime(parsed.timestamp()));
+            return Ok(SystemTime::from(parsed.timestamp()));
         }
     }
 
     // "Equivalent to %Y-%m-%d (the ISO 8601 date format). (C99)"
     // ("%F", ISO_8601_FORMAT),
-    if let Ok(filetime) = strtime::parse(format::ISO_8601, s)
+    if let Ok(parsed_time) = strtime::parse(format::ISO_8601, s)
         .and_then(|tm| tm.to_date())
         .and_then(|date| {
             TimeZone::system()
                 .to_ambiguous_zoned(date.to_datetime(Time::midnight()))
                 .unambiguous()
         })
-        .map(|zdt| timestamp_to_filetime(zdt.timestamp()))
+        .map(|zdt| SystemTime::from(zdt.timestamp()))
     {
-        return Ok(filetime);
+        return Ok(parsed_time);
     }
 
     // "@%s" is "The number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC). (TZ) (Calculated from mktime(tm).)"
     if s.bytes().next() == Some(b'@')
-        && let Ok(ts) = &s[1..].parse::<i64>()
+        && let Ok(ts) = s[1..].parse::<i64>()
     {
-        return Ok(FileTime::from_unix_time(*ts, 0));
+        let ts = if ts >= 0 {
+            SystemTime::UNIX_EPOCH + Duration::from_secs(ts as u64)
+        } else {
+            SystemTime::UNIX_EPOCH - Duration::from_secs(ts.unsigned_abs())
+        };
+        return Ok(ts);
     }
 
     if let Ok(parsed) = parse_datetime::parse_datetime_at_date(ref_zoned, s)
         && let Some(zoned) = parsed.into_zoned()
     {
-        return Ok(timestamp_to_filetime(zoned.timestamp()));
+        return Ok(SystemTime::from(zoned.timestamp()));
     }
 
     Err(TouchError::InvalidDateFormat(s.to_owned()))
@@ -841,15 +797,15 @@ fn prepend_century(s: &str) -> UResult<String> {
     ))
 }
 
-/// Parses a timestamp string into a [`FileTime`].
+/// Parses a timestamp string into a [`SystemTime`].
 ///
-/// This function attempts to parse a string into a [`FileTime`]
+/// This function attempts to parse a string into a [`SystemTime`]
 /// As expected by gnu touch -t : `[[cc]yy]mmddhhmm[.ss]`
 ///
 /// Note that  If the year is specified with only two digits,
 /// then cc is 20 for years in the range 0 … 68, and 19 for years in 69 … 99.
 /// in order to be compatible with GNU `touch`.
-fn parse_timestamp(s: &str) -> UResult<FileTime> {
+fn parse_timestamp(s: &str) -> UResult<SystemTime> {
     use format::{YYYYMMDDHHMM, YYYYMMDDHHMM_DOT_SS};
 
     let current_year = || Timestamp::now().to_zoned(TimeZone::system()).year();
@@ -905,7 +861,7 @@ fn parse_timestamp(s: &str) -> UResult<FileTime> {
             )
         })?;
 
-    Ok(timestamp_to_filetime(local.timestamp()))
+    Ok(SystemTime::from(local.timestamp()))
 }
 
 /// Returns a [`PathBuf`] to stdout.
@@ -924,7 +880,7 @@ fn pathbuf_from_stdout() -> Result<PathBuf, TouchError> {
 
 #[cfg(test)]
 mod tests {
-    use filetime::FileTime;
+    use std::time::{Duration, SystemTime};
 
     use crate::{
         ChangeTimes, Options, Source, determine_atime_mtime_change, error::TouchError, touch,
@@ -987,7 +943,7 @@ mod tests {
 
     #[test]
     fn test_invalid_filetime() {
-        let invalid_filetime = FileTime::from_unix_time(0, 1_111_111_111);
+        let invalid_filetime = SystemTime::UNIX_EPOCH + Duration::from_secs(300_000_000_001);
         match touch(
             &[],
             &Options {
@@ -1021,14 +977,18 @@ mod tests {
         let path = dir.path().join("futimens-file");
         std::fs::write(&path, b"data").unwrap();
 
-        let atime = FileTime::from_unix_time(1_600_000_000, 123_456_789);
-        let mtime = FileTime::from_unix_time(1_600_000_100, 987_654_321);
+        let atime = SystemTime::UNIX_EPOCH + Duration::new(1_600_000_000, 123_456_789);
+        let mtime = SystemTime::UNIX_EPOCH + Duration::new(1_600_000_100, 987_654_321);
 
-        super::try_futimens_via_write_fd(&path, atime, mtime).unwrap();
+        let timestamps = super::build_timestamps(
+            super::system_time_to_timespec(atime),
+            super::system_time_to_timespec(mtime),
+        );
+        super::try_futimens_via_write_fd(&path, &timestamps).unwrap();
 
         let metadata = std::fs::metadata(&path).unwrap();
-        let actual_atime = FileTime::from_last_access_time(&metadata);
-        let actual_mtime = FileTime::from_last_modification_time(&metadata);
+        let actual_atime = metadata.accessed().unwrap();
+        let actual_mtime = metadata.modified().unwrap();
 
         assert_eq!(actual_atime, atime);
         assert_eq!(actual_mtime, mtime);

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2467,11 +2467,8 @@ fn test_cp_archive() {
     let (at, mut ucmd) = at_and_ucmd!();
     let previous = std::time::SystemTime::now() - Duration::from_secs(3600);
     // set the file creation/modification an hour ago
-    let file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(at.plus(TEST_HELLO_WORLD_SOURCE))
-        .unwrap();
-    file.set_times(
+    std_fs::set_times(
+        at.plus(TEST_HELLO_WORLD_SOURCE),
         std_fs::FileTimes::new()
             .set_accessed(previous)
             .set_modified(previous),
@@ -2567,11 +2564,8 @@ fn test_cp_preserve_timestamps() {
     let (at, mut ucmd) = at_and_ucmd!();
     let previous = std::time::SystemTime::now() - Duration::from_secs(3600);
     // set the file creation/modification an hour ago
-    let file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(at.plus(TEST_HELLO_WORLD_SOURCE))
-        .unwrap();
-    file.set_times(
+    std_fs::set_times(
+        at.plus(TEST_HELLO_WORLD_SOURCE),
         std_fs::FileTimes::new()
             .set_accessed(previous)
             .set_modified(previous),
@@ -2603,11 +2597,8 @@ fn test_cp_no_preserve_timestamps() {
     let (at, mut ucmd) = at_and_ucmd!();
     let previous = std::time::SystemTime::now() - Duration::from_secs(3600);
     // set the file creation/modification an hour ago
-    let file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(at.plus(TEST_HELLO_WORLD_SOURCE))
-        .unwrap();
-    file.set_times(
+    std_fs::set_times(
+        at.plus(TEST_HELLO_WORLD_SOURCE),
         std_fs::FileTimes::new()
             .set_accessed(previous)
             .set_modified(previous),
@@ -2797,18 +2788,23 @@ fn test_cp_reflink_never() {
 #[test]
 #[cfg(target_vendor = "apple")]
 fn test_cp_reflink_never_does_not_clonefile() {
-    use filetime::FileTime; // todo: replace with std
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("src", "reflink never contents");
     // Stamp the source with a mtime well in the past; a clonefile would copy it verbatim.
-    let past = FileTime::from_unix_time(1_000_000_000, 0); // 2001-09-09
-    filetime::set_file_times(at.plus("src"), past, past).unwrap();
+    let past = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000); // 2001-09-09
+    std::fs::set_times(
+        at.plus("src"),
+        std::fs::FileTimes::new()
+            .set_accessed(past)
+            .set_modified(past),
+    )
+    .unwrap();
 
     ucmd.arg("--reflink=never").arg("src").arg("dst").succeeds();
 
     assert_eq!(at.read("dst"), "reflink never contents");
-    let src_mtime = FileTime::from_last_modification_time(&at.metadata("src"));
-    let dst_mtime = FileTime::from_last_modification_time(&at.metadata("dst"));
+    let src_mtime = at.metadata("src").modified().unwrap();
+    let dst_mtime = at.metadata("dst").modified().unwrap();
     assert_ne!(
         dst_mtime, src_mtime,
         "--reflink=never must copy (not clonefile), so dst must not inherit the source's mtime"
@@ -7825,28 +7821,14 @@ fn test_cp_current_directory_preserve_attributes() {
 
     // Set specific timestamps on the source files (1 hour ago)
     let previous = std::time::SystemTime::now() - Duration::from_secs(3600);
-    let file1 = std::fs::OpenOptions::new()
-        .write(true)
-        .open(at.plus("source_dir/file1.txt"))
-        .unwrap();
-    file1
-        .set_times(
-            std::fs::FileTimes::new()
-                .set_accessed(previous)
-                .set_modified(previous),
-        )
-        .unwrap();
-    let file2 = std::fs::OpenOptions::new()
-        .write(true)
-        .open(at.plus("source_dir/file2.txt"))
-        .unwrap();
-    file2
-        .set_times(
-            std::fs::FileTimes::new()
-                .set_accessed(previous)
-                .set_modified(previous),
-        )
-        .unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(previous)
+        .set_modified(previous);
+    std::fs::set_times(at.plus("source_dir/file1.txt"), times).unwrap();
+    let times = std::fs::FileTimes::new()
+        .set_accessed(previous)
+        .set_modified(previous);
+    std::fs::set_times(at.plus("source_dir/file2.txt"), times).unwrap();
 
     // Create existing destination directory
     at.mkdir("dest_dir");

--- a/tests/by-util/test_install.rs
+++ b/tests/by-util/test_install.rs
@@ -511,12 +511,11 @@ fn test_install_compare_preserve_timestamps() {
     at.write(source, "data");
     at.write(dest, "data");
     let old = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
-    fs::OpenOptions::new()
+    let f = fs::OpenOptions::new()
         .write(true)
         .open(at.plus(source))
-        .unwrap()
-        .set_modified(old)
         .unwrap();
+    f.set_modified(old).unwrap();
 
     // With --preserve-timestamps, the timestamp difference forces the copy so
     // the destination ends up with the source's modification time.

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -4,43 +4,48 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (formats) cymdhm cymdhms datetime filestat mdhm mdhms mktime preopen strtime tzdb ymdhm ymdhms
 
-use filetime::FileTime;
-#[cfg(not(target_os = "freebsd"))]
-use filetime::set_symlink_file_times;
 use jiff::{fmt::strtime, tz::TimeZone};
-use std::fs::remove_file;
+use std::fs::{FileTimes, remove_file};
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 use uutests::util::{AtPath, TestScenario};
 use uutests::util_name;
 
-fn get_file_times(at: &AtPath, path: &str) -> (FileTime, FileTime) {
+fn get_file_times(at: &AtPath, path: &str) -> (SystemTime, SystemTime) {
     let m = at.metadata(path);
-    (
-        FileTime::from_last_access_time(&m),
-        FileTime::from_last_modification_time(&m),
-    )
+    (m.accessed().unwrap(), m.modified().unwrap())
 }
 
 #[cfg(not(target_os = "freebsd"))]
-fn get_symlink_times(at: &AtPath, path: &str) -> (FileTime, FileTime) {
+fn get_symlink_times(at: &AtPath, path: &str) -> (SystemTime, SystemTime) {
     let m = at.symlink_metadata(path);
-    (
-        FileTime::from_last_access_time(&m),
-        FileTime::from_last_modification_time(&m),
+    (m.accessed().unwrap(), m.modified().unwrap())
+}
+
+fn set_file_times(at: &AtPath, path: &str, atime: SystemTime, mtime: SystemTime) {
+    std::fs::set_times(
+        at.plus(path),
+        FileTimes::new().set_accessed(atime).set_modified(mtime),
     )
+    .unwrap();
 }
 
-fn set_file_times(at: &AtPath, path: &str, atime: FileTime, mtime: FileTime) {
-    filetime::set_file_times(at.plus_as_string(path), atime, mtime).unwrap();
+#[cfg(not(target_os = "freebsd"))]
+fn set_symlink_times(path: PathBuf, atime: SystemTime, mtime: SystemTime) {
+    std::fs::set_times_nofollow(
+        path,
+        FileTimes::new().set_accessed(atime).set_modified(mtime),
+    )
+    .unwrap();
 }
 
-fn str_to_filetime(format: &str, s: &str) -> FileTime {
+fn str_to_system_time(format: &str, s: &str) -> SystemTime {
     let tm = strtime::parse(format, s).unwrap();
     let dt = tm.to_datetime().unwrap();
     let ts = dt.to_zoned(TimeZone::UTC).unwrap().timestamp();
-    FileTime::from_unix_time(ts.as_second(), ts.subsec_nanosecond() as u32)
+    SystemTime::from(ts)
 }
 
 #[test]
@@ -90,14 +95,20 @@ fn test_touch_set_mdhm_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime(
+    let start_of_year = str_to_system_time(
         "%Y%m%d%H%M",
         &format!("{}01010000", time::OffsetDateTime::now_utc().year()),
     );
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45240);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
 }
 
 #[test]
@@ -111,14 +122,20 @@ fn test_touch_set_mdhms_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime(
+    let start_of_year = str_to_system_time(
         "%Y%m%d%H%M.%S",
         &format!("{}01010000.00", time::OffsetDateTime::now_utc().year()),
     );
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45296);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45296);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
 }
 
 #[test]
@@ -137,7 +154,7 @@ fn test_touch_2_digit_years_68() {
     assert!(at.file_exists(file));
 
     //  January 1, 2068, 00:00:00
-    let expected = FileTime::from_unix_time(3_092_601_600, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(3_092_601_600);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -158,7 +175,7 @@ fn test_touch_2_digit_years_2038() {
     assert!(at.file_exists(file));
 
     // January 1, 2038, 00:00:00
-    let expected = FileTime::from_unix_time(2_145_916_800, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(2_145_916_800);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -181,7 +198,7 @@ fn test_touch_2_digit_years_69() {
 
     assert!(at.file_exists(file));
     // January 1, 1969, 00:00:00
-    let expected = FileTime::from_unix_time(-31_536_000, 0);
+    let expected = SystemTime::UNIX_EPOCH - Duration::from_secs(31_536_000);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -199,11 +216,17 @@ fn test_touch_set_ymdhm_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45240);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
 }
 
 #[test]
@@ -217,11 +240,17 @@ fn test_touch_set_ymdhms_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M.%S", "201501010000.00");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M.%S", "201501010000.00");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45296);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45296);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
 }
 
 #[test]
@@ -235,11 +264,17 @@ fn test_touch_set_cymdhm_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45240);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
 }
 
 #[test]
@@ -253,11 +288,17 @@ fn test_touch_set_cymdhms_time() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M.%S", "201501010000.00");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M.%S", "201501010000.00");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45296);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45296);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45296)
+    );
 }
 
 #[test]
@@ -281,10 +322,13 @@ fn test_touch_set_only_atime() {
 
         assert!(at.file_exists(file));
 
-        let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+        let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
         let (atime, mtime) = get_file_times(&at, file);
         assert_ne!(atime, mtime);
-        assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+        assert_eq!(
+            atime.duration_since(start_of_year).unwrap(),
+            Duration::from_secs(45240)
+        );
     }
 }
 
@@ -303,7 +347,7 @@ fn test_touch_set_both_time_and_reference() {
     let ref_file = "test_touch_reference";
     let file = "test_touch_set_both_time_and_reference";
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
 
     at.touch(ref_file);
     set_file_times(&at, ref_file, start_of_year, start_of_year);
@@ -319,7 +363,7 @@ fn test_touch_set_both_date_and_reference() {
     let ref_file = "test_touch_reference";
     let file = "test_touch_set_both_date_and_reference";
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501011234");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501011234");
 
     at.touch(ref_file);
     set_file_times(&at, ref_file, start_of_year, start_of_year);
@@ -339,8 +383,8 @@ fn test_touch_set_both_offset_date_and_reference() {
     let ref_file = "test_touch_reference";
     let file = "test_touch_set_both_date_and_reference";
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501011234");
-    let five_days_later = str_to_filetime("%Y%m%d%H%M", "201501061234");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501011234");
+    let five_days_later = str_to_system_time("%Y%m%d%H%M", "201501061234");
 
     at.touch(ref_file);
     set_file_times(&at, ref_file, start_of_year, start_of_year);
@@ -383,10 +427,13 @@ fn test_touch_set_only_mtime() {
 
         assert!(at.file_exists(file));
 
-        let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+        let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
         let (atime, mtime) = get_file_times(&at, file);
         assert_ne!(atime, mtime);
-        assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+        assert_eq!(
+            mtime.duration_since(start_of_year).unwrap(),
+            Duration::from_secs(45240)
+        );
     }
 }
 
@@ -401,11 +448,17 @@ fn test_touch_set_both() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - start_of_year.unix_seconds(), 45240);
-    assert_eq!(mtime.unix_seconds() - start_of_year.unix_seconds(), 45240);
+    assert_eq!(
+        atime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
+    assert_eq!(
+        mtime.duration_since(start_of_year).unwrap(),
+        Duration::from_secs(45240)
+    );
 }
 
 #[test]
@@ -415,8 +468,8 @@ fn test_touch_no_dereference() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_touch_no_dereference_a";
     let file_b = "test_touch_no_dereference_b";
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
-    let end_of_year = str_to_filetime("%Y%m%d%H%M", "201512312359");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
+    let end_of_year = str_to_system_time("%Y%m%d%H%M", "201512312359");
 
     at.touch(file_a);
     set_file_times(&at, file_a, start_of_year, start_of_year);
@@ -445,7 +498,7 @@ fn test_touch_reference() {
     let (at, mut _ucmd) = (scenario.fixtures.clone(), scenario.ucmd());
     let file_a = "test_touch_reference_a";
     let file_b = "test_touch_reference_b";
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501010000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501010000");
 
     at.touch(file_a);
     set_file_times(&at, file_a, start_of_year, start_of_year);
@@ -503,7 +556,7 @@ fn test_touch_set_date() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "201501011234");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "201501011234");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, start_of_year);
@@ -521,7 +574,7 @@ fn test_touch_set_date2() {
 
     assert!(at.file_exists(file));
 
-    let start_of_year = str_to_filetime("%Y%m%d%H%M", "200001230000");
+    let start_of_year = str_to_system_time("%Y%m%d%H%M", "200001230000");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, start_of_year);
@@ -539,7 +592,7 @@ fn test_touch_set_date3() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(1_623_786_360, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(1_623_786_360);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -557,7 +610,7 @@ fn test_touch_set_date4() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(67413, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(67413);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
     assert_eq!(atime, expected);
@@ -578,9 +631,9 @@ fn test_touch_set_date5() {
     // Slightly different result on Windows for nano seconds
     // TODO: investigate
     #[cfg(windows)]
-    let expected = FileTime::from_unix_time(67413, 23_456_700);
+    let expected = SystemTime::UNIX_EPOCH + Duration::new(67413, 23_456_700);
     #[cfg(not(windows))]
-    let expected = FileTime::from_unix_time(67413, 23_456_789);
+    let expected = SystemTime::UNIX_EPOCH + Duration::new(67413, 23_456_789);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
@@ -599,7 +652,7 @@ fn test_touch_set_date6() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(946_684_800, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(946_684_800);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
@@ -618,7 +671,7 @@ fn test_touch_set_date7() {
 
     assert!(at.file_exists(file));
 
-    let expected = FileTime::from_unix_time(1_074_254_400, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(1_074_254_400);
 
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
@@ -640,7 +693,7 @@ fn test_touch_set_date_without_leading_zeroes() {
         .succeeds()
         .no_stderr();
 
-    let expected = FileTime::from_unix_time(1_782_537_120, 0);
+    let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(1_782_537_120);
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, expected);
     assert_eq!(mtime, expected);
@@ -785,7 +838,7 @@ fn test_touch_mtime_dst_succeeds() {
 
     assert!(at.file_exists(file));
 
-    let target_time = str_to_filetime("%Y%m%d%H%M", "202103140300");
+    let target_time = str_to_system_time("%Y%m%d%H%M", "202103140300");
     let (_, mtime) = get_file_times(&at, file);
     assert_eq!(target_time, mtime);
 }
@@ -845,13 +898,12 @@ fn test_touch_dash_updates_stdout_file() {
     // `touch -` must update the times of the file open as stdout (fd 1), even
     // when it is read-only, and set them to "now" rather than a 1970 sentinel.
     use std::fs::File;
-    use std::time::SystemTime;
 
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("c");
     // Age the file so the update to "now" is detectable.
-    let old = FileTime::from_unix_time(1_000_000, 0);
-    filetime::set_file_times(at.plus("c"), old, old).unwrap();
+    let old = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+    set_file_times(&at, "c", old, old);
 
     let file = File::open(at.plus("c")).unwrap();
     ucmd.set_stdout(file).arg("-").succeeds();
@@ -969,11 +1021,17 @@ fn test_touch_leap_second() {
 
     assert!(at.file_exists(file));
 
-    let epoch = str_to_filetime("%Y%m%d%H%M", "197001010000");
+    let epoch = str_to_system_time("%Y%m%d%H%M", "197001010000");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, mtime);
-    assert_eq!(atime.unix_seconds() - epoch.unix_seconds(), 60);
-    assert_eq!(mtime.unix_seconds() - epoch.unix_seconds(), 60);
+    assert_eq!(
+        atime.duration_since(epoch).unwrap(),
+        Duration::from_secs(60)
+    );
+    assert_eq!(
+        mtime.duration_since(epoch).unwrap(),
+        Duration::from_secs(60)
+    );
 }
 
 #[test]
@@ -1091,13 +1149,13 @@ fn test_touch_symlink_with_no_deref() {
     let (at, mut ucmd) = at_and_ucmd!();
     let target = "foo.txt";
     let symlink = "bar.txt";
-    let initial_time = FileTime::from_unix_time(123, 0);
-    let updated_atime = FileTime::from_unix_time(456, 0);
+    let initial_time = SystemTime::UNIX_EPOCH + Duration::from_secs(123);
+    let updated_atime = SystemTime::UNIX_EPOCH + Duration::from_secs(456);
 
     at.touch(target);
     let target_times = get_file_times(&at, target);
     at.relative_symlink_file(target, symlink);
-    set_symlink_file_times(at.plus(symlink), initial_time, initial_time).unwrap();
+    set_symlink_times(at.plus(symlink), initial_time, initial_time);
 
     ucmd.args(&["-a", "--no-dereference", "-d", "@456", symlink])
         .succeeds();
@@ -1116,11 +1174,11 @@ fn test_touch_reference_symlink_with_no_deref() {
     let target = "foo.txt";
     let symlink = "bar.txt";
     let arg = "baz.txt";
-    let time = FileTime::from_unix_time(123, 0);
+    let time = SystemTime::UNIX_EPOCH + Duration::from_secs(123);
 
     at.touch(target);
     at.relative_symlink_file(target, symlink);
-    set_symlink_file_times(at.plus(symlink), time, time).unwrap();
+    set_symlink_times(at.plus(symlink), time, time);
     at.touch(arg);
 
     ucmd.args(&["--reference", symlink, "--no-dereference", arg])
@@ -1254,7 +1312,7 @@ fn test_touch_set_time_on_unreadable_unwritable_file() {
 
     // Restore permissions so the test harness can read back the metadata.
     std::fs::set_permissions(at.plus(file), std::fs::Permissions::from_mode(0o644)).unwrap();
-    let expected = str_to_filetime("%Y-%m-%d %H:%M", "2000-01-03 00:00");
+    let expected = str_to_system_time("%Y-%m-%d %H:%M", "2000-01-03 00:00");
     let (atime, mtime) = get_file_times(&at, file);
     assert_eq!(atime, expected);
     assert_eq!(mtime, expected);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,6 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#![feature(fs_set_times)]
+
 use std::env;
 
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_coreutils");


### PR DESCRIPTION
Replaces the `filetime` crate with `std::fs::set_times` and `std::fs::set_times_nofollow`.

Rust 1.99 is currently beta, so `RUSTC_BOOTSTRAP` and the feature gate are
temporary and can be removed once 1.99 is stable.

All relevant tests pass.

Fixes #13808
