### PR TITLE
Revert "yes: deadlock fix"

### DIFF
--- a/src/uu/yes/src/yes.rs
+++ b/src/uu/yes/src/yes.rs
@@ -99,11 +99,7 @@ pub fn exec(bytes: &[u8]) -> io::Result<()> {
     // tee() cannot control offset. We can do tee only if original bytes.len() is multiple of PIPE_BUF,
     // but it is slower than mixing splice even it reduces syscalls...
     let bytes_len = bytes.len();
-    // Skip the splice/tee fast path if bytes wouldn't fit in the pipe.
-    // p_write.write_all(bytes) below has nothing draining p_read yet, so writing more than
-    // the pipe holds deadlocks.
-    if bytes_len <= MAX_ROOTLESS_PIPE_SIZE
-        && let Ok((p_read, mut p_write)) = pipe::<true>()
+    if let Ok((p_read, mut p_write)) = pipe::<true>()
         && p_write.write_all(bytes).is_ok()
         && let Ok((broker_read, broker_write)) = pipe::<true>()
         // GNU catches all strace injections for splice expect for 1st one (checking support of it)

--- a/tests/by-util/test_yes.rs
+++ b/tests/by-util/test_yes.rs
@@ -72,20 +72,6 @@ fn test_long_input() {
     run(&[&arg[..arg.len() - 1]], expected_out.as_bytes());
 }
 
-/// A joined line larger than the internal broker pipe's capacity (1 MiB)
-/// can cause a deadlock
-#[test]
-#[cfg(any(target_os = "linux", target_os = "android"))]
-#[cfg_attr(wasi_runner, ignore)]
-fn test_long_line_exceeds_pipe_capacity() {
-    // A single argv string is capped at ~128 KiB by the kernel, so use many
-    // args joined by spaces to build a >1 MiB line instead of one huge arg.
-    let word = "a".repeat(60_000);
-    let args: Vec<&str> = std::iter::repeat_n(word.as_str(), 20).collect();
-    let line = args.join(" ");
-    run(&args, format!("{line}\n{line}\n").as_bytes());
-}
-
 #[test]
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 #[cfg_attr(wasi_runner, ignore)]


### PR DESCRIPTION
Reverts uutils/coreutils#14210
This is unnecessary since len is checked at 1st via tee call.