### PR TITLE
sort: fix for Lines fuse if chunk boundary is exactly at EOF #14126

### DIFF
--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -362,7 +362,6 @@ fn read_to_buffer<T: Read>(
     separator: u8,
 ) -> UResult<(usize, bool)> {
     let mut read_target = &mut buffer[start_offset..];
-    let mut last_file_empty = true;
     let mut newline_search_offset = 0;
     let mut found_newline = false;
     loop {
@@ -398,20 +397,19 @@ fn read_to_buffer<T: Read>(
                 } else {
                     // This file has been fully read.
                     let mut leftover_len = read_target.len();
-                    if !last_file_empty {
-                        // The file was not empty.
-                        let read_len = buffer.len() - leftover_len;
-                        if buffer[read_len - 1] != separator {
-                            // The file did not end with a separator. We have to insert one.
-                            buffer[read_len] = separator;
-                            leftover_len -= 1;
-                        }
-                        let read_len = buffer.len() - leftover_len;
-                        read_target = &mut buffer[read_len..];
+                    // Decide from buffered bytes: a file may span calls, so a 0-byte read can
+                    // still leave an unterminated tail that must be separated from the next file.
+                    let read_len = buffer.len() - leftover_len;
+                    if read_len > 0 && buffer[read_len - 1] != separator {
+                        // The data so far does not end with a separator. We have to insert one.
+                        // `read_target` is non-empty here, so `buffer[read_len]` is in bounds.
+                        buffer[read_len] = separator;
+                        leftover_len -= 1;
                     }
+                    let read_len = buffer.len() - leftover_len;
+                    read_target = &mut buffer[read_len..];
                     if let Some(next_file) = next_files.next() {
                         // There is another file.
-                        last_file_empty = true;
                         *file = next_file?;
                     } else {
                         // This was the last file.
@@ -422,7 +420,6 @@ fn read_to_buffer<T: Read>(
             }
             Ok(n) => {
                 read_target = &mut read_target[n..];
-                last_file_empty = false;
             }
             Err(e) if e.kind() == ErrorKind::Interrupted => {
                 // retry

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1158,6 +1158,20 @@ fn test_multiple_files() {
         .stdout_only_fixture("multiple_files.expected");
 }
 
+/// A file that does not end with a separator must not be fused onto the next file.
+#[test]
+fn test_unterminated_file_not_fused_across_chunk_boundary() {
+    // "a\nb\nc" is 5 bytes, so `-S 5b` puts the chunk boundary exactly at its EOF.
+    for buffer_size in ["1b", "2b", "3b", "4b", "5b", "6b", "7b", "8b", "16b"] {
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.write("first.txt", "a\nb\nc");
+        at.write("second.txt", "z\n");
+        ucmd.args(&["-S", buffer_size, "first.txt", "second.txt"])
+            .succeeds()
+            .stdout_only("a\nb\nc\nz\n");
+    }
+}
+
 #[test]
 fn test_merge_interleaved() {
     new_ucmd!()


### PR DESCRIPTION
The flag was wrong: it's initialised true on every call to read_to_buffer, but a file spans several calls.

Call 1 consumes "a\nb\nc\n" and leaves "rm" in carry_over; call 2 reads 0 bytes from the already-exhausted first file, sees the freshly-reset flag, concludes the file was empty, and skips the separator.

So "rm" and " -rf" are parsed as one line.

Fixes #14126 