### PR TITLE
od: replace byteorder with std endian methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,7 +3963,6 @@ dependencies = [
 name = "uu_od"
 version = "0.10.0"
 dependencies = [
- "byteorder",
  "clap",
  "fluent",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,7 +421,6 @@ bigdecimal = "0.4"
 binary-heap-plus = "0.5.0"
 bstr = "1.9.1"
 bytecount = "0.6.8"
-byteorder = "1.5.0"
 cfg_aliases = "0.2.2"
 clap = { version = "4.5", features = ["wrap_help", "cargo", "color"] }
 clap_complete = "4.4"

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -15,7 +15,6 @@ readme.workspace = true
 path = "src/od.rs"
 
 [dependencies]
-byteorder = { workspace = true }
 clap = { workspace = true }
 half = { workspace = true }
 rustix = { workspace = true, features = ["stdio"] }

--- a/src/uu/od/src/byteorder_io.rs
+++ b/src/uu/od/src/byteorder_io.rs
@@ -2,13 +2,6 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (ToDO) byteorder
-
-// workaround until https://github.com/BurntSushi/byteorder/issues/41 has been fixed
-// based on: https://github.com/netvl/immeta/blob/4460ee/src/utils.rs#L76
-
-use byteorder::ByteOrder as ByteOrderTrait;
-use byteorder::{BigEndian, LittleEndian, NativeEndian};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ByteOrder {
@@ -18,25 +11,16 @@ pub enum ByteOrder {
 }
 
 macro_rules! gen_byte_order_ops {
-    ($($read_name:ident, $write_name:ident -> $tpe:ty),+) => {
+    ($($read_name:ident -> $tpe:ty),+) => {
         impl ByteOrder {
             $(
-            #[allow(dead_code)]
             #[inline]
             pub fn $read_name(self, source: &[u8]) -> $tpe {
+                let bytes = source[..std::mem::size_of::<$tpe>()].try_into().unwrap();
                 match self {
-                    ByteOrder::Little => LittleEndian::$read_name(source),
-                    ByteOrder::Big => BigEndian::$read_name(source),
-                    ByteOrder::Native => NativeEndian::$read_name(source),
-                }
-            }
-
-            #[allow(dead_code)]
-            pub fn $write_name(self, target: &mut [u8], n: $tpe) {
-                match self {
-                    ByteOrder::Little => LittleEndian::$write_name(target, n),
-                    ByteOrder::Big => BigEndian::$write_name(target, n),
-                    ByteOrder::Native => NativeEndian::$write_name(target, n),
+                    Self::Little => <$tpe>::from_le_bytes(bytes),
+                    Self::Big => <$tpe>::from_be_bytes(bytes),
+                    Self::Native => <$tpe>::from_ne_bytes(bytes),
                 }
             }
             )+
@@ -45,13 +29,10 @@ macro_rules! gen_byte_order_ops {
 }
 
 gen_byte_order_ops! {
-    read_u16, write_u16 -> u16,
-    read_u32, write_u32 -> u32,
-    read_u64, write_u64 -> u64,
-    read_i16, write_i16 -> i16,
-    read_i32, write_i32 -> i32,
-    read_i64, write_i64 -> i64,
-    read_f32, write_f32 -> f32,
-    read_f64, write_f64 -> f64,
-    read_u128, write_u128 -> u128
+    read_u16 -> u16,
+    read_u32 -> u32,
+    read_u64 -> u64,
+    read_f32 -> f32,
+    read_f64 -> f64,
+    read_u128 -> u128
 }


### PR DESCRIPTION
Replace the external `byteorder` dependency in `uu_od` with standard library `<$type>::from_{le,be,ne}_bytes` methods.
