### PR TITLE
id: order groups= by effective gid and -G by real gid, like GNU

### DIFF
--- a/src/uu/id/src/id.rs
+++ b/src/uu/id/src/id.rs
@@ -315,11 +315,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             )?;
         }
 
-        let groups = entries::get_groups_gnu(Some(gid))?;
+        // GNU heads the two forms with opposite gids: `groups=` with the
+        // effective gid, `-G` with the real gid. Don't share one list.
         let groups = if state.user_specified {
             possible_pw.as_ref().map(Passwd::belongs_to).unwrap()
+        } else if state.gsflag {
+            group_list_real_gid_first()?
         } else {
-            groups.clone()
+            entries::get_groups_gnu(Some(getegid().as_raw()))?
         };
 
         if state.gsflag {
@@ -628,6 +631,29 @@ fn auditid() -> io::Result<()> {
     writeln!(lock, "termid.port=0x{:x}", auditinfo.ai_termid.port)?;
     writeln!(lock, "asid={}", auditinfo.ai_asid)?;
     Ok(())
+}
+
+/// The group list as `id -G` prints it. `-r` does not affect it, matching GNU.
+fn group_list_real_gid_first() -> io::Result<Vec<u32>> {
+    Ok(sort_real_gid_first(
+        getgid().as_raw(),
+        getegid().as_raw(),
+        entries::get_groups_gnu(None)?,
+    ))
+}
+
+/// Real gid, then effective gid when it differs, then `getgroups()` minus those.
+fn sort_real_gid_first(rgid: u32, egid: u32, supplementary: Vec<u32>) -> Vec<u32> {
+    let mut ordered = vec![rgid];
+    if egid != rgid {
+        ordered.push(egid);
+    }
+    for group in supplementary {
+        if !ordered.contains(&group) {
+            ordered.push(group);
+        }
+    }
+    ordered
 }
 
 fn id_print(state: &State, groups: &[u32]) -> io::Result<()> {

--- a/tests/by-util/test_id.rs
+++ b/tests/by-util/test_id.rs
@@ -152,6 +152,40 @@ fn test_id_real() {
 }
 
 #[test]
+fn test_id_groups_ordering() {
+    // `groups=` is headed by the effective gid and `-G` by the real gid, so the
+    // two forms list the same set in a different order. Only observable when the
+    // real and effective gids differ, which needs a setgid wrapper, but the set
+    // and the `-r`-independence of `-G` hold either way.
+    let ts = TestScenario::new(util_name!());
+
+    let groups = ts.ucmd().arg("-G").succeeds().stdout_move_str();
+    let mut from_flag: Vec<&str> = groups.split_whitespace().collect();
+    assert!(!from_flag.is_empty());
+
+    // `-G` heads with the real gid
+    let rgid = ts.ucmd().args(&["-g", "-r"]).succeeds().stdout_move_str();
+    assert_eq!(from_flag[0], rgid.trim_end());
+
+    let default = ts.ucmd().succeeds().stdout_move_str();
+    let field = default.split(" groups=").nth(1).unwrap();
+    let mut from_default: Vec<&str> = field
+        .split(&[' ', '\n'][..])
+        .next()
+        .unwrap()
+        .split(',')
+        .map(|g| g.split('(').next().unwrap())
+        .collect();
+
+    from_flag.sort_unstable();
+    from_default.sort_unstable();
+    assert_eq!(from_flag, from_default);
+
+    // `-r` does not affect `-G`, matching GNU
+    ts.ucmd().args(&["-G", "-r"]).succeeds().stdout_is(&groups);
+}
+
+#[test]
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn test_id_pretty_print() {
     // `-p` is BSD only and not supported on GNU's `id`


### PR DESCRIPTION
GNU heads the two forms with opposite gids: `groups=` with the effective gid, `-G` with the real gid then the effective one. Both were derived from the same `gid` local, so only one could be right.

Only observable when the real and effective gids differ, e.g. under `setpriv --regid=A --egid=B`. `-r` still does not affect `-G`.