### PR TITLE
simplify by cfg(windows)

### DIFF
--- a/src/uu/cat/src/cat.rs
+++ b/src/uu/cat/src/cat.rs
@@ -704,7 +704,7 @@ fn write_end_of_line<W: Write>(
 
 fn handle_broken_pipe(error: &io::Error) {
     // SIGPIPE is not available on Windows.
-    if cfg!(target_os = "windows") && error.kind() == ErrorKind::BrokenPipe {
+    if cfg!(windows) && error.kind() == ErrorKind::BrokenPipe {
         std::process::exit(13);
     }
 }

--- a/src/uu/comm/src/comm.rs
+++ b/src/uu/comm/src/comm.rs
@@ -273,7 +273,7 @@ fn open_file(name: &OsString, line_ending: LineEnding) -> io::Result<LineReader>
     } else {
         // some platforms shows different read error
         // try to override the error message, but failure of it is not serious
-        #[cfg(any(target_os = "wasi", target_os = "windows"))]
+        #[cfg(any(target_os = "wasi", windows))]
         if std::fs::metadata(name).is_ok_and(|m| m.is_dir()) {
             return Err(io::Error::other(translate!("comm-error-is-directory")));
         }

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -43,7 +43,7 @@ selinux = { workspace = true, optional = true }
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["fs"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",

--- a/src/uu/cp/src/copydir.rs
+++ b/src/uu/cp/src/copydir.rs
@@ -44,7 +44,7 @@ struct DirNeedingPermissions {
 }
 
 /// Ensure a Windows path starts with a `\\?`.
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn adjust_canonicalization(p: &Path) -> Cow<'_, Path> {
     // In some cases, \\? can be missing on some Windows paths.  Add it at the
     // beginning unless the path is prefixed with a device namespace.

--- a/src/uu/cp/src/platform/mod.rs
+++ b/src/uu/cp/src/platform/mod.rs
@@ -24,14 +24,14 @@ mod linux;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) use self::linux::copy_on_write;
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 mod windows;
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 pub(crate) use self::windows::copy_on_write;
 
-#[cfg(not(any(unix, target_os = "windows")))]
+#[cfg(not(any(unix, windows)))]
 mod other;
-#[cfg(not(any(unix, target_os = "windows")))]
+#[cfg(not(any(unix, windows)))]
 pub(crate) use self::other::copy_on_write;
 
 #[cfg(target_os = "wasi")]

--- a/src/uu/du/Cargo.toml
+++ b/src/uu/du/Cargo.toml
@@ -34,7 +34,7 @@ fluent = { workspace = true }
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 uucore = { workspace = true, features = ["safe-traversal"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",

--- a/src/uu/env/src/diagnostics.rs
+++ b/src/uu/env/src/diagnostics.rs
@@ -118,12 +118,12 @@ fn describe(
 /// drawn from. Anything past the end of `payload` stays past it, so that
 /// [`diagnostics::char_span`] still reads it as "nothing left to point at".
 fn byte_offset(payload: &str, pos: usize) -> usize {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         let _ = payload;
         pos
     }
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         let mut units = 0;
         for (offset, c) in payload.char_indices() {

--- a/src/uu/env/src/native_int_str.rs
+++ b/src/uu/env/src/native_int_str.rs
@@ -17,13 +17,13 @@ use std::ffi::OsString;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 #[cfg(target_os = "wasi")]
 use std::os::wasi::ffi::{OsStrExt, OsStringExt};
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 use std::os::windows::prelude::*;
 use std::{borrow::Cow, ffi::OsStr};
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use u8 as NativeIntCharU;
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 use u16 as NativeIntCharU;
 
 pub type NativeCharInt = NativeIntCharU;
@@ -40,12 +40,12 @@ pub trait Convert<From, To> {
 
 impl<'a> Convert<&'a str, Cow<'a, NativeIntStr>> for NCvt {
     fn convert(f: &'a str) -> Cow<'a, NativeIntStr> {
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             Cow::Owned(f.encode_utf16().collect())
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         {
             Cow::Borrowed(f.as_bytes())
         }
@@ -54,12 +54,12 @@ impl<'a> Convert<&'a str, Cow<'a, NativeIntStr>> for NCvt {
 
 impl<'a> Convert<&'a String, Cow<'a, NativeIntStr>> for NCvt {
     fn convert(f: &'a String) -> Cow<'a, NativeIntStr> {
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             Cow::Owned(f.encode_utf16().collect())
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         {
             Cow::Borrowed(f.as_bytes())
         }
@@ -68,12 +68,12 @@ impl<'a> Convert<&'a String, Cow<'a, NativeIntStr>> for NCvt {
 
 impl<'a> Convert<String, Cow<'a, NativeIntStr>> for NCvt {
     fn convert(f: String) -> Cow<'a, NativeIntStr> {
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             Cow::Owned(f.encode_utf16().collect())
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         {
             Cow::Owned(f.into_bytes())
         }
@@ -96,12 +96,12 @@ impl<'a> Convert<&'a OsString, Cow<'a, NativeIntStr>> for NCvt {
 
 impl<'a> Convert<OsString, Cow<'a, NativeIntStr>> for NCvt {
     fn convert(f: OsString) -> Cow<'a, NativeIntStr> {
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             Cow::Owned(f.encode_wide().collect())
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         {
             Cow::Owned(f.into_vec())
         }
@@ -135,12 +135,12 @@ impl<'a> Convert<Vec<String>, Vec<Cow<'a, NativeIntStr>>> for NCvt {
 }
 
 pub fn to_native_int_representation(input: &OsStr) -> Cow<'_, NativeIntStr> {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         Cow::Owned(input.encode_wide().collect())
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         Cow::Borrowed(input.as_bytes())
     }
@@ -148,12 +148,12 @@ pub fn to_native_int_representation(input: &OsStr) -> Cow<'_, NativeIntStr> {
 
 #[allow(clippy::needless_pass_by_value)] // needed on windows
 pub fn from_native_int_representation(input: Cow<'_, NativeIntStr>) -> Cow<'_, OsStr> {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         Cow::Owned(OsString::from_wide(&input))
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         match input {
             Cow::Borrowed(borrow) => Cow::Borrowed(OsStr::from_bytes(borrow)),
@@ -164,26 +164,26 @@ pub fn from_native_int_representation(input: Cow<'_, NativeIntStr>) -> Cow<'_, O
 
 #[allow(clippy::needless_pass_by_value)] // needed on windows
 pub fn from_native_int_representation_owned(input: NativeIntString) -> OsString {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         OsString::from_wide(&input)
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         OsString::from_vec(input)
     }
 }
 
 pub fn get_single_native_int_value(c: char) -> Option<NativeCharInt> {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         let mut buf = [0u16, 0];
         let s = c.encode_utf16(&mut buf);
         if s.len() == 1 { Some(buf[0]) } else { None }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         let mut buf = [0u8, 0, 0, 0];
         let s = c.encode_utf8(&mut buf);
@@ -193,12 +193,12 @@ pub fn get_single_native_int_value(c: char) -> Option<NativeCharInt> {
 
 pub fn get_char_from_native_int(ni: NativeCharInt) -> Option<(char, NativeCharInt)> {
     let c_opt;
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         c_opt = char::decode_utf16([ni; 1]).next().unwrap().ok();
     };
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         c_opt = std::str::from_utf8(&[ni; 1])
             .ok()

--- a/src/uu/expand/src/expand.rs
+++ b/src/uu/expand/src/expand.rs
@@ -274,7 +274,7 @@ fn open(path: &OsString) -> UResult<BufReader<Box<dyn Read>>> {
     }
     let path_ref = Path::new(path);
     // some platforms cannot catch this as read error. accept additional overhead.
-    #[cfg(any(target_os = "wasi", target_os = "windows"))]
+    #[cfg(any(target_os = "wasi", windows))]
     if path_ref.is_dir() {
         return Err(uucore::error::USimpleError::new(
             1,

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -25,7 +25,7 @@ hostname = { workspace = true, features = ["set"] }
 uucore = { workspace = true, features = ["wide"] }
 fluent = { workspace = true }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Networking_WinSock",
   "Win32_Foundation",

--- a/src/uu/ls/src/display.rs
+++ b/src/uu/ls/src/display.rs
@@ -1258,9 +1258,9 @@ fn create_hyperlink(name: &OsStr, path: &PathData) -> OsString {
     ret.push(HOSTNAME.as_os_str());
 
     // a set of safe ASCII bytes that don't need encoding
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     let unencoded = |c| matches!(c, '_' | '-' | '.' | '~' | '/');
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let unencoded = |c| matches!(c, '_' | '-' | '.' | '~' | '/' | '\\' | ':');
 
     for &b in absolute_path.as_os_str().as_encoded_bytes() {

--- a/src/uu/od/src/multifile_reader.rs
+++ b/src/uu/od/src/multifile_reader.rs
@@ -118,7 +118,7 @@ impl MultifileReader<'_> {
                             // print an error at the time that the file is needed,
                             // then move to the next file
                             let error_msg = match e.kind() {
-                                #[cfg(target_os = "windows")]
+                                #[cfg(windows)]
                                 io::ErrorKind::NotFound => "No such file or directory",
                                 _ => &strip_errno(&e),
                             };

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -46,7 +46,7 @@ const STDBUF_INJECT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libstdbuf
 
 #[cfg(all(
     not(feature = "feat_external_libstdbuf"),
-    any(target_os = "cygwin", target_os = "windows")
+    any(target_os = "cygwin", windows)
 ))]
 const STDBUF_INJECT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/libstdbuf.dll"));
 

--- a/src/uu/sum/src/sum.rs
+++ b/src/uu/sum/src/sum.rs
@@ -76,7 +76,7 @@ fn open(name: &OsString) -> UResult<Reader> {
     } else {
         let path = Path::new(name);
         // some platforms cannot catch those errors when open or read. needs additional cost
-        #[cfg(any(target_os = "wasi", target_os = "windows"))]
+        #[cfg(any(target_os = "wasi", windows))]
         match path.metadata() {
             Ok(_) => {
                 if path.is_dir() {

--- a/src/uu/sync/Cargo.toml
+++ b/src/uu/sync/Cargo.toml
@@ -27,7 +27,7 @@ fluent = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_System_WindowsProgramming",

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -251,7 +251,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if files.is_empty() {
             sync()?;
         } else {
-            #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "android", windows))]
             syncfs(&files)?;
         }
     } else if matches.get_flag(options::DATA) {
@@ -297,7 +297,7 @@ fn sync() -> UResult<()> {
     platform::do_sync()
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "android", windows))]
 fn syncfs(files: &[String]) -> UResult<()> {
     platform::do_syncfs(files)
 }

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -475,9 +475,9 @@ pub fn uu_app() -> Command {
     let polling_help = translate!("tail-help-polling-linux");
     #[cfg(all(unix, not(target_os = "linux")))]
     let polling_help = translate!("tail-help-polling-unix");
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let polling_help = translate!("tail-help-polling-windows");
-    #[cfg(not(any(unix, target_os = "windows")))]
+    #[cfg(not(any(unix, windows)))]
     let polling_help = translate!("tail-help-polling-unix");
 
     Command::new("tail")

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -558,11 +558,11 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
         }
         _ => {}
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     writer.flush()?;
 
     // SIGPIPE is not available on Windows.
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     writer.flush().inspect_err(|err| {
         if err.kind() == ErrorKind::BrokenPipe {
             std::process::exit(13);

--- a/src/uu/tail/src/text.rs
+++ b/src/uu/tail/src/text.rs
@@ -16,7 +16,7 @@ pub const DEV_PTMX: &str = "/dev/ptmx";
 pub const BACKEND: &str = "inotify";
 #[cfg(all(unix, not(target_os = "linux")))]
 pub const BACKEND: &str = "kqueue";
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 pub const BACKEND: &str = "ReadDirectoryChanges";
-#[cfg(not(any(unix, target_os = "windows")))]
+#[cfg(not(any(unix, windows)))]
 pub const BACKEND: &str = "polling";

--- a/src/uu/touch/Cargo.toml
+++ b/src/uu/touch/Cargo.toml
@@ -34,7 +34,7 @@ libc = { workspace = true }
 [target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_Foundation",

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -885,12 +885,12 @@ where
 /// Platform-specific flush operation
 #[inline]
 pub fn flush_output<W: Write>(output: &mut W) -> UResult<()> {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     return output
         .flush()
         .map_err_context(|| translate!("tr-error-write-error"));
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     match output.flush() {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {

--- a/src/uu/tr/src/simd.rs
+++ b/src/uu/tr/src/simd.rs
@@ -92,12 +92,12 @@ where
 /// Helper function to handle platform-specific write operations
 #[inline]
 pub fn write_output<W: Write>(output: &mut W, buf: &[u8]) -> UResult<()> {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     return output
         .write_all(buf)
         .map_err_context(|| translate!("tr-error-write-error"));
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     match output.write_all(buf) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {

--- a/src/uu/tty/src/tty.rs
+++ b/src/uu/tty/src/tty.rs
@@ -57,7 +57,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         set_exit_code(1);
         writeln!(stdout, "{}", translate!("tty-not-a-tty"))
     };
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let write_result = {
         use std::os::windows::io::AsHandle;
         let stdin = std::io::stdin();
@@ -83,7 +83,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn file_name(handle: std::os::windows::io::BorrowedHandle) -> Option<String> {
     // This code is adapted from rust's standard library
     // https://github.com/rust-lang/rust/blob/0424cc16731e6141a18077f8ccde77ba148d9649/library/std/src/sys/io/is_terminal/windows.rs#L25

--- a/src/uu/unexpand/src/unexpand.rs
+++ b/src/uu/unexpand/src/unexpand.rs
@@ -297,7 +297,7 @@ impl Read for Input {
 
 fn open(path: &OsString) -> UResult<BufReader<Input>> {
     // some platforms show different read error
-    #[cfg(any(target_os = "wasi", target_os = "windows"))]
+    #[cfg(any(target_os = "wasi", windows))]
     {
         let filename = std::path::Path::new(path);
         if filename.is_dir() {

--- a/src/uu/whoami/Cargo.toml
+++ b/src/uu/whoami/Cargo.toml
@@ -21,7 +21,7 @@ clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process"] }
 fluent = { workspace = true }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_NetworkManagement_NetManagement",
   "Win32_System_WindowsProgramming",

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -118,7 +118,7 @@ xattr = { workspace = true, optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { workspace = true, optional = true }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 wild = { workspace = true }
 windows-sys = { workspace = true, optional = true, default-features = false, features = [
   "Wdk_System_SystemInformation",

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -594,7 +594,7 @@ fn get_file_to_check(
 /// Returns a reader to the list of checksums
 fn get_input_file(filename: &OsStr) -> UResult<Box<dyn Read>> {
     let file = File::open(filename).map_err(|e| match e.kind() {
-        #[cfg(any(target_os = "wasi", target_os = "windows"))]
+        #[cfg(any(target_os = "wasi", windows))]
         io::ErrorKind::NotFound => io::Error::other(format!(
             "{}: {}",
             filename.maybe_quote(),
@@ -603,7 +603,7 @@ fn get_input_file(filename: &OsStr) -> UResult<Box<dyn Read>> {
         _ => io::Error::other(format!("{}: {}", filename.maybe_quote(), strip_errno(&e))),
     })?;
     // some platforms shows different read error
-    #[cfg(any(target_os = "wasi", target_os = "windows"))]
+    #[cfg(any(target_os = "wasi", windows))]
     if file.metadata().is_ok_and(|m| m.is_dir()) {
         return Err(io::Error::other(
             translate!("error-is-a-directory", "file" => filename.maybe_quote()),

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -65,7 +65,7 @@ impl FileInformation {
     }
 
     /// Get information from a currently open file
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     pub fn from_file(file: &impl AsRawHandle) -> IOResult<Self> {
         let mut info = BY_HANDLE_FILE_INFORMATION::default();
         // SAFETY: `info` is a valid pointer to be populated by GetFileInformationByHandle.
@@ -89,7 +89,7 @@ impl FileInformation {
             };
             Ok(Self(stat?))
         }
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             use std::fs::OpenOptions;
             use std::os::windows::fs::OpenOptionsExt;
@@ -112,7 +112,7 @@ impl FileInformation {
             assert!(self.0.st_size >= 0, "File size is negative");
             self.0.st_size.try_into().unwrap()
         }
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             ((self.0.nFileSizeHigh as u64) << 32) | (self.0.nFileSizeLow as u64)
         }
@@ -187,7 +187,7 @@ impl PartialEq for FileInformation {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 impl PartialEq for FileInformation {
     fn eq(&self, other: &Self) -> bool {
         self.0.dwVolumeSerialNumber == other.0.dwVolumeSerialNumber
@@ -204,7 +204,7 @@ impl Hash for FileInformation {
             self.0.st_dev.hash(state);
             self.0.st_ino.hash(state);
         }
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             self.0.dwVolumeSerialNumber.hash(state);
             self.file_index().hash(state);

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -432,7 +432,7 @@ use crate::error::UResult;
     target_vendor = "apple",
     target_os = "netbsd",
     target_os = "openbsd",
-    target_os = "windows"
+    windows
 ))]
 use crate::error::USimpleError;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "cygwin"))]
@@ -442,9 +442,9 @@ use std::io::{BufRead, BufReader};
 #[cfg(any(
     target_vendor = "apple",
     target_os = "freebsd",
-    target_os = "windows",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    windows
 ))]
 use std::ptr;
 #[cfg(any(

--- a/src/uucore/src/lib/features/process/unix.rs
+++ b/src/uucore/src/lib/features/process/unix.rs
@@ -182,7 +182,7 @@ const MAX_KTIME_T: Duration = if cfg!(target_os = "linux") {
 /// Sets up a timer on SIGALRM for platforms that support POSIX.1-2008 realtime
 /// clock extensions. Notably, both Android and Redox do not support the latter
 /// fallback since it was removed in that same spec.
-#[cfg(not(any(target_vendor = "apple", target_os = "openbsd", target_os = "windows")))]
+#[cfg(not(any(target_vendor = "apple", target_os = "openbsd", windows)))]
 mod timer {
     use super::MAX_KTIME_T;
     use std::io;
@@ -297,7 +297,7 @@ mod timer {
 
 /// Sets up a timer on SIGALRM for platforms that do not support POSIX.1-2008
 /// realtime clock extensions. Notably, Darwin, OpenBSD, and Windows.
-#[cfg(any(target_vendor = "apple", target_os = "openbsd", target_os = "windows"))]
+#[cfg(any(target_vendor = "apple", target_os = "openbsd", windows))]
 mod timer {
     use super::MAX_KTIME_T;
     use nix::errno::Errno;

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -10,7 +10,7 @@
 // * feature-gated external crates (re-shared as public internal modules)
 #[cfg(feature = "libc")]
 pub extern crate libc;
-#[cfg(all(feature = "windows-sys", target_os = "windows"))]
+#[cfg(all(feature = "windows-sys", windows))]
 pub extern crate windows_sys;
 
 //## internal modules

--- a/tests/by-util/test_chown.rs
+++ b/tests/by-util/test_chown.rs
@@ -35,9 +35,9 @@ fn skipping_test_is_okay(result: &CmdResult, needle: &str) -> bool {
     false
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "android", windows))]
 const ROOT_GROUP: &str = "root";
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", windows)))]
 const ROOT_GROUP: &str = "wheel";
 
 #[cfg(test)]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -2997,7 +2997,7 @@ fn test_cp_sparse_never_reflink_always() {
 // Regression test for https://github.com/uutils/coreutils/issues/12186
 // `cp --sparse=always` should be supported on Windows (matching GNU), not
 // rejected with "--sparse is only supported on linux".
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_sparse_always_windows() {
     use std::os::windows::fs::MetadataExt;
@@ -3034,7 +3034,7 @@ fn test_cp_sparse_always_windows() {
 // Companion to the regression above: `cp --sparse=never` must also be accepted
 // on Windows and produce a faithful, non-sparse copy (it was rejected by the
 // same "--sparse is only supported on linux" error before #12186).
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_sparse_never_windows() {
     use std::os::windows::fs::MetadataExt;
@@ -3061,7 +3061,7 @@ fn test_cp_sparse_never_windows() {
 // `--sparse=auto` (the default) must preserve an already-sparse source on Windows,
 // matching GNU. Before this fix the default mode did a plain copy that dropped the
 // source's holes. A non-sparse source must still copy plainly (no new holes).
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_sparse_auto_preserves_sparse_source_windows() {
     use std::os::windows::fs::MetadataExt;
@@ -3116,7 +3116,7 @@ fn test_cp_sparse_auto_preserves_sparse_source_windows() {
 // `--reflink=auto` means "clone if possible, else plain copy" (GNU), so on
 // Windows — which has no reflink support — it must fall back to a plain copy
 // rather than fail.
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_reflink_auto_windows() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -3129,7 +3129,7 @@ fn test_cp_reflink_auto_windows() {
 
 // `--reflink=always` (and bare `--reflink`, which defaults to `always`) must
 // still fail on Windows: cloning was explicitly required but is unsupported.
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_reflink_always_windows() {
     for argument in ["--reflink=always", "--reflink"] {
@@ -3142,7 +3142,7 @@ fn test_cp_reflink_always_windows() {
 
 // `--debug` must report the sparse detection that actually happened: `zeros`
 // when the sparse copy ran (the test temp dir is NTFS, which supports it).
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_cp_debug_sparse_always_windows() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -3360,7 +3360,7 @@ fn test_copy_through_just_created_symlink() {
             .arg("b/1")
             .arg("c")
             .fails()
-            .stderr_only(if cfg!(not(target_os = "windows")) {
+            .stderr_only(if cfg!(not(windows)) {
                 "cp: will not copy 'b/1' through just-created symlink 'c/1'\n"
             } else {
                 "cp: will not copy 'b/1' through just-created symlink 'c\\1'\n"
@@ -3426,7 +3426,7 @@ fn test_cp_symlink_overwrite_detection() {
         .arg("good/README")
         .arg("tmp")
         .fails()
-        .stderr_only(if cfg!(target_os = "windows") {
+        .stderr_only(if cfg!(windows) {
             "cp: will not copy 'good/README' through just-created symlink 'tmp\\README'\n"
         } else {
             "cp: will not copy 'good/README' through just-created symlink 'tmp/README'\n"
@@ -3455,7 +3455,7 @@ fn test_cp_dangling_symlink_inside_directory() {
         .arg("good/README")
         .arg("tmp")
         .fails()
-        .stderr_only( if cfg!(target_os="windows") {
+        .stderr_only( if cfg!(windows) {
             "cp: not writing through dangling symlink 'tmp\\README'\ncp: not writing through dangling symlink 'tmp\\README'\n"
         } else {
             "cp: not writing through dangling symlink 'tmp/README'\ncp: not writing through dangling symlink 'tmp/README'\n"
@@ -4488,7 +4488,7 @@ fn test_cp_archive_on_directory_ending_dot() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "linux", windows, target_os = "macos"))]
 fn test_cp_debug_default() {
     #[cfg(target_os = "macos")]
     let expected = "copy offload: unknown, reflink: unsupported, sparse detection: unsupported";
@@ -4510,7 +4510,7 @@ fn test_cp_debug_default() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "linux", windows, target_os = "macos"))]
 fn test_cp_debug_multiple_default() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -6984,7 +6984,7 @@ fn test_copy_symlink_overwrite() {
         .arg("b/1")
         .arg("c")
         .fails()
-        .stderr_only(if cfg!(not(target_os = "windows")) {
+        .stderr_only(if cfg!(not(windows)) {
             "cp: will not overwrite just-created 'c/1' with 'b/1'\n"
         } else {
             "cp: will not overwrite just-created 'c\\1' with 'b/1'\n"
@@ -7000,7 +7000,7 @@ fn test_symlink_mode_overwrite() {
     at.write("a/t", "hello");
     at.write("b/t", "hello");
 
-    if cfg!(not(target_os = "windows")) {
+    if cfg!(not(windows)) {
         ucmd.arg("-s")
             .arg("a/t")
             .arg("b/t")
@@ -8460,7 +8460,7 @@ fn test_cp_xattr_enotsup_handling() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_cp_preserve_directory_permissions_by_default() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -8504,7 +8504,7 @@ fn test_cp_preserve_directory_permissions_by_default() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_cp_existing_perm_dir() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;
@@ -8534,7 +8534,7 @@ fn test_cp_existing_perm_dir() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_cp_gnu_preserve_mode() {
     use std::io;
 

--- a/tests/by-util/test_df.rs
+++ b/tests/by-util/test_df.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashSet;
 
-#[cfg(not(any(target_os = "freebsd", target_os = "windows")))]
+#[cfg(not(any(target_os = "freebsd", windows)))]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 #[cfg(target_os = "linux")]
@@ -340,7 +340,7 @@ fn test_type_option() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd", target_os = "openbsd", target_os = "windows")))] // FIXME: fix test for FreeBSD, OpenBSD & Win
+#[cfg(not(any(target_os = "freebsd", target_os = "openbsd", windows)))] // FIXME: fix test for FreeBSD, OpenBSD & Win
 #[cfg(not(feature = "feat_selinux"))]
 fn test_type_option_with_file() {
     let fs_type = new_ucmd!()
@@ -1006,7 +1006,7 @@ fn test_output_file_all_filesystems() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd", target_os = "windows")))] // FIXME: fix test for FreeBSD & Win
+#[cfg(not(any(target_os = "freebsd", windows)))] // FIXME: fix test for FreeBSD & Win
 fn test_output_file_specific_files() {
     // Create three files.
     let (at, mut ucmd) = at_and_ucmd!();
@@ -1025,7 +1025,7 @@ fn test_output_file_specific_files() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd", target_os = "windows")))] // FIXME: fix test for FreeBSD & Win
+#[cfg(not(any(target_os = "freebsd", windows)))] // FIXME: fix test for FreeBSD & Win
 fn test_file_column_width_if_filename_contains_unicode_chars() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("äöü.txt");
@@ -1048,7 +1048,7 @@ fn test_output_field_no_more_than_once() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd", target_os = "windows")))] // FIXME: fix test for FreeBSD & Win
+#[cfg(not(any(target_os = "freebsd", windows)))] // FIXME: fix test for FreeBSD & Win
 fn test_nonexistent_file() {
     new_ucmd!()
         .arg("does-not-exist")

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -9,10 +9,10 @@
 #[cfg(not(windows))]
 use regex::Regex;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use uutests::unwrap_or_return;
 use uutests::util::TestScenario;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 use uutests::util::expected_result;
 use uutests::{at_and_ucmd, new_ucmd, util_name};
 
@@ -56,7 +56,7 @@ fn du_basics(s: &str) {
     assert_eq!(s, answer);
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn du_basics(s: &str) {
     let answer = concat!(
         "0\t.\\subdir\\deeper\\deeper_dir\n",
@@ -68,11 +68,7 @@ fn du_basics(s: &str) {
     assert_eq!(s, answer);
 }
 
-#[cfg(all(
-    not(target_vendor = "apple"),
-    not(target_os = "windows"),
-    not(target_os = "openbsd")
-))]
+#[cfg(all(not(target_vendor = "apple"), not(target_os = "openbsd"), not(windows)))]
 fn du_basics(s: &str) {
     let answer = concat!(
         "8\t./subdir/deeper/deeper_dir\n",
@@ -116,7 +112,7 @@ fn test_du_basics_subdir() {
 fn du_basics_subdir(s: &str) {
     assert_eq!(s, "4\tsubdir/deeper/deeper_dir\n8\tsubdir/deeper\n");
 }
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn du_basics_subdir(s: &str) {
     assert_eq!(s, "0\tsubdir/deeper\\deeper_dir\n0\tsubdir/deeper\n");
 }
@@ -126,9 +122,9 @@ fn du_basics_subdir(s: &str) {
 }
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 fn du_basics_subdir(s: &str) {
     // MS-WSL linux has altered expected output
@@ -522,7 +518,7 @@ fn test_du_soft_link() {
     println!("Output: {s}");
 
     // Helper closure to assert output matches one of the valid sizes
-    #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd"))]
+    #[cfg(any(target_vendor = "apple", windows, target_os = "freebsd"))]
     let assert_valid_size = |output: &str, valid_sizes: &[&str]| {
         assert!(
             valid_sizes.contains(&output),
@@ -541,7 +537,7 @@ fn test_du_soft_link() {
         assert_valid_size(s, &valid_sizes);
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         let valid_sizes = ["4\tsubdir/links\n", "8\tsubdir/links\n"];
         assert_valid_size(s, &valid_sizes);
@@ -555,11 +551,7 @@ fn test_du_soft_link() {
         assert_valid_size(s, &valid_sizes);
     }
 
-    #[cfg(all(
-        not(target_vendor = "apple"),
-        not(target_os = "windows"),
-        not(target_os = "freebsd")
-    ))]
+    #[cfg(all(not(target_vendor = "apple"), not(target_os = "freebsd"), not(windows)))]
     {
         // MS-WSL linux has altered expected output
         if uucore::os::is_wsl_1() {
@@ -596,7 +588,7 @@ fn test_du_hard_link() {
 fn du_hard_link(s: &str) {
     assert_eq!(s, "12\tsubdir/links\n");
 }
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn du_hard_link(s: &str) {
     assert_eq!(s, "8\tsubdir/links\n");
 }
@@ -606,10 +598,10 @@ fn du_hard_link(s: &str) {
 }
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
     not(target_os = "openbsd"),
-    not(target_os = "android")
+    not(target_os = "android"),
+    not(windows)
 ))]
 fn du_hard_link(s: &str) {
     // MS-WSL linux has altered expected output
@@ -642,7 +634,7 @@ fn test_du_d_flag() {
 fn du_d_flag(s: &str) {
     assert_eq!(s, "20\t./subdir\n24\t.\n");
 }
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn du_d_flag(s: &str) {
     assert_eq!(s, "8\t.\\subdir\n8\t.\n");
 }
@@ -652,9 +644,9 @@ fn du_d_flag(s: &str) {
 }
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 fn du_d_flag(s: &str) {
     // MS-WSL linux has altered expected output
@@ -716,7 +708,7 @@ fn test_du_dereference_args() {
 fn du_dereference(s: &str) {
     assert_eq!(s, "4\tsubdir/links/deeper_dir\n16\tsubdir/links\n");
 }
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn du_dereference(s: &str) {
     assert_eq!(s, "0\tsubdir/links\\deeper_dir\n8\tsubdir/links\n");
 }
@@ -726,9 +718,9 @@ fn du_dereference(s: &str) {
 }
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 fn du_dereference(s: &str) {
     // MS-WSL linux has altered expected output
@@ -740,10 +732,10 @@ fn du_dereference(s: &str) {
 }
 
 #[cfg(not(any(
-    target_os = "windows",
     target_os = "android",
     target_os = "freebsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    windows
 )))]
 #[test]
 fn test_du_no_dereference() {
@@ -792,13 +784,13 @@ fn test_du_inodes_basic() {
     let ts = TestScenario::new(util_name!());
     let result = ts.ucmd().arg("--inodes").succeeds();
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         let result_reference = unwrap_or_return!(expected_result(&ts, &["--inodes"]));
         assert_eq!(result.stdout_str(), result_reference.stdout_str());
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     assert_eq!(
         result.stdout_str(),
         concat!(
@@ -823,9 +815,9 @@ fn test_du_inodes() {
 
     let result = ts.ucmd().arg("--separate-dirs").arg("--inodes").succeeds();
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     result.stdout_contains("3\t.\\subdir\\links\n");
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     result.stdout_contains("3\t./subdir/links\n");
     result.stdout_contains("3\t.\n");
 
@@ -1380,7 +1372,7 @@ fn test_du_time_unaffected_by_exclude() {
     assert!(stdout.contains("\td\n"), "missing dir entry: {stdout}");
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "openbsd")))]
+#[cfg(not(any(windows, target_os = "openbsd")))]
 #[cfg(feature = "chmod")]
 #[test]
 fn test_du_no_permission() {
@@ -1411,7 +1403,7 @@ fn test_du_no_permission() {
     assert_eq!(result.stdout_str(), "0\tsubdir/links\n");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 #[cfg(feature = "chmod")]
 #[test]
 fn test_du_no_exec_permission() {
@@ -1533,7 +1525,7 @@ fn test_du_apparent_size() {
 
     let result = ucmd.args(&["--apparent-size", "--all", "a"]).succeeds();
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         result.stdout_contains_line("1\ta/b/file2");
         result.stdout_contains_line("1\ta/b/file1");
@@ -1541,7 +1533,7 @@ fn test_du_apparent_size() {
         result.stdout_contains_line("1\ta");
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         result.stdout_contains_line("1\ta\\b\\file2");
         result.stdout_contains_line("1\ta\\b\\file1");
@@ -1561,7 +1553,7 @@ fn test_du_bytes() {
 
     let result = ucmd.args(&["--bytes", "--all", "a"]).succeeds();
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         result.stdout_contains_line("6\ta/b/file2");
         result.stdout_contains_line("3\ta/b/file1");
@@ -1569,7 +1561,7 @@ fn test_du_bytes() {
         result.stdout_contains_line("9\ta");
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         result.stdout_contains_line("6\ta\\b\\file2");
         result.stdout_contains_line("3\ta\\b\\file1");
@@ -1607,7 +1599,7 @@ fn test_du_exclude() {
 #[test]
 // Disable on Windows because we are looking for /
 // And the tests would be more complex if we have to support \ too
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_du_exclude_2() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -1658,7 +1650,7 @@ fn test_du_exclude_2() {
 #[test]
 // Disable on Windows because we are looking for /
 // And the tests would be more complex if we have to support \ too
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_du_exclude_mix() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -1713,7 +1705,7 @@ fn test_du_exclude_mix() {
 #[test]
 // Disable on Windows because we are looking for /
 // And the tests would be more complex if we have to support \ too
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_du_complex_exclude_patterns() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;
@@ -1823,7 +1815,7 @@ fn test_du_symlink_multiple_fail() {
 
 #[test]
 // Disable on Windows because of different path separators and handling of null characters
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_du_files0_from() {
     let ts = TestScenario::new(util_name!());
     let at = &ts.fixtures;

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -75,7 +75,7 @@ fn test_invalid_arg() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_flags_after_command() {
     new_ucmd!()
         // This would cause an error if -u=v were processed because it's malformed
@@ -159,9 +159,9 @@ fn test_env_permissions() {
 
 #[test]
 fn test_echo() {
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let args = ["cmd", "/d/c", "echo"];
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     let args = ["echo"];
 
     let result = new_ucmd!().args(&args).arg("FOO-bar").succeeds();
@@ -169,7 +169,7 @@ fn test_echo() {
     assert_eq!(result.stdout_str().trim(), "FOO-bar");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 #[test]
 fn test_if_windows_batch_files_can_be_executed() {
     let result = new_ucmd!().arg("./runBat.bat").succeeds();
@@ -538,7 +538,7 @@ fn test_chdir_happens_after_relative_file_loading() {
     );
 }
 
-#[cfg(not(target_os = "windows"))] // windows has no executable "echo", its only supported as part of a batch-file
+#[cfg(not(windows))] // windows has no executable "echo", its only supported as part of a batch-file
 #[test]
 fn test_split_string_into_args_one_argument_no_quotes() {
     let scene = TestScenario::new(util_name!());
@@ -551,7 +551,7 @@ fn test_split_string_into_args_one_argument_no_quotes() {
     assert_eq!(out, "hello world\n");
 }
 
-#[cfg(not(target_os = "windows"))] // windows has no executable "echo", its only supported as part of a batch-file
+#[cfg(not(windows))] // windows has no executable "echo", its only supported as part of a batch-file
 #[test]
 fn test_split_string_into_args_one_argument() {
     let scene = TestScenario::new(util_name!());
@@ -564,7 +564,7 @@ fn test_split_string_into_args_one_argument() {
     assert_eq!(out, "hello world\n");
 }
 
-#[cfg(not(target_os = "windows"))] // windows has no executable "echo", its only supported as part of a batch-file
+#[cfg(not(windows))] // windows has no executable "echo", its only supported as part of a batch-file
 #[test]
 fn test_split_string_into_args_s_escaping_challenge() {
     let scene = TestScenario::new(util_name!());
@@ -588,7 +588,7 @@ fn test_split_string_into_args_s_escaped_c_not_allowed() {
     );
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_into_args_s_whitespace_handling() {
     let scene = TestScenario::new(util_name!());
@@ -601,7 +601,7 @@ fn test_split_string_into_args_s_whitespace_handling() {
     assert_eq!(out, "xAx\nxBx\n");
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_into_args_long_option_whitespace_handling() {
     let scene = TestScenario::new(util_name!());
@@ -614,7 +614,7 @@ fn test_split_string_into_args_long_option_whitespace_handling() {
     assert_eq!(out, "xAx\nxBx\n");
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_option_forms_match_gnu_required_argument_handling() {
     let scene = TestScenario::new(util_name!());
@@ -638,7 +638,7 @@ fn test_split_string_option_forms_match_gnu_required_argument_handling() {
         .stdout_is("x:one\nx:two\n");
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_into_args_debug_output_whitespace_handling() {
     let scene = TestScenario::new(util_name!());
@@ -685,7 +685,7 @@ fn test_env_split_quoted_with_backslash_space() {
     assert_eq!(out.stdout_str(), output);
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_single_quotes_keep_unknown_backslash_sequences_literal() {
     let scene = TestScenario::new(util_name!());
@@ -721,7 +721,7 @@ fn test_split_string_single_quotes_keep_unknown_backslash_sequences_literal() {
         .stdout_is("\\9");
 }
 
-#[cfg(not(target_os = "windows"))] // no printf available
+#[cfg(not(windows))] // no printf available
 #[test]
 fn test_split_string_backslash_a_behavior_matches_gnu_quoting_context() {
     let scene = TestScenario::new(util_name!());
@@ -1496,7 +1496,7 @@ mod test_raw_string_parser {
         string_parser,
     };
 
-    const LEN_OWL: usize = if cfg!(target_os = "windows") { 2 } else { 4 };
+    const LEN_OWL: usize = if cfg!(windows) { 2 } else { 4 };
 
     #[test]
     fn test_ascii_only_take_one_look_at_correct_data_and_end_behavior() {
@@ -1709,7 +1709,7 @@ mod test_raw_string_parser {
     fn test_deal_with_invalid_encoding() {
         let owl_invalid_part;
         let (brace_1, brace_2);
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             let mut buffer = [0u16; 2];
             let owl = '🦉'.encode_utf16(&mut buffer);
@@ -1717,7 +1717,7 @@ mod test_raw_string_parser {
             brace_1 = '<'.encode_utf16(&mut buffer).to_vec();
             brace_2 = '>'.encode_utf16(&mut buffer).to_vec();
         }
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         {
             let mut buffer = [0u8; 4];
             let owl = '🦉'.encode_utf8(&mut buffer);
@@ -1987,7 +1987,7 @@ fn test_shebang_error() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_reject_shell_style_variable_expansions() {
     for split in [
         "-Secho $TEST_VAR_12345",
@@ -2004,7 +2004,7 @@ fn test_reject_shell_style_variable_expansions() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_simple_braced_variable() {
     new_ucmd!()
         .env("TEST_VAR_12345", "value")

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -6,11 +6,11 @@
 // spell-checker:ignore (words) bogusfile emptyfile abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstu
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 use std::io::Read;
 use uutests::new_ucmd;
@@ -577,11 +577,11 @@ fn test_all_but_last_lines_large_file() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(
@@ -681,11 +681,11 @@ fn test_validate_stdin_offset_lines() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(
@@ -810,11 +810,11 @@ fn test_validate_stdin_offset_bytes() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/proc) not visible")]
@@ -827,11 +827,11 @@ fn test_read_backwards_bytes_proc_fs_version() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/proc) not visible")]
@@ -848,11 +848,11 @@ fn test_read_backwards_bytes_proc_fs_modules() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/proc) not visible")]
@@ -869,11 +869,11 @@ fn test_read_backwards_lines_proc_fs_modules() {
 }
 
 #[cfg(all(
-    not(target_os = "windows"),
     not(target_os = "macos"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 #[test]
 #[cfg_attr(wasi_runner, ignore = "WASI sandbox: host paths (/sys) not visible")]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -3296,7 +3296,7 @@ mod quoting {
         );
     }
 
-    #[cfg(not(any(target_vendor = "apple", target_os = "windows", target_os = "openbsd")))]
+    #[cfg(not(any(target_vendor = "apple", windows, target_os = "openbsd")))]
     #[test]
     /// This test creates files with an UTF-8 encoded name and verify that it
     /// gets escaped depending on the used locale.
@@ -3743,7 +3743,7 @@ fn test_ls_indicator_style() {
     }
 }
 
-#[cfg(not(any(target_vendor = "apple", target_os = "windows", target_os = "openbsd")))] // Truncate not available on mac or win
+#[cfg(not(any(target_vendor = "apple", windows, target_os = "openbsd")))] // Truncate not available on mac or win
 #[test]
 fn test_ls_human_si() {
     let scene = TestScenario::new(util_name!());
@@ -6316,7 +6316,7 @@ fn test_ls_hyperlink() {
 fn test_ls_hyperlink_encode_link() {
     let (at, mut ucmd) = at_and_ucmd!();
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         at.touch("back\\slash");
         at.touch("ques?tion");
@@ -6325,7 +6325,7 @@ fn test_ls_hyperlink_encode_link() {
     at.touch("sp ace");
 
     let result = ucmd.arg("--hyperlink").succeeds();
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     {
         assert!(
             result
@@ -6491,9 +6491,9 @@ fn test_ls_hyperlink_utf8_encoding() {
     let at = &scene.fixtures;
 
     at.touch("café.txt");
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     at.touch("file:with:colons.txt");
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     at.touch("file-with-colons.txt");
     at.touch("file with spaces.txt");
 
@@ -6501,9 +6501,9 @@ fn test_ls_hyperlink_utf8_encoding() {
     let output = result.stdout_str();
 
     assert!(output.contains("caf%c3%a9.txt"));
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     assert!(output.contains("file%3awith%3acolons.txt"));
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     assert!(output.contains("file-with-colons.txt"));
     assert!(output.contains("file%20with%20spaces.txt"));
 

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -1401,7 +1401,7 @@ fn test_hex_lowercase() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 #[cfg_attr(wasi_runner, ignore)]
 fn test_is_a_directory() {
     let scene = TestScenario::new(util_name!());

--- a/tests/by-util/test_sync.rs
+++ b/tests/by-util/test_sync.rs
@@ -80,7 +80,7 @@ fn test_sync_no_permission_dir() {
     result.stderr_contains("sync: error opening 'foo': Permission denied");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 #[cfg(feature = "chmod")]
 #[test]
 fn test_sync_no_permission_file() {

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -18,9 +18,9 @@ use rand::distr::Alphanumeric;
 use rstest::rstest;
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(windows)
 ))]
 use rustix::process::{Pid, Signal, kill_process};
 use std::char::from_digit;
@@ -31,9 +31,9 @@ use std::io::{Seek, SeekFrom};
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 use std::path::Path;
 use std::process::Stdio;
@@ -41,9 +41,9 @@ use tail::chunks::BUFFER_SIZE as CHUNK_BUFFER_SIZE;
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 use tail::text;
 use uutests::at_and_ucmd;
@@ -336,10 +336,10 @@ fn test_follow_redirect_stdin_name_retry() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_stdin_redirect_dir() {
     // $ mkdir dir
@@ -552,7 +552,7 @@ fn test_follow_single() {
 
 /// Test for following when bytes are written that are not valid UTF-8.
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: test times out
+#[cfg(not(windows))] // FIXME: test times out
 fn test_follow_non_utf8_bytes() {
     // Tail the test file and start following it.
     let (at, mut ucmd) = at_and_ucmd!();
@@ -730,7 +730,7 @@ fn test_follow_stdin_pipe() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: for currently not working platforms
+#[cfg(not(windows))] // FIXME: for currently not working platforms
 fn test_follow_invalid_pid() {
     new_ucmd!()
         .args(&["-f", "--pid=-1234"])
@@ -758,9 +758,9 @@ fn test_follow_invalid_pid() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "freebsd")
+    not(target_os = "freebsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_with_pid() {
     use std::process::Command;
@@ -1377,10 +1377,10 @@ fn test_retry_missing_file_error() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_retry_follow_name_waits_for_creation() {
     // Test tail --retry behavior
@@ -1422,10 +1422,10 @@ fn test_retry_follow_name_waits_for_creation() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_retry_descriptor_detects_truncation() {
     // Test tail --retry behavior
@@ -1481,10 +1481,10 @@ fn test_retry_descriptor_detects_truncation() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_retry_descriptor_gives_up_on_untailable() {
     // Test tail --retry behavior
@@ -1526,7 +1526,7 @@ fn test_retry_descriptor_gives_up_on_untailable() {
 // ==> existing <==
 // >X
 #[test]
-#[cfg(all(not(target_os = "windows"), not(target_os = "android")))] // FIXME: for currently not working platforms
+#[cfg(all(not(windows), not(target_os = "android")))] // FIXME: for currently not working platforms
 fn test_descriptor_no_retry_skips_late_file() {
     // Test tail --retry behavior
     // Ensure that --follow=descriptor (without --retry) does *not* try
@@ -1571,10 +1571,10 @@ fn test_descriptor_no_retry_skips_late_file() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_capital_f_recovers_after_dir_swap() {
     // Test tail --retry behavior
@@ -1702,10 +1702,10 @@ fn test_follow_name_replaced_by_symlink_is_untailable() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_retry8() {
     // Ensure that inotify will switch to polling mode if directory
@@ -1772,9 +1772,9 @@ fn test_retry8() {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_retry9() {
     // Test inotify behavior when directory is recreated
@@ -1854,9 +1854,9 @@ fn test_retry9() {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_descriptor_vs_rename1() {
     // Test file descriptor behavior vs rename
@@ -1918,9 +1918,9 @@ fn test_follow_descriptor_vs_rename1() {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_descriptor_vs_rename2() {
     // Ensure the headers are correct for --verbose.
@@ -1970,10 +1970,10 @@ fn test_follow_descriptor_vs_rename2() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_shows_headers_on_creation() {
     // Test -F flag with file headers
@@ -2040,7 +2040,7 @@ fn test_follow_name_shows_headers_on_creation() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "windows"), not(target_os = "android")))] // FIXME: for currently not working platforms
+#[cfg(all(not(windows), not(target_os = "android")))] // FIXME: for currently not working platforms
 fn test_follow_name_remove() {
     // This test triggers a remove event while `tail --follow=name file` is running.
     // ((sleep 2 && rm file &)>/dev/null 2>&1 &) ; tail --follow=name file
@@ -2213,7 +2213,7 @@ fn test_follow_name_truncate3() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
+    not(windows),
     not(feature = "feat_selinux") // flaky
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_truncate4() {
@@ -2250,7 +2250,7 @@ fn test_follow_name_truncate4() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: for currently not working platforms
+#[cfg(not(windows))] // FIXME: for currently not working platforms
 fn test_follow_detects_file_truncation() {
     // Test tail behavior on file truncation
     // Ensure all logs are output upon file truncation
@@ -2305,10 +2305,10 @@ fn test_follow_detects_file_truncation() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_create1() {
     // This test triggers a move/create event while `tail --follow=name file` is running.
@@ -2362,9 +2362,9 @@ fn test_follow_name_move_create1() {
 #[cfg(all(
     not(target_vendor = "apple"),
     not(target_os = "android"),
-    not(target_os = "windows"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_hash_table_stress() {
     // Test inotify hash table under heavy file churn by watching 9 files simultaneously.
@@ -2441,10 +2441,10 @@ fn test_follow_name_hash_table_stress() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move1() {
     // This test triggers a move event while `tail --follow=name file` is running.
@@ -2503,10 +2503,10 @@ fn test_follow_name_move1() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move2() {
     // Like test_follow_name_move1, but move to a name that's already monitored.
@@ -2591,10 +2591,10 @@ fn test_follow_name_move2() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_move_retry1() {
     // Similar to test_follow_name_move1 but with `--retry` (`-F`)
@@ -2651,10 +2651,10 @@ fn test_follow_name_move_retry1() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))] // FIXME: for currently not working platforms
 fn test_follow_name_rename_chain() {
     // Test -F flag behavior across file renames
@@ -2755,7 +2755,7 @@ fn test_follow_name_rename_chain() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))] // FIXME: for currently not working platforms
+#[cfg(not(windows))] // FIXME: for currently not working platforms
 fn test_follow_inotify_only_regular() {
     // The GNU test inotify-only-regular.sh uses strace to ensure that `tail -f`
     // doesn't make inotify syscalls and only uses inotify for regular files or fifos.
@@ -2830,10 +2830,10 @@ fn test_fifo() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
     not(target_os = "android"),
     not(target_os = "freebsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(windows)
 ))]
 fn test_fifo_with_pid() {
     use std::process::{Command, Stdio};
@@ -3208,7 +3208,7 @@ fn test_pipe_when_lines_option_given_input_size_is_one_byte_greater_than_buffer_
 // FIXME: windows: this test failed with timeout in the CI. Running this test in
 // a Windows VirtualBox image produces no errors.
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_pipe_when_lines_option_given_input_size_has_multiple_size_of_buffer_size() {
     let total_lines = 100;
     let random_string = RandomizedString::generate_with_delimiter(
@@ -3508,7 +3508,7 @@ fn test_pipe_when_bytes_option_given_input_size_is_one_byte_greater_than_buffer_
 // FIXME: windows: this test failed with timeout in the CI. Running this test in
 // a Windows VirtualBox image produces no errors.
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_pipe_when_bytes_option_given_input_size_has_multiple_size_of_buffer_size() {
     let random_string = RandomizedString::generate(AlphanumericNewline, CHUNK_BUFFER_SIZE * 3);
     let random_string = random_string.as_str();
@@ -3622,7 +3622,7 @@ fn test_seek_bytes_forward_outside_file() {
 // Some basic tests for ---presume-input-pipe. These tests build upon the
 // debug_assert in bounded tail to detect that we're using the bounded_tail in
 // case the option is given on command line.
-#[cfg(all(not(target_os = "android"), not(target_os = "windows")))] // FIXME:
+#[cfg(all(not(target_os = "android"), not(windows)))] // FIXME:
 #[test]
 fn test_args_when_presume_input_pipe_given_input_is_pipe() {
     let random_string = RandomizedString::generate(AlphanumericNewline, 1000);
@@ -4638,7 +4638,7 @@ fn test_args_when_directory_given_shorthand_big_f_together_with_retry() {
 #[test]
 #[cfg(all(
     not(target_vendor = "apple"),
-    not(target_os = "windows"),
+    not(windows),
     not(target_os = "freebsd"),
     not(target_os = "openbsd"),
     not(feature = "feat_selinux") // flaky

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -862,7 +862,7 @@ fn test_touch_dash_updates_stdout_file() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 fn test_touch_trailing_slash() {
     let file = "no-file/";
     new_ucmd!().args(&[file]).fails().stderr_only(format!(
@@ -871,7 +871,7 @@ fn test_touch_trailing_slash() {
 }
 
 #[test]
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 fn test_touch_trailing_slash_windows() {
     let file = "no-file/";
     new_ucmd!()

--- a/tests/by-util/test_uname.rs
+++ b/tests/by-util/test_uname.rs
@@ -111,7 +111,7 @@ fn test_uname_operating_system() {
         .arg("--operating-system")
         .succeeds()
         .stdout_is("Redox\n");
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     {
         let result = new_ucmd!().arg("--operating-system").succeeds();
         println!("{:?}", result.stdout_str());


### PR DESCRIPTION
Simplify `target_os = "windows"` by `cfg(windows)` which is already used at our codebase.