### PR TITLE
sort: support attached '-t=' to select '=' as field separator

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2113,6 +2113,23 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<OsString> = args.collect();
     let key_args = uucore::diagnostics::capture(&args);
 
+    // GNU `sort` supports `-t=` to set the field separator to `=`.
+    // Clap strips the first `=` after a short option (see
+    // https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242,
+    // and the same rewrite in `cut`), so rewrite every attached `-t<chars>`
+    // argument to its long form, which preserves the separator verbatim.
+    let args = args.into_iter().map(|x| {
+        // Non-UTF-8 separators are rejected later anyway, so lossy conversion
+        // here only affects arguments that cannot become a valid separator.
+        let as_str = x.to_string_lossy();
+        if as_str.starts_with("-t") && as_str.chars().count() > 2 {
+            OsString::from(format!("--{}={}", options::SEPARATOR, &as_str[2..]))
+        } else {
+            x
+        }
+    });
+    let args: Vec<OsString> = args.collect();
+
     let (processed_args, mut legacy_warnings) = preprocess_legacy_args(args);
     if !legacy_warnings.is_empty() {
         index_legacy_warnings(&processed_args, &mut legacy_warnings);

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1798,6 +1798,37 @@ fn test_separator_null() {
 }
 
 #[test]
+fn test_separator_attached_equals() {
+    // `-t=` must select `=` itself as the separator (clap strips a leading
+    // `=` from attached short-option values), matching GNU sort. #14120
+    new_ucmd!()
+        .args(&["-t=", "-k", "2"])
+        .pipe_in("a=b=c\nb=a=d\n")
+        .succeeds()
+        .stdout_only("b=a=d\na=b=c\n");
+}
+
+#[test]
+fn test_separator_attached_equals_double() {
+    // `-t==` selects the two-character separator `==`, which GNU rejects.
+    new_ucmd!()
+        .args(&["-t==", "-k", "2"])
+        .pipe_in("a=b=c\n")
+        .fails()
+        .stderr_contains("separator must be exactly one character long: '=='");
+}
+
+#[test]
+fn test_separator_attached_equals_multi_char() {
+    // `-t=a` selects the two-character separator `=a`, which GNU rejects.
+    new_ucmd!()
+        .args(&["-t=a", "-k", "2"])
+        .pipe_in("a=b=c\n")
+        .fails()
+        .stderr_contains("separator must be exactly one character long: '=a'");
+}
+
+#[test]
 fn test_output_is_input() {
     let input = "a\nb\nc\n";
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
Fixes #14120

## Problem

`sort -t= -k2` failed with `separator must be exactly one character long: ''`, while GNU sort accepts it (separator `=`). The separate form `-t =` worked.

## Cause

Clap strips the first `=` after a short option, so the attached value in `-t=` arrived at the separator handling as an empty string. GNU getopt passes everything after the option letter through verbatim.

This is the same clap limitation `cut` already works around for `-d=` (see #2424 and the rewrite in `cut`'s `uumain`).

## Fix

Rewrite attached `-t<chars>` arguments to their long form (`--field-separator=<chars>`) before clap parsing, which preserves `=` characters verbatim:

| invocation | separator before | separator after | matches GNU |
|---|---|---|---|
| `-t=` | ❌ error `''` | ✅ `=` | ✅ |
| `-t==` | ✅ error `'=='` | ✅ error `'=='` | ✅ |
| `-t=a` | ⚠️ silently used `a` | ✅ error `'=a'` | ✅ |

Note the third row: previously `-t=a` silently used `a` as the separator — a silent divergence from GNU that this fix also removes. Separate-form `-t =` and long-form `--field-separator=` are untouched.

## Testing

- 3 new tests in `test_sort.rs`: attached `-t=` sorting correctly, plus the two multi-character error cases matching GNU
- Full `cargo test --test tests`: 4698 passed (the one failure, `test_human_numeric_blank_thousands_sep_locale`, fails identically on clean master in this environment — locale-dependent, unrelated)
- `cargo clippy -p uu_sort` and `cargo fmt` clean
