### PR TITLE
sort: run read_error_message only on gnu glibc linux

### DIFF
--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1249,7 +1249,8 @@ fn test_merge_write_error_does_not_panic() {
 // A read error must be reported with context and without the raw io::Error suffix.
 // It used to print `sort: Input/output error (os error 5)`.
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg_attr(wasi_runner, ignore)]
 fn test_read_error_message() {
     // Reading /proc/self/mem from offset 0 fails with EIO.
     new_ucmd!()


### PR DESCRIPTION
this PR aims to fix https://github.com/uutils/coreutils/actions/runs/32907302905/job/97998830625 introduced in pr #14005