### PR TITLE
printf: fix for \c inside %b 

### DIFF
--- a/src/uucore/src/lib/features/format/mod.rs
+++ b/src/uucore/src/lib/features/format/mod.rs
@@ -244,10 +244,9 @@ impl<C: FormatChar> FormatItem<C> {
         args: &mut FormatArguments,
     ) -> Result<ControlFlow<()>, FormatError> {
         match self {
-            Self::Spec(spec) => spec.write(writer, args)?,
-            Self::Char(c) => return c.write(writer).map_err(FormatError::IoError),
+            Self::Spec(spec) => spec.write(writer, args),
+            Self::Char(c) => c.write(writer).map_err(FormatError::IoError),
         }
-        Ok(ControlFlow::Continue(()))
     }
 }
 

--- a/src/uucore/src/lib/features/format/spec.rs
+++ b/src/uucore/src/lib/features/format/spec.rs
@@ -343,7 +343,8 @@ impl Spec {
         &self,
         mut writer: impl Write,
         args: &mut FormatArguments,
-    ) -> Result<(), FormatError> {
+    ) -> Result<ControlFlow<()>, FormatError> {
+        let mut control_flow = ControlFlow::Continue(());
         match self {
             Self::Char {
                 width,
@@ -391,7 +392,9 @@ impl Spec {
                     match c.write(&mut parsed)? {
                         ControlFlow::Continue(()) => {}
                         ControlFlow::Break(()) => {
-                            // TODO: This should break the _entire execution_ of printf
+                            // A `\c` inside the argument stops output for the
+                            // rest of the printf invocation, not just this spec.
+                            control_flow = ControlFlow::Break(());
                             break;
                         }
                     }
@@ -496,7 +499,8 @@ impl Spec {
                 .fmt(writer, &f)
                 .map_err(FormatError::IoError)
             }
-        }
+        }?;
+        Ok(control_flow)
     }
 }
 

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -674,6 +674,16 @@ fn stop_after_additional_escape() {
 }
 
 #[test]
+fn stop_after_additional_escape_in_b_string() {
+    // A `\c` inside a %b argument must stop the entire invocation, not just
+    // that argument's own expansion.
+    new_ucmd!()
+        .args(&["A%bB\\n", "x\\cy"])
+        .succeeds()
+        .stdout_only("Ax");
+}
+
+#[test]
 fn sub_float_leading_zeroes() {
     new_ucmd!()
         .args(&["%010f", "1"])


### PR DESCRIPTION
changed Spec::write's return type to Result<ControlFlow<()>, FormatError> so it can report the break, and updated FormatItem::write to forward that signal instead of hardcoding Continue.

Fixes #14164

