### PR TITLE
*sum: hide the legacy --text from document

### DIFF
--- a/src/uu/checksum_common/locales/en-US.ftl
+++ b/src/uu/checksum_common/locales/en-US.ftl
@@ -5,7 +5,6 @@ ck-common-help-algorithm = select the digest type to use. See DIGEST below
 ck-common-help-untagged = create a reversed style checksum, without digest type
 ck-common-help-tag-default = create a BSD style checksum (default)
 ck-common-help-tag = create a BSD style checksum
-ck-common-help-text = read in text mode (default)
 ck-common-help-length = digest length in bits; must not exceed the max size and must be a multiple of 8 for blake2b; must be 224, 256, 384, or 512 for sha2 or sha3
 ck-common-help-check = read checksums from the FILEs and check them
 ck-common-help-base64 = emit base64-encoded digests, not hexadecimal

--- a/src/uu/checksum_common/locales/fr-FR.ftl
+++ b/src/uu/checksum_common/locales/fr-FR.ftl
@@ -5,7 +5,6 @@ ck-common-help-algorithm = sélectionner le type de condensé à utiliser. Voir 
 ck-common-help-untagged = créer une somme de contrôle de style inversé, sans type de condensé
 ck-common-help-tag-default = créer une somme de contrôle de style BSD (par défaut)
 ck-common-help-tag = créer une somme de contrôle de style BSD
-ck-common-help-text = lire en mode texte (par défaut)
 ck-common-help-length = longueur du condensé en bits ; ne doit pas dépasser le maximum pour l'algorithme blake2 et doit être un multiple de 8
 ck-common-help-raw = émettre un condensé binaire brut, pas hexadécimal
 ck-common-help-strict = sortir avec un code non-zéro pour les lignes de somme de contrôle mal formatées

--- a/src/uu/checksum_common/src/cli.rs
+++ b/src/uu/checksum_common/src/cli.rs
@@ -44,7 +44,7 @@ pub trait ChecksumCommand {
 
     fn with_binary(self) -> Self;
 
-    fn with_text(self, is_default: bool) -> Self;
+    fn with_text(self) -> Self;
 
     fn with_tag(self, is_default: bool) -> Self;
 
@@ -136,19 +136,15 @@ impl ChecksumCommand for Command {
         )
     }
 
-    fn with_text(self, is_default: bool) -> Self {
-        let mut arg = Arg::new(options::TEXT)
-            .long(options::TEXT)
-            .short('t')
-            .action(ArgAction::SetTrue);
-
-        arg = if is_default {
-            arg.help(translate!("ck-common-help-text"))
-        } else {
-            arg.hide(true)
-        };
-
-        self.arg(arg)
+    fn with_text(self) -> Self {
+        self.arg(
+            Arg::new(options::TEXT)
+                .long(options::TEXT)
+                .short('t')
+                // deliberately hide the unrecommended feature from all *sum even GNU hides it only from cksum
+                .hide(true)
+                .action(ArgAction::SetTrue),
+        )
     }
 
     fn with_tag(self, default: bool) -> Self {

--- a/src/uu/checksum_common/src/lib.rs
+++ b/src/uu/checksum_common/src/lib.rs
@@ -123,7 +123,7 @@ pub fn standalone_checksum_app_with_length(about: String, usage: String) -> Comm
         .with_check_and_opts()
         .with_length()
         .with_tag(false)
-        .with_text(true)
+        .with_text()
         .with_zero()
 }
 
@@ -134,7 +134,7 @@ pub fn standalone_checksum_app(about: String, usage: String) -> Command {
         .with_binary()
         .with_check_and_opts()
         .with_tag(false)
-        .with_text(true)
+        .with_text()
         .with_zero()
 }
 

--- a/src/uu/cksum/src/cksum.rs
+++ b/src/uu/cksum/src/cksum.rs
@@ -129,7 +129,7 @@ pub fn uu_app() -> Command {
         .with_raw()
         .with_check_and_opts()
         .with_base64()
-        .with_text(false)
+        .with_text()
         .with_binary()
         .with_zero()
         .with_debug()


### PR DESCRIPTION
`--text` is legacy feature. So not worth to docunent it. https://github.com/uutils/coreutils/issues/9168#issuecomment-3501551300