### PR TITLE
uucore: treat empty locale env vars as unset (fixes #13964)

### DIFF
--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -38,7 +38,7 @@ const DEFAULT_LOCALE: Locale = locale!("und");
 pub fn get_locale_from_env(locale_name: &str) -> (Locale, UEncoding) {
     let locale_var = ["LC_ALL", locale_name, "LANG"]
         .iter()
-        .find_map(|&key| std::env::var(key).ok());
+        .find_map(|&key| std::env::var(key).ok().filter(|v| !v.is_empty()));
 
     if let Some(locale_var_str) = locale_var {
         let mut split = locale_var_str.split(&['.', '@']);

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3384,6 +3384,27 @@ mod quoting {
             .succeeds()
             .stdout_is("é\n");
     }
+
+    #[test]
+    fn test_empty_lc_all_falls_through_to_lang() {
+        let scene = TestScenario::new(util_name!());
+        let at = &scene.fixtures;
+        // Create a file with a non-ASCII character.
+        at.touch("café");
+
+        // When LC_ALL is empty it should be treated as unset,
+        // falling through to LANG for locale resolution.
+        // Without the fix, empty LC_ALL was treated as POSIX,
+        // causing the non-ASCII name to be octal-escaped.
+        scene
+            .ucmd()
+            .env("LC_ALL", "")
+            .env("LANG", "en_US.UTF-8")
+            .env("LC_CTYPE", "en_US.UTF-8")
+            .args(&["--quoting-style=literal"])
+            .succeeds()
+            .stdout_contains("café");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13964

## Problem

When `LC_ALL` is set to empty string (which POSIX says means "use the next variable in the cascade"), `get_locale_from_env` parsed it as the C/POSIX locale with ASCII encoding. This caused `ls` to escape non-ASCII filenames into octal sequences even when `LC_CTYPE` or `LANG` specified UTF-8.

## Fix

Treat empty environment variables the same as unset in `get_locale_from_env` by filtering out empty values with `.filter(|v| !v.is_empty())`.

## Verification

Before (with `LC_ALL=`, `LANG=uk_UA.UTF-8`, `LC_CTYPE=uk_UA.UTF-8`):
```
$ ls
'\303\266 \303\246 \303\251 latin umlauts UTF-8'
\320\272\320\270\321\200\320\270\320\273\321\226\321\207\320\275\320\260 ...
```

After:
```
$ ls
ö æ é latin umlauts UTF-8
кирилічна назва в UTF-8
```

This matches GNU `ls` behavior.