### PR TITLE
uptime: fix cfg for get_uptime

### DIFF
--- a/src/uucore/src/lib/features/uptime/unix.rs
+++ b/src/uucore/src/lib/features/uptime/unix.rs
@@ -64,7 +64,12 @@ fn get_macos_boot_time_sysctl() -> Option<time_t> {
 /// # Returns
 ///
 /// Returns a UResult with the uptime in seconds if successful, otherwise an UptimeError.
-#[cfg(not(any(target_os = "cygwin", target_os = "netbsd", target_vendor = "apple")))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "fuchsia",
+    target_os = "openbsd",
+))]
 #[allow(clippy::unnecessary_wraps, reason = "needed on some platforms")]
 pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
     use rustix::time::{ClockId, clock_gettime};
@@ -83,7 +88,12 @@ pub fn get_uptime(_boot_time: Option<time_t>) -> UResult<i64> {
 /// # Returns
 ///
 /// Returns a UResult with the uptime in seconds if successful, otherwise an UptimeError.
-#[cfg(any(target_os = "cygwin", target_os = "netbsd", target_vendor = "apple"))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "fuchsia",
+    target_os = "openbsd",
+)))]
 pub fn get_uptime(boot_time: Option<time_t>) -> UResult<i64> {
     use crate::utmpx::BOOT_TIME;
     use crate::utmpx::Utmpx;


### PR DESCRIPTION
Fix the `cfg` conditions to match the platforms where [`ClockId::Boottime`](https://docs.rs/rustix/latest/rustix/time/enum.ClockId.html#variant.Boottime) is available.

This fixes a compilation error on FreeBSD, where `ClockId::Boottime` is not available:

```
  error[E0599]: no variant, associated function, or constant named `Boottime` found for enum `ClockId` in the current scope
    --> src/uucore/src/lib/features/uptime/unix.rs:72:37
     |
  72 |     let tp = clock_gettime(ClockId::Boottime);
     |                                     ^^^^^^^^ variant, associated function, or constant not found in `ClockId`
```