### PR TITLE
stty: gate by target support

### DIFF
--- a/src/uu/stty/Cargo.toml
+++ b/src/uu/stty/Cargo.toml
@@ -15,16 +15,14 @@ readme.workspace = true
 path = "src/stty.rs"
 doctest = false
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 clap = { workspace = true }
+nix = { workspace = true, features = ["ioctl", "term"] }
 uucore = { workspace = true, features = ["parser"] }
 fluent = { workspace = true }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }
-
-[target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["ioctl", "term"] }
 
 [lints]
 workspace = true
@@ -32,3 +30,4 @@ workspace = true
 [[bin]]
 name = "stty"
 path = "src/main.rs"
+required-features = ["uucore/default"]

--- a/src/uu/stty/src/flags.rs
+++ b/src/uu/stty/src/flags.rs
@@ -57,6 +57,7 @@ pub const CONTROL_FLAGS: &[Flag<C>] = &[
     Flag::new("cstopb", C::CSTOPB),
     Flag::new("cread", C::CREAD).sane(),
     Flag::new("clocal", C::CLOCAL),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("crtscts", C::CRTSCTS),
 ];
 
@@ -75,7 +76,9 @@ pub const INPUT_FLAGS: &[Flag<I>] = &[
     Flag::new("ixon", I::IXON),
     // not supported by nix
     // Flag::new("iuclc", I::IUCLC),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("ixany", I::IXANY),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("imaxbel", I::IMAXBEL).sane(),
     #[cfg(any(target_os = "android", target_os = "linux", target_vendor = "apple"))]
     Flag::new("iutf8", I::IUTF8),
@@ -228,16 +231,21 @@ pub const LOCAL_FLAGS: &[Flag<L>] = &[
     // Not supported by nix
     // Flag::new("xcase", L::XCASE),
     Flag::new("tostop", L::TOSTOP),
-    #[cfg(not(target_os = "cygwin"))]
+    #[cfg(not(any(target_os = "cygwin", target_os = "redox")))]
     Flag::new("echoprt", L::ECHOPRT),
-    #[cfg(not(target_os = "cygwin"))]
+    #[cfg(not(any(target_os = "cygwin", target_os = "redox")))]
     Flag::new("prterase", L::ECHOPRT).hidden(),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("echoctl", L::ECHOCTL).sane(),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("ctlecho", L::ECHOCTL).sane().hidden(),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("echoke", L::ECHOKE).sane(),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("crtkill", L::ECHOKE).sane().hidden(),
+    #[cfg(not(target_os = "redox"))]
     Flag::new("flusho", L::FLUSHO),
-    #[cfg(not(target_os = "cygwin"))]
+    #[cfg(not(any(target_os = "cygwin", target_os = "redox")))]
     Flag::new("extproc", L::EXTPROC),
 ];
 
@@ -263,13 +271,25 @@ pub const BAUD_RATES: &[(&str, BaudRate)] = &[
     ("57600", BaudRate::B57600),
     ("115200", BaudRate::B115200),
     ("230400", BaudRate::B230400),
-    #[cfg(not(target_os = "cygwin"))]
+    // TODO: https://github.com/nix-rust/nix/pull/2815
+    #[cfg(not(any(
+        target_os = "cygwin",
+        target_os = "fuchsia",
+        target_os = "hurd",
+        target_os = "redox"
+    )))]
     ("460800", BaudRate::B460800),
     #[cfg(any(target_os = "android", target_os = "linux"))]
     ("500000", BaudRate::B500000),
     #[cfg(any(target_os = "android", target_os = "linux"))]
     ("576000", BaudRate::B576000),
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    // TODO: https://github.com/nix-rust/nix/pull/2815
+    #[cfg(not(any(
+        target_os = "cygwin",
+        target_os = "fuchsia",
+        target_os = "hurd",
+        target_os = "redox"
+    )))]
     ("921600", BaudRate::B921600),
     #[cfg(any(target_os = "android", target_os = "linux"))]
     ("1000000", BaudRate::B1000000),

--- a/src/uu/stty/src/stty.rs
+++ b/src/uu/stty/src/stty.rs
@@ -14,6 +14,8 @@
 // spell-checker:ignore notaflag notacombo notabaud
 // spell-checker:ignore baudrate TCGETS
 
+#![cfg(unix)]
+
 mod flags;
 
 use crate::flags::AllFlags;
@@ -1252,6 +1254,11 @@ fn get_sane_control_char(cc_index: S) -> u8 {
         S::VEOL => 0,
         S::VEOL2 => 0,
         S::VMIN => 1,
+        #[cfg(not(any(
+            all(target_os = "linux", target_arch = "sparc64"),
+            target_os = "illumos",
+            target_os = "solaris"
+        )))]
         S::VTIME => 0,
         #[cfg(target_os = "linux")]
         S::VSWTC => 0,


### PR DESCRIPTION
Gate `stty` to Unix targets.

Some `stty` flags, baud rates, and control characters are not available on all Unix-like targets. Previously, these were exposed unconditionally, which led to compilation failures on targets such as Redox, Cygwin, Fuchsia, and Solaris.

Some of the baud-rate availability is currently constrained by the `nix`; see https://github.com/nix-rust/nix/pull/2815.

No functional changes.

Split from https://github.com/uutils/coreutils/pull/12317.
