### PR TITLE
uucore, cat: remove winapi-util dependency in favor of windows-sys and std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3343,7 +3343,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "uucore",
- "winapi-util",
  "windows-sys 0.61.2",
 ]
 
@@ -4608,7 +4607,6 @@ dependencies = [
  "uucore_procs",
  "walkdir",
  "wild",
- "winapi-util",
  "windows-sys 0.61.2",
  "xattr",
  "z85",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,7 +498,6 @@ utmp-classic = "0.1.6"
 uutils_term_grid = "0.8"
 walkdir = "2.5"
 wild = "2.2.1"
-winapi-util = "0.1.8"
 windows-sys = { version = "0.61.0", default-features = false }
 xattr = "1.3.1"
 z85 = "3.0.5"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2066,7 +2066,6 @@ dependencies = [
  "unit-prefix",
  "uucore_procs",
  "wild",
- "winapi-util",
  "windows-sys",
  "z85",
 ]
@@ -2185,15 +2184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
 dependencies = [
  "glob",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -29,7 +29,6 @@ tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi-util = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/src/uu/cat/src/platform/windows.rs
+++ b/src/uu/cat/src/platform/windows.rs
@@ -5,24 +5,24 @@
 
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
+use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
 use uucore::fs::FileInformation;
-use winapi_util::AsHandleRef;
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_NT,
 };
 
 /// An unsafe overwrite occurs when the same file is used as both stdin and stdout
 /// and the stdout file is not empty.
-pub fn is_safe_overwrite<I: AsHandleRef, O: AsHandleRef>(input: &I, output: &O) -> bool {
+pub fn is_safe_overwrite<I: AsRawHandle, O: AsRawHandle>(input: &I, output: &O) -> bool {
     !is_same_file_by_path(input, output) ||
     // Check if the output file is empty
     !FileInformation::from_file(output).is_ok_and(|info| info.file_size() > 0)
 }
 
 /// Get the file path for a file handle
-fn get_file_path_from_handle<F: AsHandleRef>(file: &F) -> Option<PathBuf> {
-    let handle = file.as_raw();
+fn get_file_path_from_handle<F: AsRawHandle>(file: &F) -> Option<PathBuf> {
+    let handle = file.as_raw_handle();
     let mut path_buf = vec![0u16; 4096];
 
     // SAFETY: We should check how many bytes was written to `path_buf`
@@ -43,7 +43,7 @@ fn get_file_path_from_handle<F: AsHandleRef>(file: &F) -> Option<PathBuf> {
 }
 
 /// Compare two file handles if they correspond to the same file
-fn is_same_file_by_path<A: AsHandleRef, B: AsHandleRef>(a: &A, b: &B) -> bool {
+fn is_same_file_by_path<A: AsRawHandle, B: AsRawHandle>(a: &A, b: &B) -> bool {
     match (get_file_path_from_handle(a), get_file_path_from_handle(b)) {
         (Some(path1), Some(path2)) => path1 == path2,
         _ => false,

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -120,7 +120,6 @@ procfs = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wild = { workspace = true }
-winapi-util = { workspace = true, optional = true }
 windows-sys = { workspace = true, optional = true, default-features = false, features = [
   "Wdk_System_SystemInformation",
   "Win32_Security",
@@ -150,7 +149,7 @@ encoding = ["data-encoding", "data-encoding-macro", "z85", "base64-simd"]
 entries = ["libc"]
 extendedbigdecimal = ["bigdecimal", "num-traits"]
 fast-inc = []
-fs = ["dunce", "libc", "winapi-util", "windows-sys"]
+fs = ["dunce", "libc", "windows-sys"]
 fsext = ["libc", "windows-sys", "bstr"]
 fsxattr = ["xattr", "itertools", "libc"]
 hardware = []

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -27,12 +27,12 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::path::{Component, MAIN_SEPARATOR, Path, PathBuf};
-#[cfg(target_os = "windows")]
-use winapi_util::AsHandleRef;
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::MAX_PATH;
 #[cfg(windows)]
-use windows_sys::Win32::Storage::FileSystem::{GetDiskFreeSpaceW, GetVolumePathNameW};
+use windows_sys::Win32::Storage::FileSystem::{
+    BY_HANDLE_FILE_INFORMATION, GetDiskFreeSpaceW, GetFileInformationByHandle, GetVolumePathNameW,
+};
 #[cfg(windows)]
 use windows_sys::Win32::System::IO::DeviceIoControl;
 #[cfg(windows)]
@@ -53,7 +53,7 @@ macro_rules! has {
 #[derive(Clone)]
 pub struct FileInformation(
     #[cfg(any(unix, target_os = "wasi"))] rustix::fs::Stat,
-    #[cfg(windows)] winapi_util::file::Information,
+    #[cfg(windows)] BY_HANDLE_FILE_INFORMATION,
 );
 
 impl FileInformation {
@@ -66,8 +66,12 @@ impl FileInformation {
 
     /// Get information from a currently open file
     #[cfg(target_os = "windows")]
-    pub fn from_file(file: &impl AsHandleRef) -> IOResult<Self> {
-        let info = winapi_util::file::information(file.as_handle_ref())?;
+    pub fn from_file(file: &impl AsRawHandle) -> IOResult<Self> {
+        let mut info = BY_HANDLE_FILE_INFORMATION::default();
+        // SAFETY: `info` is a valid pointer to be populated by GetFileInformationByHandle.
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &raw mut info) } == 0 {
+            return Err(Error::last_os_error());
+        }
         Ok(Self(info))
     }
 
@@ -88,7 +92,7 @@ impl FileInformation {
         #[cfg(target_os = "windows")]
         {
             use std::fs::OpenOptions;
-            use std::os::windows::prelude::*;
+            use std::os::windows::fs::OpenOptionsExt;
             let mut open_options = OpenOptions::new();
             let mut custom_flags = 0;
             if !dereference {
@@ -110,13 +114,13 @@ impl FileInformation {
         }
         #[cfg(target_os = "windows")]
         {
-            self.0.file_size()
+            ((self.0.nFileSizeHigh as u64) << 32) | (self.0.nFileSizeLow as u64)
         }
     }
 
     #[cfg(windows)]
     pub fn file_index(&self) -> u64 {
-        self.0.file_index()
+        ((self.0.nFileIndexHigh as u64) << 32) | (self.0.nFileIndexLow as u64)
     }
 
     pub fn number_of_links(&self) -> u64 {
@@ -163,7 +167,7 @@ impl FileInformation {
         #[cfg(target_os = "aix")]
         return self.0.st_nlink.try_into().unwrap();
         #[cfg(windows)]
-        return self.0.number_of_links();
+        return self.0.nNumberOfLinks as u64;
     }
 
     #[cfg(any(unix, target_os = "wasi"))]
@@ -186,8 +190,8 @@ impl PartialEq for FileInformation {
 #[cfg(target_os = "windows")]
 impl PartialEq for FileInformation {
     fn eq(&self, other: &Self) -> bool {
-        self.0.volume_serial_number() == other.0.volume_serial_number()
-            && self.0.file_index() == other.0.file_index()
+        self.0.dwVolumeSerialNumber == other.0.dwVolumeSerialNumber
+            && self.file_index() == other.file_index()
     }
 }
 
@@ -202,8 +206,8 @@ impl Hash for FileInformation {
         }
         #[cfg(target_os = "windows")]
         {
-            self.0.volume_serial_number().hash(state);
-            self.0.file_index().hash(state);
+            self.0.dwVolumeSerialNumber.hash(state);
+            self.file_index().hash(state);
         }
     }
 }


### PR DESCRIPTION
Remove `winapi-util` dependency in favor of `windows-sys` and `std`.
