### PR TITLE
pr: rename `--column` to `--columns`

### DIFF
--- a/src/uu/pr/locales/en-US.ftl
+++ b/src/uu/pr/locales/en-US.ftl
@@ -57,7 +57,7 @@ pr-help-across =
                   across the page in a  round-robin  order (for example, when column is 2, the
                   first input line heads column 1, the second heads column 2, the third is the
                   second line in column 1, and so on).
-pr-help-column =
+pr-help-columns =
   Produce multi-column output that is arranged in column columns
                   (the default shall be 1) and is written down each column  in  the order in which
                   the text is received from the input file. This option should not be used with -m.

--- a/src/uu/pr/locales/fr-FR.ftl
+++ b/src/uu/pr/locales/fr-FR.ftl
@@ -55,7 +55,7 @@ pr-help-across =
                   à travers la page dans un ordre round-robin (par exemple, quand colonne est 2,
                   la première ligne d'entrée va en tête de colonne 1, la seconde va en tête de colonne 2,
                   la troisième est la seconde ligne en colonne 1, et ainsi de suite).
-pr-help-column =
+pr-help-columns =
   Produire une sortie multi-colonnes qui est arrangée en colonnes colonnes
                   (la valeur par défaut sera 1) et est écrite dans chaque colonne dans l'ordre
                   dans lequel le texte est reçu du fichier d'entrée. Cette option ne doit pas être

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -54,7 +54,7 @@ mod options {
     pub const PAGE_WIDTH: &str = "page-width";
     pub const ACROSS: &str = "across";
     pub const COLUMN_DOWN: &str = "column-down";
-    pub const COLUMN: &str = "column";
+    pub const COLUMNS: &str = "columns";
     pub const COLUMN_CHAR_SEPARATOR: &str = "separator";
     pub const COLUMN_STRING_SEPARATOR: &str = "sep-string";
     pub const MERGE: &str = "merge";
@@ -314,10 +314,10 @@ pub fn uu_app() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::new(options::COLUMN)
-                .long(options::COLUMN)
-                .help(translate!("pr-help-column"))
-                .value_name("column"),
+            Arg::new(options::COLUMNS)
+                .long(options::COLUMNS)
+                .help(translate!("pr-help-columns"))
+                .value_name("columns"),
         )
         .arg(
             Arg::new(options::COLUMN_CHAR_SEPARATOR)
@@ -588,7 +588,7 @@ fn build_options(
 
     let is_merge_mode = matches.get_flag(options::MERGE);
 
-    if is_merge_mode && matches.contains_id(options::COLUMN) {
+    if is_merge_mode && matches.contains_id(options::COLUMNS) {
         return Err(PrError::EncounteredErrors {
             msg: translate!("pr-error-column-merge-conflict"),
         });
@@ -959,20 +959,20 @@ fn build_options(
     let start_column_option = match res {
         Some(Ok(0)) => {
             return Err(PrError::EncounteredErrors {
-                msg: "invalid --column argument '0'".to_string(),
+                msg: "invalid --columns argument '0'".to_string(),
             });
         }
         Some(res) => Some(res?),
         None => None,
     };
 
-    // --column has more priority than -column
+    // --columns has more priority than -column
 
     let column_option_value =
-        match parse_usize(matches, options::COLUMN, "invalid number of columns") {
+        match parse_usize(matches, options::COLUMNS, "invalid number of columns") {
             Some(Ok(0)) => {
                 return Err(PrError::EncounteredErrors {
-                    msg: "invalid --column argument '0'".to_string(),
+                    msg: "invalid --columns argument '0'".to_string(),
                 });
             }
             Some(res) => Some(res?),

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -319,10 +319,10 @@ fn test_with_stdin() {
 }
 
 #[test]
-fn test_with_column() {
+fn test_with_columns() {
     let test_file_path = "column.log";
     let expected_test_file_path = "column.log.expected";
-    for arg in ["-3", "--column=3"] {
+    for arg in ["-3", "--columns=3"] {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
@@ -336,19 +336,19 @@ fn test_with_column() {
 }
 
 #[test]
-fn test_with_column_across_option() {
+fn test_with_columns_and_across_option() {
     let test_file_path = "column.log";
     let expected_test_file_path = "column_across.log.expected";
     let mut scenario = new_ucmd!();
     let value = file_last_modified_time(&scenario, test_file_path);
     scenario
-        .args(&["--pages=3:5", "--column=3", "-a", "-n", test_file_path])
+        .args(&["--pages=3:5", "--columns=3", "-a", "-n", test_file_path])
         .succeeds()
         .stdout_is_templated_fixture(expected_test_file_path, &[("{last_modified_time}", &value)]);
 }
 
 #[test]
-fn test_with_column_across_option_and_column_separator() {
+fn test_with_columns_across_option_and_column_separator() {
     let test_file_path = "column.log";
     for (arg, expected) in [
         ("-s|", "column_across_sep.log.expected"),
@@ -357,7 +357,14 @@ fn test_with_column_across_option_and_column_separator() {
         let mut scenario = new_ucmd!();
         let value = file_last_modified_time(&scenario, test_file_path);
         scenario
-            .args(&["--pages=3:5", "--column=3", arg, "-a", "-n", test_file_path])
+            .args(&[
+                "--pages=3:5",
+                "--columns=3",
+                arg,
+                "-a",
+                "-n",
+                test_file_path,
+            ])
             .succeeds()
             .stdout_is_templated_fixture(expected, &[("{last_modified_time}", &value)]);
     }
@@ -408,10 +415,10 @@ fn test_with_mpr() {
 }
 
 #[test]
-fn test_with_mpr_and_column_options() {
+fn test_with_mpr_and_columns_options() {
     let test_file_path = "column.log";
     new_ucmd!()
-        .args(&["--column=2", "-m", "-n", test_file_path])
+        .args(&["--columns=2", "-m", "-n", test_file_path])
         .fails()
         .stderr_only("pr: cannot specify number of columns when printing in parallel\n");
 
@@ -432,7 +439,7 @@ fn test_with_offset_space_option() {
             "-o",
             "5",
             "--pages=3:5",
-            "--column=3",
+            "--columns=3",
             "-a",
             "-n",
             test_file_path,
@@ -511,7 +518,7 @@ fn test_column_width_too_large() {
 fn test_column_count_too_large() {
     let arg = "9999999999999999999";
     new_ucmd!()
-        .args(&["--column", arg])
+        .args(&["--columns", arg])
         .fails_with_code(1)
         .stderr_is(format!(
             "pr: invalid number of columns: '{arg}': Value too large for defined data type\n"
@@ -1147,9 +1154,9 @@ fn test_expand_tab_does_not_consume_next_argument() {
 #[test]
 fn test_zero_columns() {
     new_ucmd!()
-        .arg("--column=0")
+        .arg("--columns=0")
         .fails_with_code(1)
-        .stderr_contains("pr: invalid --column argument '0'");
+        .stderr_contains("pr: invalid --columns argument '0'");
 }
 
 #[test]
@@ -1157,7 +1164,7 @@ fn test_zero_columns_shortcut() {
     new_ucmd!()
         .arg("-0")
         .fails_with_code(1)
-        .stderr_contains("pr: invalid --column argument '0'");
+        .stderr_contains("pr: invalid --columns argument '0'");
 }
 
 #[test]


### PR DESCRIPTION
This PR renames the `--column` option to `--columns` to match GNU `pr`.