### PR TITLE
date: reject a trailing timezone when the input already has one

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -1039,8 +1039,12 @@ fn resolve_tz_abbreviation(word: &str) -> Option<TimeZone> {
 /// (e.g. "10:30 EST").
 ///
 /// If a trailing abbreviation is found and the rest of the string is a parsable
-/// date, returns `Some(Zoned)`. Returns `None` if no abbreviation is detected or
-/// if parsing fails, indicating that standard parsing should be attempted.
+/// date that could still legally take a timezone, returns `Some(Zoned)`.
+///
+/// Returns `None` when no abbreviation is detected, when parsing fails, or when
+/// the remainder already carries zone information or cannot take a zone at all
+/// (GNU `date` rejects those). In every `None` case the caller should fall back
+/// to standard parsing, which reports the error.
 fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S, now: &Zoned) -> Option<Zoned> {
     let s = date_str.as_ref();
 
@@ -1050,21 +1054,32 @@ fn try_parse_with_abbreviation<S: AsRef<str>>(date_str: S, now: &Zoned) -> Optio
 
     let date_part = s.trim_end_matches(last_word).trim();
 
-    // Reject inputs that specify a timezone twice, e.g. "EST EST" or "EST PST":
-    // GNU `date` considers these invalid. If what remains after stripping the
-    // trailing abbreviation is itself a bare timezone abbreviation, don't rescue
-    // it here; let the standard parser reject the whole string.
-    if date_part
-        .split_whitespace()
-        .last()
-        .is_some_and(|w| resolve_tz_abbreviation(w).is_some())
-    {
+    // GNU rejects "@0 EST": a timestamp cannot take a timezone.
+    if date_part.starts_with('@') {
         return None;
     }
 
     // Parse in the target timezone so "10:30 EDT" means 10:30 in EDT.
     let parsed = parse_datetime::parse_datetime_at_date(now.clone(), date_part).ok()?;
-    let zoned = parsed.into_zoned()?.datetime().to_zoned(tz).ok()?;
+    let zoned = parsed.into_zoned()?;
+
+    // `parse_datetime` returns the zone the input named, or `now`'s when it named
+    // none, so a mismatch means `date_part` carries one of its own.
+    if zoned.time_zone() != now.time_zone() {
+        return None;
+    }
+
+    // That check cannot see a zone whose offset equals `now`'s ("12:00 UTC EST"
+    // under `-u`). Gated so the common case stays at one parse: `-f` runs this
+    // once per line.
+    let names_zone = date_part.contains('+')
+        || date_part.contains(|c: char| c.is_ascii_alphabetic())
+        || date_part.split_whitespace().any(|w| w.starts_with('-'));
+    if names_zone {
+        parse_datetime::parse_datetime_at_date(now.clone(), format!("{date_part} EST")).ok()?;
+    }
+
+    let zoned = zoned.datetime().to_zoned(tz).ok()?;
 
     // The trailing abbreviation only describes the *input* timezone. For display,
     // re-zone to the system timezone (i.e. `now`'s zone, which is UTC under `-u`).

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
-// spell-checker: ignore: AEDT AEST EEST NZDT NZST Kolkata Iseconds févr février janv janvier mercredi samedi sommes juin décembre Januar Juni Dezember enero junio diciembre gennaio giugno dicembre junho dezembro lundi dimanche Montag Sonntag Samstag sábado febr MEST KST uueuu ueuu vasárnap június január distros
+// spell-checker: ignore: AEDT AEST EEST NZDT NZST Kolkata Iseconds févr février janv janvier mercredi samedi sommes juin décembre Januar Juni Dezember enero junio diciembre gennaio giugno dicembre junho dezembro lundi dimanche Montag Sonntag Samstag sábado febr MEST MESZ KST uueuu ueuu vasárnap június január distros
 // spell-checker: ignore: uppercases
 
 use std::cmp::Ordering;
@@ -99,6 +99,51 @@ fn test_large_year_default_output_boundary() {
         .args(&["-d", "10000-02-30"])
         .fails_with_code(1)
         .stderr_contains("invalid date");
+}
+
+#[test]
+fn test_date_rejects_input_that_cannot_take_a_timezone() {
+    // A trailing timezone abbreviation must not rescue an input that already
+    // carries zone information, or that cannot take a zone at all. GNU date
+    // rejects all of these.
+    for input in [
+        "Jan 23 6:00PM GMT-1 EST",    // offset plus abbreviation
+        "023-060 MEST",               // time with offset, plus abbreviation
+        "2024-01-15 12:00 EST EST",   // the same abbreviation twice
+        "@0 EST",                     // a timestamp cannot take a zone
+        "2024-01-15 12:00 UTC EST",   // a named zone whose offset matches TZ
+        "2024-01-15 12:00 GMT EST",   // likewise, spelled differently
+        "2024-01-15 12:00 +0000 EST", // a numeric offset matching TZ
+        "2024-01-15 12:00 -0500 EST", // a standalone negative offset
+        "UTC 2024-01-15 12:00 EST",   // zone stated before the date
+    ] {
+        new_ucmd!()
+            .env("LC_ALL", "C")
+            .env("TZ", "UTC0")
+            .args(&["-d", input])
+            .fails_with_code(1)
+            .stderr_contains("invalid date");
+    }
+}
+
+#[test]
+fn test_date_accepts_gnu_timezone_abbreviations() {
+    // Abbreviations GNU date accepts, with the UTC time they map to.
+    for (input, expected) in [
+        ("2024-01-15 12:00 MEZ", "11:00\n"),
+        ("2024-01-15 12:00 MESZ", "10:00\n"),
+        ("2024-01-15 12:00 MEST", "10:00\n"),
+        ("2024-01-15 12:00 KST", "03:00\n"),
+        ("2024-01-15 12:00 EST", "17:00\n"),
+        ("2024-01-15 12:00 IST", "06:30\n"),
+    ] {
+        new_ucmd!()
+            .env("LC_ALL", "C")
+            .env("TZ", "UTC0")
+            .args(&["-u", "-d", input, "+%H:%M"])
+            .succeeds()
+            .stdout_is(expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13865.

`date` accepted two inputs that GNU rejects:

```console
$ date -d 'Jan 23 6:00PM GMT-1 EST'
Fri Jan 23 23:00:00 UTC 2026
$ date -d '023-060 MEST'
Wed Aug 26 21:00:00 UTC 2026     # today's date
```

## Root cause

It is not `parse_datetime`. The crate rejects both strings, both at the pinned 0.15.0 and on its main branch. I checked by calling it directly rather than through `date`.

`try_parse_with_abbreviation` strips a trailing timezone abbreviation and re-parses what is left, so that the abbreviation can be applied as the input timezone. It already guarded against a second timezone, but only by checking whether the last remaining word was itself a bare abbreviation. That catches `EST PST` and nothing else. `GMT-1` fails the shape check because of the hyphen and `023-060` fails it because of the digits, so both were rescued after the standard parser had correctly rejected them. In the second case `023-060` parses on its own as 23:00 with a -01:00 offset, which is where the surprising today's-date output came from.

The same hole let `@0 EST` through, and a timestamp cannot take a timezone at all.

## The change

Ask `parse_datetime` whether what is left can still take a timezone, by appending one it already understands. If it cannot, the remainder either carries timezone information of its own or cannot accept one, so the rescue is declined and the whole string falls through to the standard parser, which rejects it.

This keeps the offset grammar in one place. The alternative was to recognise offset forms textually in `date.rs`, which means maintaining a second copy of that grammar, and a rule broad enough to catch `023-060` also matches the `-15` in `2024-01-15`.

Deleting this rescue path was the other option, and it does not work: `parse_datetime` 0.15.0 rejects `MEZ`, `MESZ`, `MEST` and `KST`, which GNU accepts, and it rejects the Australian abbreviations that `tests/by-util/test_date.rs` deliberately covers. All of those still parse.

## Tests

`test_date_rejects_input_that_cannot_take_a_timezone` covers the two inputs from the issue plus `2024-01-15 12:00 EST EST` and `@0 EST`. `test_date_accepts_gnu_timezone_abbreviations` pins the abbreviations that must keep working, including the four that only this path handles. The first one fails before the change. The second passes before and after, and is there to catch a regression.

## Verification

Differential testing against GNU coreutils 9.1 over 66 inputs, comparing this branch, its base commit, and GNU. There is no input where this branch disagrees with GNU while the base agreed. Everything that changed moved from accepted to rejected, matching GNU each time, and that includes `2024-01-15T12:00Z EST`, which is not one of the reported cases.

The date suite goes from 142 to 144 passing with the same five failures before and after. Those five are `test_date_set_valid*` and `test_date_for_no_permission_file`, which fail in my container because setting the clock needs a capability it does not have. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

Every GNU behaviour referenced here was measured by running GNU `date`, not by reading its source.

## Left alone

Three things I noticed while working on this, all separate from the reported bug and none of them touched here:

- IANA location names are accepted as abbreviations, so `date -d '2024-01-15 12:00 OSLO'` works. `build_tz_abbrev_map` derives them from zone-name suffixes. GNU rejects them.
- `parse_datetime` returns offsets that differ from GNU for `ADT`, `AST`, `BST`, `GST` and `SST`. Wrong times rather than errors, and the ambiguity looks like a decision for maintainers.
- POSIX TZ strings are rejected: `TZ="EST5EDT" 2024-06-01 12:00` gives 16:00 under GNU and fails here. `TZ="America/New_York"` works, so it is specific to that form.

Happy to file these separately if they are worth tracking.
