### PR TITLE
fold: do not fold a bytewise line that is exactly the width

### DIFF
--- a/src/uu/fold/src/fold.rs
+++ b/src/uu/fold/src/fold.rs
@@ -248,9 +248,11 @@ fn fold_file_bytewise<T: Read, W: Write>(
         // We have a full `width`-byte chunk plus at least one lookahead byte.
         let chunk = &line[..width];
 
-        // An existing newline within the chunk ends the line naturally; the
-        // newline is part of the slice, so no extra newline is emitted.
-        if let Some(end) = chunk.iter().position(|c| *c == NL).map(|i| i + 1) {
+        // A newline no further than the `width`-th byte ends the line
+        // naturally; the newline is part of the slice, so no extra newline is
+        // emitted. The lookahead byte is included because a line of exactly
+        // `width` bytes needs no fold at all.
+        if let Some(end) = line[..=width].iter().position(|c| *c == NL).map(|i| i + 1) {
             output.write_all(&line[..end])?;
             line.drain(..end);
             continue;
@@ -267,12 +269,10 @@ fn fold_file_bytewise<T: Read, W: Write>(
             width
         };
 
+        // Width/space-driven fold: `end <= width` and the check above ruled out
+        // a newline there, so the break always needs one.
         output.write_all(&line[..end])?;
-        // Width/space-driven fold: insert a newline unless the next byte is
-        // already a newline (it is emitted on the next pass).
-        if line[end] != NL {
-            output.write_all(&[NL])?;
-        }
+        output.write_all(&[NL])?;
         line.drain(..end);
     }
     Ok(())

--- a/tests/by-util/test_fold.rs
+++ b/tests/by-util/test_fold.rs
@@ -819,6 +819,36 @@ fn test_bytewise_fold_at_word_boundary_only_whitespace_preserve_final_newline() 
 }
 
 #[test]
+fn test_bytewise_fold_line_of_exactly_width_is_not_folded() {
+    // A line that is exactly `width` bytes long already fits, so -s must not
+    // break it at its last blank.
+    new_ucmd!()
+        .args(&["-w7", "-s", "-b"])
+        .pipe_in("aaa bbb\nccc ddd\n")
+        .succeeds()
+        .stdout_is("aaa bbb\nccc ddd\n");
+}
+
+#[test]
+fn test_bytewise_fold_remainder_of_exactly_width_is_not_folded() {
+    // Same, for what is left of a line after a width-driven fold.
+    new_ucmd!()
+        .args(&["-w7", "-s", "-b"])
+        .pipe_in("aaa bbb ccc\n")
+        .succeeds()
+        .stdout_is("aaa \nbbb ccc\n");
+}
+
+#[test]
+fn test_bytewise_fold_line_longer_than_width_still_folds() {
+    new_ucmd!()
+        .args(&["-w7", "-s", "-b"])
+        .pipe_in("aaa bbbb\n")
+        .succeeds()
+        .stdout_is("aaa \nbbbb\n");
+}
+
+#[test]
 fn test_bytewise_backspace_should_be_preserved() {
     new_ucmd!()
         .arg("-b")


### PR DESCRIPTION
In byte mode (`-b`), a line that is exactly `width` bytes long is wrapped
anyway when `-s` is given:

```
$ printf 'aaa bbb\n' | fold -bs -w 7   # GNU
aaa bbb
$ printf 'aaa bbb\n' | ./fold -bs -w 7  # this build
aaa 
bbb
```

`fold_file_bytewise` buffers `width + 1` bytes and looks for a natural line
end inside `line[..width]`. For a line of exactly `width` bytes the
terminating newline sits at index `width` — one byte past that slice — so it is
never found, and the code falls through to the fold path. Without `-s` the
`if line[end] != NL` guard happens to cover it, because `end == width`; with
`-s` the break moves back to the last blank and the guard looks at the wrong
byte, so the line is split early and the blank is left dangling at the end of
the output line.

Extending the newline search by that one lookahead byte fixes it. The guard on
the fold path then becomes unreachable — `end <= width`, and a newline in
`line[..=width]` has just been ruled out — so it is dropped and the newline is
written unconditionally.

Real-world instance, `/usr/share/doc/apt/copyright` on a Debian system, where
this line is exactly 60 bytes:

```
$ diff <(fold -bs -w 60 copyright) <(./fold -bs -w 60 copyright)
90c90,91
<  1. Redistributions of source code must retain the copyright
---
>  1. Redistributions of source code must retain the 
>  copyright
```

**Testing:** three new tests in `tests/by-util/test_fold.rs` cover a whole line
of exactly the width, the remainder of a folded line landing on exactly the
width, and — as a control — a line one byte longer that must still fold. The
first two fail on current `main` and pass here; the third passes either way.
The full `fold` suite is green (94 passed), `cargo fmt --all --check` and
`cargo clippy -p uu_fold --all-targets` are clean.

Release builds of `main` and of this branch were also run against the system
`fold` inside `debian:stable-slim` over 60 files from `/usr/share/doc` and
`/etc`, with flags `-b`, `-bs`, `-s` and none, at widths 1, 2, 3, 5, 7, 8, 11,
20, 40, 60 and 80 — 2640 invocations. 468 of them go from differing to
byte-identical, and none regress. Every remaining difference is in the
character/column path, which this PR does not touch; byte mode (`-b`, `-bs`,
1320 invocations) now matches GNU everywhere in that sweep.

Behaviour was established by observing GNU `fold`'s output on a Debian system —
no GNU source was consulted.