### PR TITLE
paste, join: support attached '-d=' / '-t=' single-'=' separators

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -844,8 +844,24 @@ fn parse_settings(matches: &clap::ArgMatches, diag_args: Option<&[OsString]>) ->
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // The command line is kept for the caret in `-o` diagnostics, which needs
     // the list as typed.
-    let (matches, diag_args) =
-        uucore::clap_localization::handle_clap_result_with_diagnostics(uu_app(), args.collect())?;
+    // GNU `join` supports `-t=` to use `=` as the field separator.
+    // Clap strips a leading `=` from an attached short-option value, so split
+    // attached `-t<chars>` into `-t <chars>` (which clap passes through
+    // verbatim). The caret diagnostics keep echoing the arguments as typed.
+    // See https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
+    let raw: Vec<OsString> = args.collect();
+    let diag_args = uucore::diagnostics::capture(&raw);
+    let args = raw.into_iter().flat_map(|x| {
+        let as_str = x.to_string_lossy();
+        if as_str.starts_with("-t") && as_str.len() > 2 {
+            vec![OsString::from("-t"), OsString::from(&as_str[2..])]
+        } else {
+            vec![x]
+        }
+    });
+
+    let matches =
+        uucore::clap_localization::handle_clap_result(uu_app(), args.collect::<Vec<OsString>>())?;
 
     let mut opts = CollatorOptions::default();
     opts.alternate_handling = Some(AlternateHandling::Shifted);

--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -27,6 +27,22 @@ mod options {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    // GNU `paste` supports `-d=` to use `=` as a delimiter.
+    // Clap parsing is limited in this situation, see:
+    // https://github.com/uutils/coreutils/issues/2424#issuecomment-863825242
+    // (same rewrite as in `cut` and `sort`)
+    let args: Vec<OsString> = args
+        .into_iter()
+        .map(|x| {
+            let as_str = x.to_string_lossy();
+            if as_str.starts_with("-d") && as_str.len() > 2 {
+                OsString::from(format!("--{}={}", options::DELIMITER, &as_str[2..]))
+            } else {
+                x
+            }
+        })
+        .collect();
+
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
 
     let serial = matches.get_flag(options::SERIAL);

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -805,3 +805,16 @@ join: invalid field number: 'x'
             .stderr_is("join: invalid field number: 'x'\n");
     }
 }
+
+#[test]
+fn test_separator_attached_equals() {
+    // `-t=` must select `=` itself as the separator; clap strips a leading
+    // `=` from attached short-option values, hence the rewrite. #14120
+    let ts = TestScenario::new(util_name!());
+    ts.fixtures.write("f1", "1=a\n2=b\n");
+    ts.fixtures.write("f2", "1=b\n2=c\n");
+    ts.ucmd()
+        .args(&["-t=", "f1", "f2"])
+        .succeeds()
+        .stdout_only("1=a=b\n2=b=c\n");
+}

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -123,6 +123,14 @@ const EXAMPLE_DATA: &[TestData] = &[
         ins: &["1\na\n", "2\nb\n"],
         out: "1💣2\na💣b\n",
     },
+    // `-d=` must select `=` itself as a delimiter; clap strips a leading `=`
+    // from attached short-option values, hence the rewrite. #14120
+    TestData {
+        name: "equals-delim-attached",
+        args: &["-d="],
+        ins: &["1\na\n", "2\nb\n"],
+        out: "1=2\na=b\n",
+    },
     TestData {
         name: "multibyte-delim-serial",
         args: &["-d", "💣", "-s"],


### PR DESCRIPTION
## Problem

While fixing #14120 (`sort -t=`), a systematic check of other utilities with single-character separator flags found the same clap limitation still unhandled in two more places:

| command | expected (GNU) | actual before |
|---|---|---|
| `paste -d= f1 f2` | `a=x` / `b=y` | `ax` / `by` — delimiter silently lost |
| `join -t= f1 f2` | merged on `=` | **empty output** — no rows matched |

Clap strips the first `=` after a short option, so the separator arrived as an empty string. `cut` already works around this for `-d=` (#2424), and #14144 does it for `sort -t=`.

## Fix

- **paste**: rewrite attached `-d<chars>` to `--delimiters=<chars>` before parsing
- **join**: split attached `-t<chars>` into `-t <chars>` (join's `-t` has no long form; the separate form passes through verbatim). Caret diagnostics keep echoing the arguments as typed, per the guidance in `clap_localization.rs`.

Both rewrites preserve separators containing further `=` characters, and separate-form usage (`paste -d =`, `join -t =`) is untouched.

## Testing

- paste: new `equals-delim-attached` case in the EXAMPLE_DATA table (`1=2`, `a=b`)
- join: new `test_separator_attached_equals` asserting GNU output byte-exact (`1=a=b`, `2=b=c`)
- Full suite: 4702 passed; the only failure (`test_human_numeric_blank_thousands_sep_locale`) fails identically on clean master in this environment
- clippy and rustfmt clean for both crates
