### PR TITLE
sort: accept musl's EIO text in read_error_message test

### DIFF
--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1249,14 +1249,20 @@ fn test_merge_write_error_does_not_panic() {
 // A read error must be reported with context and without the raw io::Error suffix.
 // It used to print `sort: Input/output error (os error 5)`.
 #[test]
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(target_os = "linux")]
 #[cfg_attr(wasi_runner, ignore)]
 fn test_read_error_message() {
     // Reading /proc/self/mem from offset 0 fails with EIO.
-    new_ucmd!()
-        .arg("/proc/self/mem")
-        .fails_with_code(2)
-        .stderr_only("sort: read failed: Input/output error\n");
+    let result = new_ucmd!().arg("/proc/self/mem").fails_with_code(2);
+    result.no_stdout();
+    // The strerror text for EIO differs between C libraries: glibc says
+    // "Input/output error" while musl says "I/O error".
+    let stderr = result.stderr_str();
+    assert!(
+        stderr == "sort: read failed: Input/output error\n"
+            || stderr == "sort: read failed: I/O error\n",
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The strerror text for EIO differs between C libraries: glibc says "Input/output error" while musl says "I/O error". Accept both and re-enable the test on non-glibc Linux targets.