### PR TITLE
pr: stop dropping lines the columns do not divide evenly

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1400,14 +1400,37 @@ fn to_table(
 ///
 /// This function should be applied when there are fewer lines than the
 /// total number of cells in the table.
+///
+/// The lines are spread over the columns the way `pr` fills a page it cannot
+/// fill completely: every column takes the ceiling of what is still unplaced
+/// divided by the number of columns left to fill, so the leftmost columns are
+/// the long ones and no line is left over.
 fn to_table_short_file(
     content_lines_per_page: usize,
     columns: usize,
     lines: &[FileLine],
 ) -> Vec<Vec<Option<&FileLine>>> {
-    let num_rows = lines.len() / columns;
+    let mut bounds = Vec::with_capacity(columns + 1);
+    bounds.push(0);
+    let mut placed = 0;
+    for column in 0..columns {
+        placed += (lines.len() - placed).div_ceil(columns - column);
+        bounds.push(placed);
+    }
+
+    let num_rows = (0..columns)
+        .map(|j| bounds[j + 1] - bounds[j])
+        .max()
+        .unwrap_or(0);
     let mut table: Vec<Vec<_>> = (0..num_rows)
-        .map(|i| (0..columns).map(|j| lines.get(num_rows * j + i)).collect())
+        .map(|i| {
+            (0..columns)
+                .map(|j| {
+                    let index = bounds[j] + i;
+                    (index < bounds[j + 1]).then(|| &lines[index])
+                })
+                .collect()
+        })
         .collect();
     // Fill the rest with Nones.
     for _ in num_rows..content_lines_per_page {
@@ -1478,19 +1501,28 @@ fn write_columns(
     // cells, where each row will be printed as a single line in the
     // output.
     let merge = options.merge_files_print.is_some();
-    let table = if !merge && (lines.len() < (content_lines_per_page * columns)) {
-        to_table_short_file(content_lines_per_page, columns, lines)
+    let table = if merge {
+        to_table_merged(content_lines_per_page, columns, filled_lines)
     } else if across_mode {
         to_table_across(content_lines_per_page, columns, lines)
-    } else if merge {
-        to_table_merged(content_lines_per_page, columns, filled_lines)
+    } else if lines.len() < (content_lines_per_page * columns) {
+        to_table_short_file(content_lines_per_page, columns, lines)
     } else {
         to_table(content_lines_per_page, columns, lines)
     };
 
     let blank_line = FileLine::default();
     for row in table {
-        let indexes = row.len();
+        // On a page that is not completely filled the last row stops part way
+        // through, and its final cell must not be followed by a column
+        // separator. Merging prints an empty cell for every column instead, so
+        // there the row always spans the full width.
+        let indexes = if merge {
+            row.len()
+        } else {
+            row.iter().take_while(|cell| cell.is_some()).count()
+        };
+        let mut cells_written = 0;
         for (i, cell) in row.iter().enumerate() {
             let line_to_print = match cell {
                 None if options.merge_files_print.is_some() => &blank_line,
@@ -1506,8 +1538,15 @@ fn write_columns(
                 get_line_for_printing(options, line_to_print, columns, i, line_width, indexes)
                     .as_bytes(),
             )?;
+            cells_written += 1;
         }
-        if not_found_break && (feed_line_present || !options.display_header_and_trailer) {
+        // The last row of a partly filled page has content in its leading
+        // columns and nothing in the rest, so it still needs to be terminated.
+        // Only a row without any content at all means the page ran out.
+        if cells_written == 0
+            && not_found_break
+            && (feed_line_present || !options.display_header_and_trailer)
+        {
             break;
         }
         writer.write_all(line_separator)?;

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -864,6 +864,71 @@ fn test_columns() {
 }
 
 #[test]
+fn test_columns_partly_filled_page() {
+    // Three lines do not divide evenly into two columns. GNU pr puts the
+    // ceiling of 3 / 2 in the first column and what is left in the second, so
+    // "c" has to show up next to "a".
+    //
+    // Command line: `printf "a\nb\nc\n" | pr -t -2 -w 20`.
+    new_ucmd!()
+        .args(&["-t", "-2", "-w", "20"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_is("a        \tc        \nb        \n");
+}
+
+#[test]
+fn test_columns_partly_filled_page_across() {
+    // Same input read across instead of down.
+    //
+    // Command line: `printf "a\nb\nc\n" | pr -t -a -2 -w 20`.
+    new_ucmd!()
+        .args(&["-t", "-a", "-2", "-w", "20"])
+        .pipe_in("a\nb\nc\n")
+        .succeeds()
+        .stdout_is("a        \tb        \nc        \n");
+}
+
+#[test]
+fn test_columns_fewer_lines_than_columns() {
+    // Fewer lines than columns still has to print those lines.
+    //
+    // Command line: `printf "a\n" | pr -t -3 -w 20`.
+    new_ucmd!()
+        .args(&["-t", "-3", "-w", "20"])
+        .pipe_in("a\n")
+        .succeeds()
+        .stdout_is("a     \n");
+
+    // Command line: `printf "a\nb\n" | pr -t -3 -w 20`.
+    new_ucmd!()
+        .args(&["-t", "-3", "-w", "20"])
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("a     \tb     \n");
+}
+
+#[test]
+fn test_columns_last_page() {
+    // Nine lines over pages that hold four each leave the ninth alone on page
+    // three, which must not come out as an empty page.
+    //
+    // Command line: `seq 9 | pr -2 -l 12 -w 20 -D DATE`.
+    let header = "\n\nDATE          Page ";
+    let expected = format!(
+        "{header}1\n\n\n1        \t3        \n2        \t4        \n{blank}\
+         {header}2\n\n\n5        \t7        \n6        \t8        \n{blank}\
+         {header}3\n\n\n9        \n\n\n\n\n\n\n",
+        blank = "\n".repeat(5),
+    );
+    new_ucmd!()
+        .args(&["-2", "-l", "12", "-w", "20", "-D", "DATE"])
+        .pipe_in("1\n2\n3\n4\n5\n6\n7\n8\n9\n")
+        .succeeds()
+        .stdout_is(expected);
+}
+
+#[test]
 fn test_merge() {
     // Create the two files to merge.
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
`pr` in column mode drops whatever the columns cannot divide evenly.

```console
$ seq 9 | pr -t -2 -w 20      # GNU coreutils 9.7
1         6
2         7
3         8
4         9
5

$ seq 9 | pr -t -2 -w 20      # uutils, main at 9875296
1               5
2               6
3               7
4               8
```

The ninth line is gone. A page holding fewer lines than it has columns comes out empty instead:

```console
$ printf 'a\n' | pr -t -3 | wc -c
2      # GNU
0      # uutils
```

`seq 9 | pr -2 -l 12` ends the same way, on an empty page 3 where GNU prints the ninth line.

It comes down to one line, `src/uu/pr/src/pr.rs:1408`:

```rust
let num_rows = lines.len() / columns;
```

Integer division truncates, so nine lines over two columns give four rows and the ninth never gets a cell.

Rounding up gets closer but still misses, because GNU balances the columns: each one takes the ceiling of what is still unplaced over the number of columns left to fill, so nine lines over four columns come out 3, 2, 2, 2 rather than 3, 3, 3, 0. I read that rule off the output of `/usr/bin/pr` rather than its source, then checked it for every column count from 1 to 7 against every input length from 0 to 39, down and across. 560 cases, no mismatch.

Two smaller things came with the fix. The short-file branch was tested before the across-mode one, so `pr -a` laid a partly filled page out downwards; and the last row of such a page stops part way through, so it needs its line separator without a trailing column separator.

## What I ran

All of it in a Debian container where `/usr/bin/pr` is GNU coreutils 9.7.

I ran 425 combinations of options and input length against GNU, this branch, and a build of `main`. `main` agreed with GNU in 138 of them and this branch agrees in 370, so 232 newly agree and none regressed. The comparison ignores column padding: uutils does not match GNU there, and `test_columns` already carries a TODO about it.

Another 574 combinations went through a line count check, comparing how many input lines survive the round trip. None lost.

`cargo test --features pr --no-default-features test_pr` passes 83. The four new tests fail on `main` and pass here, the 79 that were already there are untouched, and no expected fixture changed.

`cargo fmt -p uu_pr -- --check` and `cargo clippy -p uu_pr --all-targets` come back clean. `clippy -D warnings` still trips on the generated `uucore/embedded_locales.rs`, which fails the same way for a crate I did not touch.

I left the padding alone. GNU pads with tabs and leaves the last column unpadded while uutils pads with spaces, which is a different problem.
