### PR TITLE
ls: exit with code 2 on write error

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -109,7 +109,7 @@ enum LsError {
 impl UError for LsError {
     fn code(&self) -> i32 {
         match self {
-            Self::IOError(_) | Self::WriteError(_) | Self::IOErrorContext(_, _, false) => 1,
+            Self::IOError(_) | Self::IOErrorContext(_, _, false) => 1,
             _ => 2,
         }
     }

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7712,3 +7712,21 @@ fn test_no_extra_stat_without_recursion() {
     };
     assert_eq!(count, 1, "expected a single stat of the directory operand");
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_write_error() {
+    let ts = TestScenario::new(util_name!());
+
+    ts.fixtures.touch("dummy_file.txt");
+
+    let dev_full = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .unwrap();
+
+    ts.ucmd()
+        .set_stdout(dev_full)
+        .fails_with_code(2)
+        .stderr_is("ls: write error: No space left on device\n");
+}


### PR DESCRIPTION
GNU ls errors with code 2 on write error
see https://github.com/uutils/coreutils/issues/9782#issuecomment-5393159635
```
$ ls --version; ls > /dev/full; printf $?
ls (GNU coreutils) 9.11
Copyright (C) 2026 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
ls: write error: No space left on device
2
```