### PR TITLE
GnuTests: fix hardcoded pathes to GNU executables

### DIFF
--- a/util/fetch-gnu.sh
+++ b/util/fetch-gnu.sh
@@ -7,6 +7,7 @@ curl -L "${repo}/releases/download/v${ver}/coreutils-${ver}.tar.xz" | tar --stri
 backport=(
   cat/splice.sh # split tests
   dd/fail-ftruncate-fstat.sh # remove LD_PRELOAD
+  misc/close-stdout.sh # fix hardcoded pathes to GNU executables
   misc/uname-labeled.sh # uname -A/--all-labeled, added after $ver
   nproc/nproc-quota.sh # remove LD_PRELOAD
   misc/empty-backup-suffix.sh


### PR DESCRIPTION
Replace hardcoded pathes calling GNU's executables