### PR TITLE
sort: replace binary-heap-plus and compare with std::collections::BinaryHeap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,15 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binary-heap-plus"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4551d8382e911ecc0d0f0ffb602777988669be09447d536ff4388d1def11296"
-dependencies = [
- "compare",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,12 +460,6 @@ checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "compare"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "condtype"
@@ -4212,10 +4197,8 @@ name = "uu_sort"
 version = "0.10.0"
 dependencies = [
  "bigdecimal",
- "binary-heap-plus",
  "clap",
  "codspeed-divan-compat",
- "compare",
  "ctrlc",
  "fluent",
  "foldhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,14 +418,12 @@ ansi-width = "0.1.0"
 ariadne = "0.6.0"
 base64-simd = "0.8"
 bigdecimal = "0.4"
-binary-heap-plus = "0.5.0"
 bstr = "1.9.1"
 bytecount = "0.6.8"
 cfg_aliases = "0.2.2"
 clap = { version = "4.5", features = ["wrap_help", "cargo", "color"] }
 clap_complete = "4.4"
 clap_mangen = "0.3"
-compare = "0.1.0"
 crossterm = { version = "0.29.0", default-features = false }
 ctor = "1.0.0"
 ctrlc = { version = "3.5.2", features = ["termination"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -115,15 +115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binary-heap-plus"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4551d8382e911ecc0d0f0ffb602777988669be09447d536ff4388d1def11296"
-dependencies = [
- "compare",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,12 +281,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "compare"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "console"
@@ -1969,9 +1954,7 @@ name = "uu_sort"
 version = "0.10.0"
 dependencies = [
  "bigdecimal",
- "binary-heap-plus",
  "clap",
- "compare",
  "ctrlc",
  "fluent",
  "foldhash",

--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -24,9 +24,7 @@ i18n-collator = ["uucore/i18n-collator"]
 
 [dependencies]
 bigdecimal = { workspace = true }
-binary-heap-plus = { workspace = true }
 clap = { workspace = true }
-compare = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 rand = { workspace = true }

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -13,6 +13,7 @@
 
 use std::{
     cmp::Ordering,
+    collections::BinaryHeap,
     ffi::{OsStr, OsString},
     fs::{self, File},
     io::{BufWriter, Read, Write},
@@ -24,7 +25,6 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use compare::Compare;
 use uucore::error::{FromIo, UResult};
 
 use crate::{
@@ -221,15 +221,13 @@ fn merge_without_limit<M: MergeInput + 'static, F: Iterator<Item = UResult<M>>>(
                 file_number,
                 line_idx: 0,
                 receiver,
+                settings,
             });
         }
     }
 
     Ok(FileMerger {
-        heap: binary_heap_plus::BinaryHeap::from_vec_cmp(
-            mergeable_files,
-            FileComparator { settings },
-        ),
+        heap: BinaryHeap::from(mergeable_files),
         request_sender,
         prev: None,
         reader_join_handle,
@@ -277,11 +275,45 @@ fn reader(
     Ok(())
 }
 /// The struct on the main thread representing an input file
-pub struct MergeableFile {
+pub struct MergeableFile<'a> {
     current_chunk: Rc<Chunk>,
     line_idx: usize,
     receiver: Receiver<Chunk>,
     file_number: usize,
+    settings: &'a GlobalSettings,
+}
+
+impl PartialEq for MergeableFile<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for MergeableFile<'_> {}
+
+impl PartialOrd for MergeableFile<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MergeableFile<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut cmp = compare_by(
+            &self.current_chunk.lines()[self.line_idx],
+            &other.current_chunk.lines()[other.line_idx],
+            self.settings,
+            self.current_chunk.line_data(),
+            other.current_chunk.line_data(),
+        );
+        if cmp == Ordering::Equal {
+            // To make sorting stable, we need to consider the file number as well,
+            // as lines from a file with a lower number are to be considered "earlier".
+            cmp = self.file_number.cmp(&other.file_number);
+        }
+        // BinaryHeap is a max heap. We use it as a min heap, so we need to reverse the ordering.
+        cmp.reverse()
+    }
 }
 
 /// A struct to keep track of the previous line we encountered.
@@ -295,7 +327,7 @@ struct PreviousLine {
 
 /// Merges files together. This is **not** an iterator because of lifetime problems.
 struct FileMerger<'a> {
-    heap: binary_heap_plus::BinaryHeap<MergeableFile, FileComparator<'a>>,
+    heap: BinaryHeap<MergeableFile<'a>>,
     request_sender: Sender<(usize, RecycledChunk)>,
     prev: Option<PreviousLine>,
     reader_join_handle: JoinHandle<UResult<()>>,
@@ -408,30 +440,6 @@ impl FileMerger<'_> {
             }
         }
         Ok(!self.heap.is_empty())
-    }
-}
-
-/// Compares files by their current line.
-struct FileComparator<'a> {
-    settings: &'a GlobalSettings,
-}
-
-impl Compare<MergeableFile> for FileComparator<'_> {
-    fn compare(&self, a: &MergeableFile, b: &MergeableFile) -> Ordering {
-        let mut cmp = compare_by(
-            &a.current_chunk.lines()[a.line_idx],
-            &b.current_chunk.lines()[b.line_idx],
-            self.settings,
-            a.current_chunk.line_data(),
-            b.current_chunk.line_data(),
-        );
-        if cmp == Ordering::Equal {
-            // To make sorting stable, we need to consider the file number as well,
-            // as lines from a file with a lower number are to be considered "earlier".
-            cmp = a.file_number.cmp(&b.file_number);
-        }
-        // BinaryHeap is a max heap. We use it as a min heap, so we need to reverse the ordering.
-        cmp.reverse()
     }
 }
 


### PR DESCRIPTION
Replace the external `binary-heap-plus` and `compare` dependencies in `uu_sort` with `std::collections::BinaryHeap` by implementing `Ord` directly on `MergeableFile`.
