### PR TITLE
stat: remove unnecessary `#[cfg(unix)]`

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1150,7 +1150,6 @@ impl Stater {
     }
 
     fn exec(&self) -> UResult<i32> {
-        #[cfg(unix)]
         let stdin_is_fifo = rustix::fs::fstat(io::stdin())
             .is_ok_and(|s| rustix::fs::FileType::from_raw_mode(s.st_mode).is_fifo());
 


### PR DESCRIPTION
We gate a variable in `exec` but later in the function we use the same variable without gate, so the gate is unnecessary and can be removed.