### PR TITLE
dd: short-circuit multiplier on zero factor

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -578,10 +578,17 @@ pub fn parse_bytes_with_opt_multiplier(s: &str) -> Result<u64, ParseError> {
     } else {
         let mut total: u64 = 1;
         for (i, part) in parts.iter().enumerate() {
-            if *part == "0" && i != parts.len() - 1 {
-                show_zero_multiplier_warning();
-            }
             let num = parse_bytes_no_x(s, part)?;
+            if num == 0 && i != parts.len() - 1 {
+                // GNU dd short-circuits on a zero factor — the product is
+                // zero regardless of the remaining factors, so return early
+                // rather than failing on huge numbers in later factors.
+                // Only warn for the literal "0" multiplier, not "00".
+                if *part == "0" {
+                    show_zero_multiplier_warning();
+                }
+                return Ok(0);
+            }
             total = total
                 .checked_mul(num)
                 .ok_or_else(|| ParseError::InvalidNumber(s.to_string()))?;


### PR DESCRIPTION
When a zero factor appears in a multiplier expression (e.g. count=00x999...), GNU dd short-circuits and returns 0 without parsing the remaining factors. Our implementation parsed all factors first, so a huge number in a later factor could fail with "Value too large" even though the product is zero.

Fix by checking the parsed value: if it is zero and not the last factor, return 0 immediately after showing the zero-multiplier warning.

Fixes #14160