### PR TITLE
tee: align error message with GNU

### DIFF
--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -7,12 +7,11 @@
 
 use std::ffi::OsString;
 use std::fs::OpenOptions;
-use std::io::{self, Error, ErrorKind, Write, stderr};
+use std::io::{self, Error, ErrorKind, Write};
 use std::path::PathBuf;
 use uucore::display::Quotable;
 use uucore::error::{UResult, strip_errno};
-use uucore::show_error;
-use uucore::translate;
+use uucore::{show_error, translate};
 
 mod cli;
 pub use crate::cli::uu_app;
@@ -215,9 +214,8 @@ impl MultiWriter {
                 Ok(slice) => self.write_flush(slice)?,
                 Err(e) if e.kind() == ErrorKind::Interrupted => {}
                 Err(e) => {
-                    let _ = writeln!(
-                        stderr(),
-                        "tee: {}",
+                    show_error!(
+                        "{}",
                         translate!("tee-error-stdin", "error" => strip_errno(&e))
                     );
                     return Err(());
@@ -271,7 +269,7 @@ fn process_error(
     if ignore_pipe && e.kind() == ErrorKind::BrokenPipe {
         return Ok(());
     }
-    let _ = writeln!(stderr(), "{}: {e}", writer.name.maybe_quote());
+    show_error!("{}: {}", writer.name.maybe_quote(), strip_errno(&e));
     if let Some(OutputErrorMode::Exit | OutputErrorMode::ExitNoPipe) = mode {
         Err(())
     } else {

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -669,7 +669,7 @@ mod linux_only {
             .pipe_in(&content[..])
             .fails()
             .stdout_contains(&content)
-            .stderr_contains("No space left on device");
+            .stderr_is("tee: /dev/full: No space left on device\n");
 
         assert_eq!(at.read(file_out), content);
     }


### PR DESCRIPTION
`echo 1|tee /dev/full` should have `tee:` and not have errno.