### PR TITLE
Revert "remove rust-version from fuzz"

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "uutils ~ 'core' uutils fuzzers"
 repository = "https://github.com/uutils/coreutils/tree/main/fuzz/"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 publish = false
 
@@ -16,8 +17,8 @@ members = ["."]
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.88.0"
 license = "MIT"
-# no need to pin rust-version for non-production
 
 # Enable debug symbols in release builds for readable backtraces
 # when fuzzing discovers crashes. This addresses issue #5343.

--- a/fuzz/uufuzz/Cargo.toml
+++ b/fuzz/uufuzz/Cargo.toml
@@ -4,6 +4,7 @@ description = "uutils ~ 'core' uutils fuzzing library"
 repository = "https://github.com/uutils/coreutils/tree/main/fuzz/uufuzz"
 version = "0.10.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [dependencies]


### PR DESCRIPTION
[`uufuzz`](https://crates.io/crates/uufuzz) is published on crates.io, so we shouldn't remove `rust-version` from the package metadata.