### PR TITLE
chgrp: gate by target support

### DIFF
--- a/src/uu/chgrp/Cargo.toml
+++ b/src/uu/chgrp/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/chgrp.rs"
 test = false
 doctest = false
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 clap = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs", "perms"] }
 fluent = { workspace = true }
@@ -27,3 +27,4 @@ workspace = true
 [[bin]]
 name = "chgrp"
 path = "src/main.rs"
+required-features = ["uucore/default"]

--- a/src/uu/chgrp/src/chgrp.rs
+++ b/src/uu/chgrp/src/chgrp.rs
@@ -5,6 +5,8 @@
 
 // spell-checker:ignore (ToDO) COMFOLLOW Chowner RFILE RFILE's derefer dgid nonblank nonprint nonprinting
 
+#![cfg(unix)]
+
 use uucore::display::Quotable;
 use uucore::entries;
 use uucore::error::{FromIo, UResult, USimpleError};

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -35,7 +35,7 @@ pub mod extendedbigdecimal;
 pub mod fast_inc;
 #[cfg(feature = "format")]
 pub mod format;
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", not(target_os = "haiku")))]
 pub mod fs;
 #[cfg(feature = "fsext")]
 pub mod fsext;
@@ -88,7 +88,10 @@ pub mod proc_info;
 pub mod process;
 #[cfg(all(unix, feature = "safe-copy"))]
 pub mod safe_copy;
-#[cfg(all(unix, not(target_os = "redox")))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "aix", target_os = "hurd", target_os = "redox"))
+))]
 pub mod safe_traversal;
 #[cfg(all(target_os = "linux", feature = "tty"))]
 pub mod tty;
@@ -100,8 +103,21 @@ pub mod hardware;
 #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
 pub mod selinux;
 #[cfg(all(
-    any(windows, all(unix, not(target_os = "fuchsia"))),
-    feature = "signals"
+    feature = "signals",
+    any(
+        windows,
+        target_vendor = "apple",
+        target_os = "aix",
+        target_os = "android",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "redox",
+        target_os = "solaris"
+    )
 ))]
 pub mod signals;
 #[cfg(all(feature = "smack", target_os = "linux"))]

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -54,7 +54,7 @@ pub use crate::features::extendedbigdecimal;
 pub use crate::features::fast_inc;
 #[cfg(feature = "format")]
 pub use crate::features::format;
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", not(target_os = "haiku")))]
 pub use crate::features::fs;
 #[cfg(feature = "hardware")]
 pub use crate::features::hardware;
@@ -106,11 +106,27 @@ pub use crate::features::pipes;
 pub use crate::features::process;
 #[cfg(all(unix, feature = "safe-copy"))]
 pub use crate::features::safe_copy;
-#[cfg(all(unix, not(target_os = "redox")))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "aix", target_os = "hurd", target_os = "redox"))
+))]
 pub use crate::features::safe_traversal;
 #[cfg(all(
-    any(windows, all(unix, not(target_os = "fuchsia"))),
-    feature = "signals"
+    feature = "signals",
+    any(
+        windows,
+        target_vendor = "apple",
+        target_os = "aix",
+        target_os = "android",
+        target_os = "cygwin",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "redox",
+        target_os = "solaris"
+    )
 ))]
 pub use crate::features::signals;
 #[cfg(all(

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -32,7 +32,7 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
         // Initialize SIGPIPE state capture at process startup (Unix only).
         // This must be at module level to set up the .init_array static that runs
         // before main() to capture whether SIGPIPE was ignored by the parent process.
-        #[cfg(all(#signals, unix, not(target_os = "fuchsia")))]
+        #[cfg(all(#signals, unix, not(any(target_os = "fuchsia", target_os = "haiku", target_os = "hurd"))))]
         uucore::init_startup_state_capture!();
 
         pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -42,7 +42,7 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
             // The Rust runtime ignores SIGPIPE, but we need to respect the parent's
             // signal disposition for proper pipeline behavior (GNU compatibility).
             // needed even for true --version
-            #[cfg(all(unix, not(target_os = "fuchsia")))]
+            #[cfg(all(unix, not(any(target_os = "fuchsia", target_os = "haiku", target_os = "hurd"))))]
             if !uucore::signals::sigpipe_was_ignored() {
                 let _ = uucore::signals::enable_pipe_errors();
             }


### PR DESCRIPTION
Gate `chgrp` to Unix targets.

This moves the relevant target-specific handling behind the appropriate platform support checks, avoiding compilation or functionality on targets where it is not available.

Split from #12317.