### PR TITLE
ln: remove pub to improve the public API

### DIFF
--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -263,10 +263,7 @@ pub fn uu_app() -> Command {
         )
 }
 
-/// Executes the `ln` utility with the given paths and settings.
-///
-/// This is made public to allow other apps to use `ln` as a library.
-pub fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
+fn exec(files: &[PathBuf], settings: &Settings) -> LnResult<()> {
     // Handle cases where we create links in a directory first.
     if let Some(ref target_path) = settings.target_dir {
         // 4th form: a directory is specified by -t.
@@ -398,8 +395,11 @@ fn is_same_entry(src: &Path, dst: &Path) -> bool {
     }
 }
 
+/// Create symlink to src at dst with the given settings
+///
+/// made public to allow other apps to use `ln` as a library
 #[allow(clippy::cognitive_complexity)]
-fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
+pub fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     let mut backup_path = None;
     let source: Cow<'_, Path> = if settings.relative {
         relative_path(src, dst)

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -397,7 +397,7 @@ fn is_same_entry(src: &Path, dst: &Path) -> bool {
 
 /// Create symlink to src at dst with the given settings
 ///
-/// made public to allow other apps to use `ln` as a library
+/// This is made public to allow other apps to use `ln` as a library.
 #[allow(clippy::cognitive_complexity)]
 pub fn link(src: &Path, dst: &Path, settings: &Settings) -> LnResult<()> {
     let mut backup_path = None;


### PR DESCRIPTION
`pub fn exec` is pub for nushell, however it is badly designed public API because
- it panics if empty array was given
- We need to introduce new dead code (duplication with clap) to avoid panic with wrong usage
- Error handlings are contained which should be covered by clap or nushell side

Closes https://github.com/uutils/coreutils/pull/12257

This change was agreed in https://github.com/uutils/coreutils/pull/12257#issuecomment-5460357158