### PR TITLE
head, tail: reject multiplier suffixes that GNU rejects

### DIFF
--- a/src/uucore/src/lib/features/parser/parse_signed_num.rs
+++ b/src/uucore/src/lib/features/parser/parse_signed_num.rs
@@ -8,8 +8,32 @@
 //! These utilities accept arguments like `-5`, `+10`, `-100K` where the leading
 //! sign indicates different behavior (e.g., "first N" vs "last N" vs "starting from N").
 
-use super::parse_size::{ParseSizeError, parse_size_u64, parse_size_u64_max, size_offset};
+use super::parse_size::{
+    ParseSizeError, Parser, allow_list_with_all_suffixes, parse_size_u64, size_offset,
+};
 use crate::display::Quotable;
+
+/// The multiplier suffixes accepted on a count argument.
+///
+/// Each of these is also valid followed by `B`, `iB` or `D`. A lowercase
+/// letter is only accepted for `k` and `m`; the remaining multipliers must be
+/// uppercase. `b` (512-byte blocks) is handled separately because it is the
+/// one suffix that has no `B`/`iB`/`D` form.
+const MULTIPLIER_SUFFIXES: &str = "kmKMGTPEZYRQ";
+
+/// Parse the numeric part of a count argument, rejecting any suffix that is
+/// not one of [`MULTIPLIER_SUFFIXES`] or a bare `b`.
+///
+/// The generic size parser accepts a lowercase form of every multiplier, which
+/// is more than these utilities allow.
+fn parse_count(size: &str) -> Result<u64, ParseSizeError> {
+    let mut allow_list = allow_list_with_all_suffixes(MULTIPLIER_SUFFIXES);
+    allow_list.push("b".to_string());
+    let allow_list: Vec<&str> = allow_list.iter().map(AsRef::as_ref).collect();
+    Parser::default()
+        .with_allow_list(&allow_list)
+        .parse_u64_max(size)
+}
 
 /// The sign prefix found on a numeric argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,10 +120,10 @@ pub fn parse_signed_num_max(src: &str) -> Result<SignedNum, ParseSizeError> {
         // Otherwise "0K" would parse as 1KiB (bare suffix means 1).
         // A genuinely bare suffix with no digits at all (e.g. "kiB")
         // still parses as 1 of that unit.
-        parse_size_u64_max(trimmed).map_err(|e| as_typed(e, size_string))?;
+        parse_count(trimmed).map_err(|e| as_typed(e, size_string))?;
         0
     } else {
-        parse_size_u64_max(trimmed).map_err(|e| as_typed(e, size_string))?
+        parse_count(trimmed).map_err(|e| as_typed(e, size_string))?
     };
 
     Ok(SignedNum { value, sign })

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -1195,3 +1195,33 @@ fn test_invalid_count_keeps_its_leading_zeros() {
         .fails_with_code(1)
         .stderr_is("head: invalid number of lines: '00x'\n");
 }
+
+#[test]
+fn test_lowercase_multiplier_suffixes_rejected() {
+    // GNU accepts a lowercase suffix only for "k" and "m"; every other
+    // multiplier must be uppercase. "b" is bare-only (no B/iB/D form).
+    for suffix in ["g", "t", "p", "e", "z", "y", "r", "q"] {
+        new_ucmd!()
+            .args(&["-c", &format!("2{suffix}")])
+            .fails_with_code(1)
+            .stderr_is(format!("head: invalid number of bytes: '2{suffix}'\n"));
+        new_ucmd!()
+            .args(&["-n", &format!("2{suffix}")])
+            .fails_with_code(1)
+            .stderr_is(format!("head: invalid number of lines: '2{suffix}'\n"));
+    }
+}
+
+#[test]
+fn test_accepted_multiplier_suffixes() {
+    for suffix in [
+        "b", "k", "m", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q", "kB", "KiB", "kD", "MiB",
+        "GB",
+    ] {
+        new_ucmd!()
+            .args(&["-c", &format!("1{suffix}")])
+            .pipe_in("x")
+            .ignore_stdin_write_error()
+            .succeeds();
+    }
+}

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1246,6 +1246,38 @@ fn test_invalid_num() {
 }
 
 #[test]
+fn test_lowercase_multiplier_suffixes_rejected() {
+    // GNU accepts a lowercase suffix only for "k" and "m"; every other
+    // multiplier must be uppercase. "b" is bare-only (no B/iB/D form).
+    for suffix in ["g", "t", "p", "e", "z", "y", "r", "q"] {
+        new_ucmd!()
+            .args(&["-c", &format!("2{suffix}")])
+            .fails()
+            .stderr_str()
+            .starts_with(&format!("tail: invalid number of bytes: '2{suffix}'"));
+        new_ucmd!()
+            .args(&["-n", &format!("2{suffix}")])
+            .fails()
+            .stderr_str()
+            .starts_with(&format!("tail: invalid number of lines: '2{suffix}'"));
+    }
+}
+
+#[test]
+fn test_accepted_multiplier_suffixes() {
+    for suffix in [
+        "b", "k", "m", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q", "kB", "KiB", "kD", "MiB",
+        "GB",
+    ] {
+        new_ucmd!()
+            .args(&["-c", &format!("1{suffix}")])
+            .pipe_in("x")
+            .ignore_stdin_write_error()
+            .succeeds();
+    }
+}
+
+#[test]
 fn test_oversized_num() {
     const BIG: &str = "99999999999999999999999999999";
     const DATA: &str = "abcd";


### PR DESCRIPTION
Fixes #13136.

`head` and `tail` parse their count argument through `parse_signed_num_max`, which uses the generic size parser with no allow list. That parser accepts a lowercase form of every multiplier, so `2g`, `2t`, `2p`, `2e`, `2z`, `2y`, `2r` and `2q` were silently accepted:

```console
$ tail -c2z a        # accepted, treated as 2 ZiB
hello
```

GNU reports `invalid number of bytes: '2z'` for all of these. It accepts a lowercase suffix only for `k` and `m`.

This restricts the shared parser to the set both utilities accept: `k m K M G T P E Z Y R Q`, each also valid followed by `B`, `iB` or `D`, plus a bare `b` (which has no `B`/`iB`/`D` form). `head` and `tail` take the same set, so one allow list covers both.

I derived the set by running GNU coreutils 9.11 and comparing, not from its source. After the change I diffed every letter of the alphabet in all four forms (`X`, `XB`, `XiB`, `XD`) for `-c` on both utilities, 208 combinations, and every `-n` combination with a `+`/`-` prefix: no remaining differences.

Tests added to `test_head.rs` and `test_tail.rs` cover both the newly rejected suffixes and the accepted ones, for `-c` and `-n`, so a regression in either direction fails.

One thing left out deliberately: with a leading zero the error names the trimmed string, so `tail -c0g` says `invalid number of bytes: 'g'` where GNU says `'0g'`. That is pre-existing (`tail -c0fb` misreports the same way today) and unrelated to the suffix set, so I will report it separately.