### PR TITLE
pathchk: prepend pathchk: to error message & improve error for long name

### DIFF
--- a/src/uu/pathchk/locales/en-US.ftl
+++ b/src/uu/pathchk/locales/en-US.ftl
@@ -9,10 +9,10 @@ pathchk-help-portability = check for all POSIX systems (equivalent to -p -P)
 # Error messages
 pathchk-error-missing-operand = missing operand
 pathchk-error-empty-file-name = empty file name
-pathchk-error-posix-path-length-exceeded = { $path }: limit { $limit } exceeded by length { $length } of file name
-pathchk-error-posix-name-length-exceeded = { $component }: limit { $limit } exceeded by length { $length } of file name component
+pathchk-error-posix-path-length-exceeded = limit { $limit } exceeded by length { $length } of file name { $path }
+pathchk-error-posix-name-length-exceeded = limit { $limit } exceeded by length { $length } of file name component { $component }
 pathchk-error-leading-hyphen = leading hyphen in file name component { $component }
-pathchk-error-path-length-exceeded = { $path }: limit { $limit } exceeded by length { $length } of file name
-pathchk-error-name-length-exceeded = { $component }: limit { $limit } exceeded by length { $length } of file name component
-pathchk-error-empty-path-not-found = pathchk: '': No such file or directory
+pathchk-error-path-length-exceeded = limit { $limit } exceeded by length { $length } of file name { $path }
+pathchk-error-name-length-exceeded = limit { $limit } exceeded by length { $length } of file name component { $component }
+pathchk-error-empty-path-not-found = '': No such file or directory
 pathchk-error-nonportable-character = nonportable character '{ $character }' in file name component { $component }

--- a/src/uu/pathchk/locales/fr-FR.ftl
+++ b/src/uu/pathchk/locales/fr-FR.ftl
@@ -9,10 +9,10 @@ pathchk-help-portability = vérifier pour tous les systèmes POSIX (équivalent 
 # Messages d'erreur
 pathchk-error-missing-operand = opérande manquant
 pathchk-error-empty-file-name = nom de fichier vide
-pathchk-error-posix-path-length-exceeded = { $path }: limite { $limit } dépassée par la longueur { $length } du nom de fichier
-pathchk-error-posix-name-length-exceeded = { $component }: limite { $limit } dépassée par la longueur { $length } du composant de nom de fichier
+pathchk-error-posix-path-length-exceeded = limite { $limit } dépassée par la longueur { $length } du nom de fichier { $path }
+pathchk-error-posix-name-length-exceeded = limite { $limit } dépassée par la longueur { $length } du composant de nom de fichier { $component }
 pathchk-error-leading-hyphen = tiret en début dans le composant de nom de fichier { $component }
-pathchk-error-path-length-exceeded = { $path }: limite { $limit } dépassée par la longueur { $length } du nom de fichier
-pathchk-error-name-length-exceeded = { $component }: limite { $limit } dépassée par la longueur { $length } du composant de nom de fichier
-pathchk-error-empty-path-not-found = pathchk: '' : Aucun fichier ou répertoire de ce type
+pathchk-error-path-length-exceeded = limite { $limit } dépassée par la longueur { $length } du nom de fichier { $path }
+pathchk-error-name-length-exceeded = limite { $limit } dépassée par la longueur { $length } du composant de nom de fichier { $component }
+pathchk-error-empty-path-not-found = '' : Aucun fichier ou répertoire de ce type
 pathchk-error-nonportable-character = caractère non portable '{ $character }' dans le composant de nom de fichier { $component }

--- a/src/uu/pathchk/src/pathchk.rs
+++ b/src/uu/pathchk/src/pathchk.rs
@@ -8,7 +8,7 @@
 use clap::{Arg, ArgAction, Command};
 use std::ffi::OsString;
 use std::fs;
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 use uucore::display::Quotable;
 use uucore::error::strip_errno;
 use uucore::error::{UResult, UUsageError, set_exit_code};
@@ -146,26 +146,20 @@ fn check_basic(path: &[String]) -> bool {
     let total_len = joined_path.len();
     // path length
     if total_len > POSIX_PATH_MAX {
-        writeln!(
-            std::io::stderr(),
+        show_error!(
             "{}",
             translate!("pathchk-error-posix-path-length-exceeded", "limit" => POSIX_PATH_MAX, "length" => total_len, "path" => joined_path)
         );
         return false;
     } else if total_len == 0 {
-        writeln!(
-            std::io::stderr(),
-            "{}",
-            translate!("pathchk-error-empty-file-name")
-        );
+        show_error!("{}", translate!("pathchk-error-empty-file-name"));
         return false;
     }
     // components: character portability and length
     for p in path {
         let component_len = p.len();
         if component_len > POSIX_NAME_MAX {
-            writeln!(
-                std::io::stderr(),
+            show_error!(
                 "{}",
                 translate!("pathchk-error-posix-name-length-exceeded", "limit" => POSIX_NAME_MAX, "length" => component_len, "component" => p.quote())
             );
@@ -184,8 +178,7 @@ fn check_extra(path: &[String]) -> bool {
     // components: leading hyphens
     for p in path {
         if p.starts_with('-') {
-            writeln!(
-                std::io::stderr(),
+            show_error!(
                 "{}",
                 translate!("pathchk-error-leading-hyphen", "component" => p.quote())
             );
@@ -194,11 +187,7 @@ fn check_extra(path: &[String]) -> bool {
     }
     // path length
     if path.join("/").is_empty() {
-        writeln!(
-            std::io::stderr(),
-            "{}",
-            translate!("pathchk-error-empty-file-name")
-        );
+        show_error!("{}", translate!("pathchk-error-empty-file-name"));
         return false;
     }
     true
@@ -210,8 +199,7 @@ fn check_default(path: &[String]) -> bool {
     let total_len = joined_path.len();
     // path length
     if total_len > PATH_MAX {
-        writeln!(
-            std::io::stderr(),
+        show_error!(
             "{}",
             translate!("pathchk-error-path-length-exceeded", "limit" => PATH_MAX, "length" => total_len, "path" => joined_path.quote())
         );
@@ -223,11 +211,7 @@ fn check_default(path: &[String]) -> bool {
         // but some non-POSIX hosts do (as an alias for "."),
         // so allow "" if `symlink_metadata` (corresponds to `lstat`) does.
         if fs::symlink_metadata(&joined_path).is_err() {
-            writeln!(
-                std::io::stderr(),
-                "{}",
-                translate!("pathchk-error-empty-path-not-found")
-            );
+            show_error!("{}", translate!("pathchk-error-empty-path-not-found"));
             return false;
         }
     }
@@ -236,8 +220,7 @@ fn check_default(path: &[String]) -> bool {
     for p in path {
         let component_len = p.len();
         if component_len > FILENAME_MAX {
-            writeln!(
-                std::io::stderr(),
+            show_error!(
                 "{}",
                 translate!("pathchk-error-name-length-exceeded", "limit" => FILENAME_MAX, "length" => component_len, "component" => p.quote())
             );
@@ -253,13 +236,10 @@ fn check_searchable(path: &str) -> bool {
     // we use lstat, just like the original implementation
     match fs::symlink_metadata(path) {
         Ok(_) => true,
+        Err(e) if e.kind() == ErrorKind::NotFound => true,
         Err(e) => {
-            if e.kind() == ErrorKind::NotFound {
-                true
-            } else {
-                show_error!("{}: {}", path, strip_errno(&e));
-                false
-            }
+            show_error!("{}: {}", path, strip_errno(&e));
+            false
         }
     }
 }
@@ -270,8 +250,7 @@ fn check_portable_chars(path_segment: &str) -> bool {
     for (i, ch) in path_segment.as_bytes().iter().enumerate() {
         if !VALID_CHARS.contains(ch) {
             let invalid = path_segment[i..].chars().next().unwrap();
-            writeln!(
-                std::io::stderr(),
+            show_error!(
                 "{}",
                 translate!("pathchk-error-nonportable-character", "character" => invalid, "component" => path_segment.quote())
             );


### PR DESCRIPTION
- long name should appear after error message for readability
- prepend `pathchk:` as GNU does