### PR TITLE
tests: use convenience functions to ensure empty output

### DIFF
--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -670,8 +670,7 @@ fn test_skip_to_match_context_underflow() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%5%-10"])
         .fails()
-        .stdout_is("")
-        .stderr_is("csplit: '%5%-10': line number out of range\n");
+        .stderr_only("csplit: '%5%-10': line number out of range\n");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")
@@ -681,8 +680,7 @@ fn test_skip_to_match_context_underflow() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "%5%-10", "-k"])
         .fails()
-        .stdout_is("")
-        .stderr_is("csplit: '%5%-10': line number out of range\n");
+        .stderr_only("csplit: '%5%-10': line number out of range\n");
 
     let count = glob(&at.plus_as_string("xx*"))
         .expect("counting splits")

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -1963,8 +1963,7 @@ fn test_oflag_direct_partial_block() {
             "status=none".to_string(),
         ])
         .succeeds()
-        .stdout_is("")
-        .stderr_is("");
+        .no_output();
     assert!(output_path.exists());
     let output_size = output_path.metadata().unwrap().len() as usize;
     assert_eq!(output_size, input_size);

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1595,7 +1595,7 @@ fn test_du_exclude() {
         .arg("--exclude=subdir")
         .arg("subdir")
         .succeeds()
-        .stdout_is("");
+        .no_output();
     ts.ucmd()
         .arg("--exclude=subdir")
         .arg("--verbose")
@@ -1888,8 +1888,7 @@ fn test_du_files0_from_missing_file_listed_twice() {
     ts.ucmd()
         .arg("--files0-from=filelist")
         .fails_with_code(1)
-        .stdout_is("")
-        .stderr_is(
+        .stderr_only(
             "du: cannot access 'missing': No such file or directory\n\
              du: cannot access 'missing': No such file or directory\n",
         );

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -830,8 +830,7 @@ fn test_env_overwrite_arg0() {
     ts.ucmd()
         .args(&["--argv0", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 }
 
 // Do not assume that coreutils uses argv0
@@ -845,32 +844,28 @@ fn test_env_arg_argv0_overwrite() {
         .args(&["--argv0", "dirname"])
         .args(&["--argv0", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // overwrite -a by -a
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["-a", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // overwrite --argv0 by -a
     ts.ucmd()
         .args(&["--argv0", "dirname"])
         .args(&["-a", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // overwrite -a by --argv0
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["--argv0", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 }
 
 // Do not assume that coreutils uses argv0
@@ -884,31 +879,27 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
         .args(&["-S--argv0 dirname"])
         .args(&["--argv0", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // normal following string arg
     ts.ucmd()
         .args(&["-a", "dirname"])
         .args(&["-S-a hijacked sh -c 'echo $0'"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // one large string arg
     ts.ucmd()
         .args(&["-S--argv0 dirname -a hijacked sh -c 'echo $0'"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // two string args
     ts.ucmd()
         .args(&["-S-a dirname"])
         .args(&["-S--argv0 hijacked sh -c 'echo $0'"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 
     // three args: normal, string, normal
     ts.ucmd()
@@ -916,8 +907,7 @@ fn test_env_arg_argv0_overwrite_mixed_with_string_args() {
         .args(&["-S-a dirname"])
         .args(&["-a", "hijacked", "sh", "-c", "echo $0"])
         .succeeds()
-        .stdout_is("hijacked\n")
-        .stderr_is("");
+        .stdout_only("hijacked\n");
 }
 
 #[test]

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -180,7 +180,7 @@ fn test_negative_byte_syntax() {
         .args(&["--bytes=-2"])
         .pipe_in("a\n")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -7623,7 +7623,7 @@ fn test_ls_recursive_no_fd_leak() {
         .arg("1")
         .limit(Resource::NOFILE, 20, 20)
         .succeeds()
-        .stderr_is("");
+        .no_stderr();
 }
 
 #[test]

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -197,8 +197,7 @@ fn test_with_valid_page_ranges() {
     scenario
         .args(&["--pages=20:5", test_file_path])
         .fails()
-        .stderr_is("pr: invalid --pages argument '20:5'\n")
-        .stdout_is("");
+        .stderr_only("pr: invalid --pages argument '20:5'\n");
     new_ucmd!()
         .args(&["--pages=1:5", test_file_path])
         .succeeds();
@@ -206,18 +205,15 @@ fn test_with_valid_page_ranges() {
     new_ucmd!()
         .args(&["--pages=-1:5", test_file_path])
         .fails()
-        .stderr_is("pr: invalid --pages argument '-1:5'\n")
-        .stdout_is("");
+        .stderr_only("pr: invalid --pages argument '-1:5'\n");
     new_ucmd!()
         .args(&["--pages=1:-5", test_file_path])
         .fails()
-        .stderr_is("pr: invalid --pages argument '1:-5'\n")
-        .stdout_is("");
+        .stderr_only("pr: invalid --pages argument '1:-5'\n");
     new_ucmd!()
         .args(&["--pages=5:1", test_file_path])
         .fails()
-        .stderr_is("pr: invalid --pages argument '5:1'\n")
-        .stdout_is("");
+        .stderr_only("pr: invalid --pages argument '5:1'\n");
 }
 
 #[test]
@@ -225,8 +221,7 @@ fn test_start_page_exceeds_page_count() {
     new_ucmd!()
         .args(&["--pages=2", "hosts.log"])
         .succeeds()
-        .stderr_is("pr: starting page number 2 exceeds page count 1\n")
-        .stdout_is("");
+        .stderr_only("pr: starting page number 2 exceeds page count 1\n");
 }
 
 #[test]
@@ -293,8 +288,7 @@ fn test_with_suppress_error_option() {
     scenario
         .args(&["--pages=20:5", "-r", test_file_path])
         .fails()
-        .stderr_is("")
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -407,14 +401,12 @@ fn test_with_mpr_and_column_options() {
     new_ucmd!()
         .args(&["--column=2", "-m", "-n", test_file_path])
         .fails()
-        .stderr_is("pr: cannot specify number of columns when printing in parallel\n")
-        .stdout_is("");
+        .stderr_only("pr: cannot specify number of columns when printing in parallel\n");
 
     new_ucmd!()
         .args(&["-a", "-m", "-n", test_file_path])
         .fails()
-        .stderr_is("pr: cannot specify both printing across and printing in parallel\n")
-        .stdout_is("");
+        .stderr_only("pr: cannot specify both printing across and printing in parallel\n");
 }
 
 #[test]

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1536,7 +1536,7 @@ fn test_large_width_format() {
             .args(&[format, arg])
             .fails_with_code(1)
             .stderr_contains("write error")
-            .stdout_is("");
+            .no_stdout();
     }
 }
 

--- a/tests/by-util/test_sha1sum.rs
+++ b/tests/by-util/test_sha1sum.rs
@@ -134,8 +134,7 @@ fn test_check_sha1() {
         .arg("-c")
         .arg(at.subdir.join("testf.sha1"))
         .succeeds()
-        .stdout_is("testf: OK\n")
-        .stderr_is("");
+        .stdout_only("testf: OK\n");
 }
 
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1280,8 +1280,7 @@ fn test_pipe() {
     new_ucmd!()
         .pipe_in("one\ntwo\nfour")
         .succeeds()
-        .stdout_is("four\none\ntwo\n")
-        .stderr_is("");
+        .stdout_only("four\none\ntwo\n");
 }
 
 #[test]
@@ -1304,7 +1303,7 @@ fn test_check() {
             .arg(diagnose_arg)
             .arg("multiple_files.expected")
             .succeeds()
-            .stderr_is("");
+            .no_output();
     }
 }
 
@@ -1323,7 +1322,7 @@ fn test_check_silent() {
             .arg(silent_arg)
             .arg("check_fail.txt")
             .fails()
-            .stdout_is("");
+            .no_output();
         new_ucmd!()
             .arg(silent_arg)
             .arg("empty.txt")

--- a/tests/by-util/test_tac.rs
+++ b/tests/by-util/test_tac.rs
@@ -145,7 +145,7 @@ fn test_before_no_separator() {
 
 #[test]
 fn test_before_empty_file() {
-    new_ucmd!().arg("-b").pipe_in("").succeeds().stdout_is("");
+    new_ucmd!().arg("-b").pipe_in("").succeeds().no_output();
 }
 
 #[test]

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -3603,7 +3603,7 @@ fn test_seek_bytes_forward_outside_file() {
         .arg("+100")
         .arg(FOOBAR_TXT)
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 // Some basic tests for ---presume-input-pipe. These tests build upon the

--- a/tests/by-util/test_tr.rs
+++ b/tests/by-util/test_tr.rs
@@ -729,7 +729,7 @@ fn tr_delete_xdigit_all() {
         .args(&["-d", "[:xdigit:]"])
         .pipe_in("0123456789acbdefABCDEF")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -747,7 +747,7 @@ fn tr_delete_digit_all() {
         .args(&["-d", "[:digit:]"])
         .pipe_in("0123456789")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -765,7 +765,7 @@ fn tr_delete_lower_all() {
         .args(&["-d", "[:lower:]"])
         .pipe_in("abcdefghijklmnopqrstuvwxyz")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -774,7 +774,7 @@ fn tr_delete_upper_all() {
         .args(&["-d", "[:upper:]"])
         .pipe_in("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -783,7 +783,7 @@ fn tr_delete_alpha_all() {
         .args(&["-d", "[:lower:][:upper:]"])
         .pipe_in("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -792,7 +792,7 @@ fn tr_delete_alnum_all() {
         .args(&["-d", "[:alpha:]"])
         .pipe_in("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -801,7 +801,7 @@ fn tr_delete_space_class() {
         .args(&["-d", "[:alnum:]"])
         .pipe_in("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -1081,7 +1081,7 @@ fn tr_ross_translate_complement_squeeze() {
         .args(&["-cs", "[:upper:][:digit:]", "[Z*]"])
         .pipe_in("")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -1108,7 +1108,7 @@ fn tr_ross_translate_overlong() {
         .args(&["-dcs", "[:alnum:]", "[:digit:]"])
         .pipe_in("")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -1117,7 +1117,7 @@ fn tr_ross_translate_squeeze_overlong() {
         .args(&["-dc", "[:lower:]"])
         .pipe_in("")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]
@@ -1126,7 +1126,7 @@ fn tr_ross_translate_squeeze_delete() {
         .args(&["-dc", "[:upper:]"])
         .pipe_in("")
         .succeeds()
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -229,8 +229,7 @@ fn test_odd_number_of_tokens() {
     new_ucmd!()
         .pipe_in("a\n")
         .fails_with_code(1)
-        .stdout_is("")
-        .stderr_is(TSORT_ODD_ERROR);
+        .stderr_only(TSORT_ODD_ERROR);
 }
 
 #[test]
@@ -242,6 +241,5 @@ fn test_only_one_input_file() {
     ucmd.arg("f")
         .arg("g")
         .fails_with_code(1)
-        .stdout_is("")
-        .stderr_is(TSORT_EXTRA_OPERAND_ERROR);
+        .stderr_only(TSORT_EXTRA_OPERAND_ERROR);
 }

--- a/tests/by-util/test_tty.rs
+++ b/tests/by-util/test_tty.rs
@@ -23,7 +23,7 @@ fn test_dev_null_silent() {
         .args(&["-s"])
         .set_stdin(File::open("/dev/null").unwrap())
         .fails_with_code(1)
-        .stdout_is("");
+        .no_output();
 }
 
 #[test]

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -437,7 +437,7 @@ fn test_read_from_directory_error() {
         // wasi-libc may report a different error string than the host libc
         cmd.stderr_contains("wc: .:");
     } else if cfg!(windows) {
-        cmd.stderr_contains(".: Permission denied").stdout_is("");
+        cmd.stderr_contains(".: Permission denied").no_stdout();
     } else {
         cmd.stderr_contains(".: Is a directory")
             .stdout_is("      0       0       0 .\n");
@@ -505,7 +505,7 @@ fn test_files0_disabled_files_argument() {
         .arg("lorem_ipsum.txt")
         .fails()
         .stderr_contains(MSG)
-        .stdout_is("");
+        .no_stdout();
 }
 
 #[test]
@@ -565,7 +565,7 @@ fn test_files0_from_with_stdin_try_read_from_stdin() {
         .pipe_in("-")
         .fails()
         .stderr_contains(MSG)
-        .stdout_is("");
+        .no_stdout();
 }
 
 #[test]

--- a/tests/by-util/test_who.rs
+++ b/tests/by-util/test_who.rs
@@ -111,7 +111,7 @@ fn test_runlevel() {
         ts.ucmd().arg(opt).succeeds().stdout_is(expected_stdout);
 
         #[cfg(not(target_os = "linux"))]
-        ts.ucmd().arg(opt).succeeds().stdout_is("");
+        ts.ucmd().arg(opt).succeeds().no_output();
     }
 }
 


### PR DESCRIPTION
This PR removes all `stderr_is("")` and `stdout_is("")` in the tests and uses the corresponding convenience functions instead.