### PR TITLE
stat: print "Block size" in file system mode

### DIFF
--- a/src/uu/stat/locales/en-US.ftl
+++ b/src/uu/stat/locales/en-US.ftl
@@ -90,6 +90,7 @@ stat-word-block = Block
 stat-word-size = Size
 stat-word-fundamental = Fundamental
 stat-word-block-size = block size
+stat-word-block-size-capitalized = Block size
 stat-word-blocks = Blocks
 stat-word-total = Total
 stat-word-free = Free

--- a/src/uu/stat/locales/fr-FR.ftl
+++ b/src/uu/stat/locales/fr-FR.ftl
@@ -73,6 +73,7 @@ stat-word-block = Bloc
 stat-word-size = Taille
 stat-word-fundamental = Fondamentale
 stat-word-block-size = taille bloc
+stat-word-block-size-capitalized = Taille bloc
 stat-word-blocks = Blocs
 stat-word-total = Total
 stat-word-free = Libres

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1428,15 +1428,14 @@ impl Stater {
                 "%n %i %l %t %s %S %b %f %a %c %d\n".into()
             } else {
                 format!(
-                    "  {}: \"%n\"\n    {}: %-8i {}: %-7l {}: %T\n{} \
-                         {}: %-10s {} {}: %S\n{}: {}: %-10b \
+                    "  {}: \"%n\"\n    {}: %-8i {}: %-7l {}: %T\n{}: %-10s \
+                         {} {}: %S\n{}: {}: %-10b \
                          {}: %-10f {}: %a\n{}: {}: %-10c {}: %d\n",
                     translate!("stat-word-file"),
                     translate!("stat-word-id"),
                     translate!("stat-word-namelen"),
                     translate!("stat-word-type"),
-                    translate!("stat-word-block"),
-                    translate!("stat-word-size"),
+                    translate!("stat-word-block-size-capitalized"),
                     translate!("stat-word-fundamental"),
                     translate!("stat-word-block-size"),
                     translate!("stat-word-blocks"),

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -53,7 +53,9 @@ fn test_fs_format() {
 }
 
 #[test]
-#[cfg(unix)]
+// `stat -f` is only implemented for these targets; elsewhere `fs_type` is
+// still `unimplemented!()`.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn test_fs_default_format_block_size_label() {
     // GNU prints "Block size:", not "Block Size:".
     new_ucmd!()

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -52,6 +52,16 @@ fn test_fs_format() {
     ts.ucmd().args(&args).succeeds().stdout_is(expected_stdout);
 }
 
+#[test]
+#[cfg(unix)]
+fn test_fs_default_format_block_size_label() {
+    // GNU prints "Block size:", not "Block Size:".
+    new_ucmd!()
+        .args(&["-f", "/"])
+        .succeeds()
+        .stdout_contains("Block size:");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_terse_normal_format() {


### PR DESCRIPTION
`stat -f` builds its second line out of two independent word translations,
`stat-word-block` (`Block`) and `stat-word-size` (`Size`), so the label comes
out capitalized on both words:

```
$ stat -f /etc/passwd            # this build
  File: "/etc/passwd"
    ID: 1f5177f6d898479e Namelen: 255     Type: overlayfs
Block Size: 4096       Fundamental block size: 4096
Blocks: Total: 118523922  Free: 116434161  Available: 110395109
Inodes: Total: 30179328   Free: 29976433
```

GNU prints `Block size:` there — lowercase `s`, one label rather than two
words. Everything else on the line, including the `%-10s` padding and the
`Fundamental block size:` label that follows, already matches.

This PR replaces the `Block` + `Size` pair with a single localizable key,
`stat-word-block-size-capitalized`. Composing a label out of separate words is
also a translation hazard: the French locale currently renders `Bloc Taille:`,
and with the label as one string it becomes `Taille bloc:`. The existing
`stat-word-block` and `stat-word-size` keys stay — they are still used for
`IO Block:` and `Size:` in the non-`-f` format.

**Testing:** new `test_fs_default_format_block_size_label` in
`tests/by-util/test_stat.rs` asserts the label; it fails on current `main` and
passes with this change (verified by reverting `stat.rs` and the locales alone
and re-running). The full `stat` suite is green (33 passed),
`cargo fmt --all --check` and `cargo clippy -p uu_stat --all-targets` are
clean. A release build of this branch was also compared against the system
`stat` inside `debian:stable-slim` for `/`, `/etc`, `/etc/passwd`, `/tmp`,
`/proc` and `/dev` — 6 of 6 byte-identical, where before all six differed on
this line.

Behaviour was established by observing GNU `stat`'s output on a Debian system —
no GNU source was consulted.