### PR TITLE
fsext: do not confuse f_bsize with f_frsize on Linux

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -566,7 +566,7 @@ impl FsUsage {
                 target_pointer_width = "64"
             ))]
             return Self {
-                blocksize: statvfs.f_bsize as u64, // or `statvfs.f_frsize` ?
+                blocksize: statvfs.block_size() as u64,
                 blocks: statvfs.f_blocks,
                 bfree: statvfs.f_bfree,
                 bavail: statvfs.f_bavail,
@@ -579,7 +579,7 @@ impl FsUsage {
                 not(target_pointer_width = "64")
             ))]
             return Self {
-                blocksize: statvfs.f_bsize as u64, // or `statvfs.f_frsize` ?
+                blocksize: statvfs.block_size() as u64,
                 blocks: statvfs.f_blocks.into(),
                 bfree: statvfs.f_bfree.into(),
                 bavail: statvfs.f_bavail.into(),
@@ -589,7 +589,9 @@ impl FsUsage {
             };
             #[cfg(target_os = "freebsd")]
             return Self {
-                blocksize: statvfs.f_bsize, // or `statvfs.f_frsize` ?
+                // FreeBSD's `struct statfs` has no fragment size; `f_bsize`
+                // is the block size the counts are expressed in.
+                blocksize: statvfs.f_bsize,
                 blocks: statvfs.f_blocks,
                 bfree: statvfs.f_bfree,
                 bavail: statvfs.f_bavail.try_into().unwrap(),
@@ -686,12 +688,30 @@ pub trait FsMeta {
 
 #[cfg(unix)]
 impl FsMeta for StatFs {
+    /// The block size the `f_blocks`, `f_bfree` and `f_bavail` counts are
+    /// expressed in.
+    ///
+    /// On Linux that is `f_frsize`, not `f_bsize`: the latter is the preferred
+    /// transfer size and may be far larger. virtiofs, for one, reports a 1 MiB
+    /// `f_bsize` next to a 4 KiB `f_frsize`, which scales every size derived
+    /// from the counts by 256. `f_frsize` is zero on pre-2.6 kernels, so fall
+    /// back to `f_bsize` there.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[allow(clippy::unnecessary_cast)]
+    fn block_size(&self) -> i64 {
+        if self.f_frsize == 0 {
+            self.f_bsize as i64
+        } else {
+            self.f_frsize as i64
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     fn block_size(&self) -> i64 {
         #[cfg(all(
             not(target_env = "musl"),
             not(target_vendor = "apple"),
             not(target_os = "aix"),
-            not(target_os = "android"),
             not(target_os = "freebsd"),
             not(target_os = "netbsd"),
             not(target_os = "openbsd"),
@@ -712,7 +732,6 @@ impl FsMeta for StatFs {
             any(
                 target_arch = "s390x",
                 target_vendor = "apple",
-                all(target_os = "android", target_pointer_width = "32"),
                 target_os = "openbsd",
                 not(target_pointer_width = "64")
             )
@@ -727,7 +746,6 @@ impl FsMeta for StatFs {
             target_os = "solaris",
             target_os = "redox",
             target_os = "cygwin",
-            all(target_os = "android", target_pointer_width = "64"),
         ))]
         return self.f_bsize.try_into().unwrap();
     }
@@ -817,10 +835,11 @@ impl FsMeta for StatFs {
         unimplemented!()
     }
 
+    /// The preferred transfer size, which on Linux is `f_bsize`.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[allow(clippy::unnecessary_cast)]
     fn io_size(&self) -> u64 {
-        self.f_frsize as u64
+        self.f_bsize as u64
     }
     #[cfg(any(target_vendor = "apple", target_os = "freebsd", target_os = "netbsd"))]
     #[allow(clippy::unnecessary_cast)]
@@ -1194,6 +1213,48 @@ mod tests {
             info.mount_dir,
             crate::os_str_from_bytes(b"/mnt/some- -dir-\xf3").unwrap()
         );
+    }
+
+    /// A `statfs` as virtiofs fills it in: a 1 MiB preferred transfer size
+    /// next to a 4 KiB fragment size, with the counts in fragments.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn virtiofs_like_statfs() -> StatFs {
+        let mut statfs: StatFs = unsafe { mem::zeroed() };
+        statfs.f_bsize = 1024 * 1024;
+        statfs.f_frsize = 4096;
+        statfs.f_blocks = 120_699_413;
+        statfs.f_bfree = 30_801_013;
+        statfs.f_bavail = 30_801_013;
+        statfs
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn test_block_size_is_the_fragment_size() {
+        let statfs = virtiofs_like_statfs();
+        assert_eq!(statfs.block_size(), 4096);
+        assert_eq!(statfs.io_size(), 1024 * 1024);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn test_fs_usage_scales_by_the_fragment_size() {
+        let usage = FsUsage::new(virtiofs_like_statfs());
+        assert_eq!(usage.blocksize, 4096);
+        assert_eq!(usage.blocks * usage.blocksize, 494_384_795_648);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn test_block_size_falls_back_when_fragment_size_is_unset() {
+        // Pre-2.6 kernels leave `f_frsize` at zero.
+        let mut statfs: StatFs = unsafe { mem::zeroed() };
+        statfs.f_bsize = 4096;
+        statfs.f_frsize = 0;
+        statfs.f_blocks = 10;
+
+        assert_eq!(statfs.block_size(), 4096);
+        assert_eq!(FsUsage::new(statfs).blocksize, 4096);
     }
 
     #[test]


### PR DESCRIPTION
On Linux `struct statfs` carries two sizes: `f_bsize`, the preferred transfer
size, and `f_frsize`, the block size that `f_blocks`, `f_bfree` and `f_bavail`
are counted in. `FsMeta` had them the wrong way round — `block_size()` returned
`f_bsize` and `io_size()` returned `f_frsize` — and `FsUsage::new` scaled the
counts by `f_bsize` (with a `// or statvfs.f_frsize ?` comment next to it).

Almost every filesystem reports the two as equal, so nothing shows. virtiofs —
the filesystem Docker Desktop uses for bind mounts — does not: on a 461 GiB
host disk it reports `f_bsize` 1 MiB and `f_frsize` 4 KiB. In a
`debian:stable-slim` container with a bind-mounted directory:

```
$ df -h /w            # GNU
Filesystem      Size  Used Avail Use% Mounted on
virtiofs2       461G  343G  118G  75% /w

$ ./df -h /w          # this build
virtiofs2       116T   86T   30T  75% /w
```

Every size is 256x too large — exactly `f_bsize / f_frsize`. The raw counts
back this up: `f_blocks` is 120699413, and 120699413 x 4096 = 494384795648
bytes = 461 GiB, the actual size of the disk; multiplying by `f_bsize` gives
118 TiB, which no disk on the machine has.

The same swap made `stat -f` print `%s` and `%S` the other way round:

```
$ stat -f -c '%s %S' /w            # GNU
1048576 4096
$ ./stat -f -c '%s %S' /w          # this build
4096 1048576
```

which contradicts this crate's own help text — `%s` is documented as "block
size (for faster transfers)" and `%S` as "fundamental block size (for block
counts)".

This PR gives Linux and Android their own `block_size()` (the fragment size,
falling back to `f_bsize` when `f_frsize` is zero, as it is on pre-2.6 kernels)
and `io_size()` (the transfer size), and has `FsUsage::new` scale by
`block_size()` instead of reading the field directly. Other targets are
untouched: Apple, FreeBSD and OpenBSD have no `f_frsize` in `struct statfs` and
their `f_bsize` already is the block size the counts use, so the existing
`cfg` arms are kept verbatim minus the Android entries that moved.

**Testing:** three unit tests in `fsext.rs`. Two build a `statfs` holding
virtiofs's numbers and check that `block_size()` and `io_size()` come out the
right way round and that `FsUsage` scales 120699413 blocks to 494384795648
bytes; the third covers the `f_frsize == 0` fallback. The first two fail on current `main` and pass here; the fallback test
passes either way. `cargo test -p uucore --features fsext` is green (9 passed),
as are the `df` (60 passed) and `stat` (38 passed) suites,
`cargo clippy -p uucore --features fsext --all-targets` and
`cargo fmt --all --check`. `cargo check -p uucore --features fsext` also passes
for `aarch64-linux-android` and on macOS, so both new `cfg` arms compile.

Against the system `df` in `debian:stable-slim`, `df -B1 --output=size` now
matches byte for byte on `/`, `/dev`, `/dev/shm` and the virtiofs mount, where
before the virtiofs row was off by 256x; `stat -f -c '%s %S'` matches on all of
them too.

Behaviour was established by observing GNU's output and the raw `statfs` values
on a Debian system — no GNU source was consulted.
