### PR TITLE
tail: replace same-file with rustix and drop the dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,7 +4308,6 @@ dependencies = [
  "notify",
  "rstest",
  "rustix",
- "same-file",
  "uucore",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,7 +482,6 @@ rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
 # raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
 rustix = { version = "1.1.4", features = ["param", "use-libc-auxv", "time"] }
-same-file = "1.0.6"
 self_cell = "1.0.4"
 selinux = "0.6"
 string-interner = "0.20.0"

--- a/src/uu/tail/Cargo.toml
+++ b/src/uu/tail/Cargo.toml
@@ -20,7 +20,6 @@ doctest = false
 clap = { workspace = true }
 memchr = { workspace = true }
 uucore = { workspace = true, features = ["fs", "parser-size", "signals"] }
-same-file = { workspace = true }
 fluent = { workspace = true }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -8,9 +8,10 @@
 use crate::paths::Input;
 use crate::{Quotable, parse, platform};
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
-use same_file::Handle;
 use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
+#[cfg(unix)]
+use std::os::fd::AsFd;
 use std::time::Duration;
 use uucore::diagnostics::OptionValue;
 use uucore::error::{UResult, USimpleError, UUsageError};
@@ -345,15 +346,15 @@ impl Settings {
         // as `tty` (but no otherwise blocking stdin), then we print a warning that `--follow`
         // cannot be applied under these circumstances and is therefore ineffective.
         if self.follow.is_some() && self.has_stdin() {
+            #[cfg(unix)]
+            let stdin_is_regular = rustix::fs::fstat(std::io::stdin().as_fd())
+                .is_ok_and(|stat| stat.st_mode & libc::S_IFMT == libc::S_IFREG);
+            #[cfg(not(unix))]
+            let stdin_is_regular = true;
             let blocking_stdin = self.pid.unwrap_or_default() == 0
                 && self.follow == Some(FollowMode::Descriptor)
                 && self.num_inputs() == 1
-                && Handle::stdin().is_ok_and(|handle| {
-                    handle
-                        .as_file()
-                        .metadata()
-                        .is_ok_and(|meta| !meta.is_file())
-                });
+                && !stdin_is_regular;
 
             if !blocking_stdin && std::io::stdin().is_terminal() {
                 show_warning!("{}", translate!("tail-warning-following-stdin-ineffective"));

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -30,6 +30,8 @@ use paths::{FileExtTail, HeaderPrinter, Input, InputKind};
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write, stdin, stdout};
+#[cfg(unix)]
+use std::os::fd::AsFd;
 use std::path::{Path, PathBuf};
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, set_exit_code};
@@ -259,10 +261,7 @@ fn tail_stdin(
     // e.g. see the differences between running ls -l /dev/stdin /dev/fd/0
     // on macOS and Linux.
     #[cfg(target_os = "macos")]
-    if let Ok(mut stdin_handle) = same_file::Handle::stdin()
-        && let Ok(meta) = stdin_handle.as_file_mut().metadata()
-        && meta.file_type().is_dir()
-    {
+    if uucore::fs::is_stdin_directory(&stdin()) {
         set_exit_code(1);
         show_error!(
             "{}",
@@ -288,9 +287,7 @@ fn tail_stdin(
         // Save the current seek position/offset of a stdin redirected file.
         // This is needed to pass "gnu/tests/tail-2/start-middle.sh"
         #[cfg(unix)]
-        let stdin_offset = same_file::Handle::stdin()
-            .and_then(|mut h| h.as_file_mut().stream_position())
-            .unwrap_or(0); // fifo
+        let stdin_offset = rustix::fs::tell(stdin().as_fd()).unwrap_or(0); // fifo
         tail_file(
             settings,
             header_printer,
@@ -574,7 +571,7 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
 // Print the target section of the file
 // use zero-copy on Linux
 fn print_target_section<
-    #[cfg(any(target_os = "linux", target_os = "android"))] R: Read + rustix::fd::AsFd,
+    #[cfg(any(target_os = "linux", target_os = "android"))] R: Read + AsFd,
     #[cfg(not(any(target_os = "linux", target_os = "android")))] R: Read,
 >(
     file: &mut R,


### PR DESCRIPTION
Replace the external `same-file` dependency in `uu_tail` with `rustix::fs::fstat` and `rustix::fs::tell` and remove it from the workspace.
