### PR TITLE
cat: always exit with 1 on error

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -416,7 +416,7 @@ where
     let line_joiner = "\ncat: ";
 
     Err(uucore::error::USimpleError::new(
-        error_messages.len() as i32,
+        1,
         error_messages.join(line_joiner),
     ))
 }

--- a/tests/by-util/test_cat.rs
+++ b/tests/by-util/test_cat.rs
@@ -649,7 +649,7 @@ fn test_write_to_self() {
         .arg("first_file")
         .arg("first_file")
         .arg("second_file")
-        .fails_with_code(2)
+        .fails_with_code(1)
         .stderr_only("cat: first_file: input file is output file\ncat: first_file: input file is output file\n");
 
     assert_eq!(
@@ -727,6 +727,15 @@ fn test_error_loop() {
     ucmd.arg("1")
         .fails()
         .stderr_is("cat: 1: Too many levels of symbolic links\n");
+}
+
+#[test]
+fn test_exit_code_is_one_regardless_of_error_count() {
+    // cat's exit code must always be 1 when errors occur, matching GNU cat.
+    // Counting is problematic, since process exit codes are truncated mod 256 by the OS
+    let missing_files: Vec<String> = (0..256).map(|i| format!("missing-{i}")).collect();
+
+    new_ucmd!().args(&missing_files).fails_with_code(1);
 }
 
 #[test]


### PR DESCRIPTION
I am unsure if returning the number of errors as exit code is a feature, and found the commit that introduced it.
https://github.com/uutils/coreutils/commit/2106ddd08 ("migrate cat code to UResult #2464")
Before it, cat_files returned Err(error_count: u32) and uumain collapsed any error into a plain exit code 1.

My commit restores this behavior, matching gnu cat.

I had to modify one test, "test_write_to_self", it was expecting exit code 2, now it will return 1.

Fixes #14215 