### PR TITLE
avoid unnecessary clone

### DIFF
--- a/src/uu/chcon/src/errors.rs
+++ b/src/uu/chcon/src/errors.rs
@@ -32,21 +32,21 @@ pub(crate) enum Error {
     #[error(transparent)]
     CommandLine(#[from] clap::Error),
 
-    #[error("{}", translate!("chcon-error-operation-failed", "operation" => operation.clone()))]
+    #[error("{}", translate!("chcon-error-operation-failed", "operation" => operation))]
     SELinux {
         operation: String,
         #[source]
         source: selinux::errors::Error,
     },
 
-    #[error("{}", translate!("chcon-error-operation-failed", "operation" => operation.clone()))]
+    #[error("{}", translate!("chcon-error-operation-failed", "operation" => operation))]
     Io {
         operation: String,
         #[source]
         source: io::Error,
     },
 
-    #[error("{}", translate!("chcon-error-operation-failed-on", "operation" => operation.clone(), "operand" => operand1.quote()))]
+    #[error("{}", translate!("chcon-error-operation-failed-on", "operation" => operation, "operand" => operand1.quote()))]
     Io1 {
         operation: String,
         operand1: OsString,

--- a/src/uu/chmod/src/chmod.rs
+++ b/src/uu/chmod/src/chmod.rs
@@ -40,7 +40,7 @@ enum ChmodError {
     PreserveRootSameAs(PathBuf),
     #[error("{}", translate!("chmod-error-permission-denied", "file" => _0.quote()))]
     PermissionDenied(PathBuf),
-    #[error("{}", translate!("chmod-error-new-permissions", "file" => _0.maybe_quote(), "actual" => _1.clone(), "expected" => _2.clone()))]
+    #[error("{}", translate!("chmod-error-new-permissions", "file" => _0.maybe_quote(), "actual" => _1, "expected" => _2))]
     NewPermissions(PathBuf, String, String),
     #[error("{}", translate!("chmod-error-changing-permissions", "file" => _0.quote(), "err" => strip_errno(_1)))]
     ChangingPermissions(PathBuf, std::io::Error),

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -134,7 +134,7 @@ impl Display for BackupError {
         write!(
             f,
             "{}",
-            translate!("cp-error-backup-format", "error" => self.0.clone(), "exec" => uucore::execution_phrase())
+            translate!("cp-error-backup-format", "error" => self.0, "exec" => uucore::execution_phrase())
         )
     }
 }

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -1089,9 +1089,9 @@ impl Options {
                 .get_one::<String>(update_control::arguments::OPT_UPDATE)
                 .is_some_and(|v| v == "none" || v == "none-fail")
         {
-            return Err(CpError::InvalidArgument(
-                translate!("cp-error-invalid-backup-argument").to_string(),
-            ));
+            return Err(CpError::InvalidArgument(translate!(
+                "cp-error-invalid-backup-argument"
+            )));
         }
 
         let backup_suffix = backup_control::determine_backup_suffix(matches);

--- a/src/uu/cp/src/platform/macos.rs
+++ b/src/uu/cp/src/platform/macos.rs
@@ -32,9 +32,7 @@ pub(crate) fn copy_on_write(
     nofollow: bool,
 ) -> CopyResult<CopyDebug> {
     if sparse_mode != SparseMode::Auto {
-        return Err(translate!("cp-error-sparse-not-supported")
-            .to_string()
-            .into());
+        return Err(translate!("cp-error-sparse-not-supported").into());
     }
     let mut copy_debug = CopyDebug {
         offload: OffloadReflinkDebug::Unknown,

--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -20,7 +20,7 @@ use uucore::translate;
 /// Parser Errors describe errors with parser input
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ParseError {
-    #[error("{}", translate!("dd-error-unrecognized-operand", "operand" => .0.clone()))]
+    #[error("{}", translate!("dd-error-unrecognized-operand", "operand" => .0))]
     UnrecognizedOperand(String),
     #[error("{}", translate!("dd-error-multiple-format-table"))]
     MultipleFmtTable,
@@ -30,25 +30,25 @@ pub enum ParseError {
     MultipleBlockUnblock,
     #[error("{}", translate!("dd-error-multiple-excl"))]
     MultipleExclNoCreate,
-    #[error("{}", translate!("dd-error-invalid-flag", "flag" => .0.clone()))]
+    #[error("{}", translate!("dd-error-invalid-flag", "flag" => .0))]
     FlagNoMatch(String),
-    #[error("{}", translate!("dd-error-invalid-output-flag", "flag" => .0.clone()))]
+    #[error("{}", translate!("dd-error-invalid-output-flag", "flag" => .0))]
     OutputFlagNoMatch(String),
-    #[error("{}", translate!("dd-error-conv-flag-no-match", "flag" => .0.clone()))]
+    #[error("{}", translate!("dd-error-conv-flag-no-match", "flag" => .0))]
     ConvFlagNoMatch(String),
-    #[error("{}", translate!("dd-error-multiplier-parse-failure", "input" => .0.clone()))]
+    #[error("{}", translate!("dd-error-multiplier-parse-failure", "input" => .0))]
     MultiplierStringParseFailure(String),
-    #[error("{}", translate!("dd-error-multiplier-overflow", "input" => .0.clone()))]
+    #[error("{}", translate!("dd-error-multiplier-overflow", "input" => .0))]
     MultiplierStringOverflow(String),
     #[error("{}", translate!("dd-error-block-without-cbs"))]
     BlockUnblockWithoutCBS,
-    #[error("{}", translate!("dd-error-status-not-recognized", "level" => .0.clone()))]
+    #[error("{}", translate!("dd-error-status-not-recognized", "level" => .0))]
     StatusLevelNotRecognized(String),
-    #[error("{}", translate!("dd-error-unimplemented", "feature" => .0.clone()))]
+    #[error("{}", translate!("dd-error-unimplemented", "feature" => .0))]
     Unimplemented(String),
-    #[error("{}", translate!("dd-error-bs-out-of-range", "param" => .0.clone()))]
+    #[error("{}", translate!("dd-error-bs-out-of-range", "param" => .0))]
     BsOutOfRange(String),
-    #[error("{}", translate!("dd-error-invalid-number", "input" => .0.clone()))]
+    #[error("{}", translate!("dd-error-invalid-number", "input" => .0))]
     InvalidNumber(String),
     #[error("invalid number: '{0}': {1}")]
     InvalidNumberWithErrMsg(String, String),

--- a/src/uu/df/src/df.rs
+++ b/src/uu/df/src/df.rs
@@ -134,15 +134,15 @@ impl Options {
 enum OptionsError {
     // TODO This needs to vary based on whether `--block-size`
     // or `-B` were provided.
-    #[error("{}", translate!("df-error-block-size-too-large", "size" => .0.clone()))]
+    #[error("{}", translate!("df-error-block-size-too-large", "size" => .0))]
     BlockSizeTooLarge(String),
     // TODO This needs to vary based on whether `--block-size`
     // or `-B` were provided.,
-    #[error("{}", translate!("df-error-invalid-block-size", "size" => .0.clone()))]
+    #[error("{}", translate!("df-error-invalid-block-size", "size" => .0))]
     InvalidBlockSize(String),
     // TODO This needs to vary based on whether `--block-size`
     // or `-B` were provided.
-    #[error("{}", translate!("df-error-invalid-suffix", "size" => .0.clone()))]
+    #[error("{}", translate!("df-error-invalid-suffix", "size" => .0))]
     InvalidSuffix(String),
 
     /// An error getting the columns to display in the output table.
@@ -189,7 +189,7 @@ fn block_size_error(
     let message = options_error.to_string();
     error.size_value_error(
         diag_args,
-        &OptionValue::new(size.clone(), 'B', OPT_BLOCKSIZE_LONG),
+        &OptionValue::new(size, 'B', OPT_BLOCKSIZE_LONG),
         0,
         &message,
         DfError::OptionsError(options_error),

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -832,7 +832,7 @@ fn build_exclude_patterns(matches: &ArgMatches) -> UResult<Vec<Pattern>> {
         if matches.get_flag(options::VERBOSE) {
             println!(
                 "{}",
-                translate!("du-verbose-adding-to-exclude-list", "pattern" => f.clone())
+                translate!("du-verbose-adding-to-exclude-list", "pattern" => f)
             );
         }
         let glob = parse_glob::from_str(&f).map_err(DuError::InvalidGlob)?;

--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -59,7 +59,7 @@ use thiserror::Error;
 pub enum EnvError {
     #[error("{}", translate!("env-error-missing-closing-quote", "position" => .0, "quote" => .1))]
     EnvMissingClosingQuote(usize, char),
-    #[error("{}", translate!("env-error-invalid-backslash-at-end", "position" => .0, "context" => .1.clone()))]
+    #[error("{}", translate!("env-error-invalid-backslash-at-end", "position" => .0, "context" => .1))]
     EnvInvalidBackslashAtEndOfStringInMinusS(usize, String),
     #[error("{}", translate!("env-error-backslash-c-not-allowed", "position" => .0))]
     EnvBackslashCNotAllowedInDoubleQuotes(usize),
@@ -71,7 +71,7 @@ pub enum EnvError {
     EnvParsingOfMissingVariable(usize),
     #[error("{}", translate!("env-error-only-braced-variable", "position" => .0))]
     EnvParsingOfVariableOnlyBracedName(usize),
-    #[error("{}", translate!("env-error-unexpected-number", "position" => .0, "char" => .1.clone()))]
+    #[error("{}", translate!("env-error-unexpected-number", "position" => .0, "char" => .1))]
     EnvParsingOfVariableUnexpectedNumber(usize, String),
     #[error("")]
     EnvReachedEnd,

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -765,9 +765,7 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
         }
 
         if b.no_target_dir && target.is_dir() {
-            return Err(
-                InstallError::OverrideDirectoryFailed(target.clone(), source.clone()).into(),
-            );
+            return Err(InstallError::OverrideDirectoryFailed(target, source.clone()).into());
         }
 
         if is_potential_directory_path(&target) {
@@ -993,11 +991,9 @@ fn copy_file(from: &Path, to: &Path) -> UResult<()> {
     }
 
     if to.is_dir() && !from.is_dir() {
-        return Err(InstallError::OverrideDirectoryFailed(
-            to.to_path_buf().clone(),
-            from.to_path_buf().clone(),
-        )
-        .into());
+        return Err(
+            InstallError::OverrideDirectoryFailed(to.to_path_buf(), from.to_path_buf()).into(),
+        );
     }
 
     // Remove existing file (create_new below provides TOCTOU protection)

--- a/src/uu/install/src/install.rs
+++ b/src/uu/install/src/install.rs
@@ -77,7 +77,7 @@ enum InstallError {
     #[error("{}", translate!("install-error-chmod-failed", "path" => .0.quote()))]
     ChmodFailed(PathBuf),
 
-    #[error("{}", translate!("install-error-chown-failed", "path" => .0.quote(), "error" => .1.clone()))]
+    #[error("{}", translate!("install-error-chown-failed", "path" => .0.quote(), "error" => .1))]
     ChownFailed(PathBuf, String),
 
     #[error("{}", translate!("install-error-invalid-target", "path" => .0.quote()))]
@@ -92,10 +92,10 @@ enum InstallError {
     #[error("{}", translate!("install-error-backing-up-destroy-source", "dest" => .0.quote(), "source" => .1.quote()))]
     BackupWouldDestroySource(PathBuf, PathBuf),
 
-    #[error("{}", translate!("install-error-install-failed", "from" => .0.quote(), "to" => .1.quote(), "error" => .2.clone()))]
+    #[error("{}", translate!("install-error-install-failed", "from" => .0.quote(), "to" => .1.quote(), "error" => .2))]
     InstallFailed(PathBuf, PathBuf, String),
 
-    #[error("{}", translate!("install-error-strip-failed", "error" => .0.clone()))]
+    #[error("{}", translate!("install-error-strip-failed", "error" => .0))]
     StripProgramFailed(String),
 
     #[error("{}", translate!("install-error-strip-terminated"))]
@@ -125,7 +125,7 @@ enum InstallError {
     #[error("{}", translate!("install-error-same-file", "file1" => .0.quote(), "file2" => .1.quote()))]
     SameFile(PathBuf, PathBuf),
 
-    #[error("{}", translate!("install-error-extra-operand", "operand" => .0.quote(), "usage" => .1.clone()))]
+    #[error("{}", translate!("install-error-extra-operand", "operand" => .0.quote(), "usage" => .1))]
     ExtraOperand(OsString, String),
 
     #[cfg(all(feature = "selinux", any(target_os = "linux", target_os = "android")))]
@@ -655,7 +655,7 @@ fn standard(mut paths: Vec<OsString>, b: &Behavior) -> UResult<()> {
 
         // If -t is used, check if target exists as a file before trying to create directories
         if b.target_dir.is_some() && target.exists() && !target.is_dir() {
-            return Err(InstallError::NotADirectory(target.clone()).into());
+            return Err(InstallError::NotADirectory(target).into());
         }
 
         if let Some(to_create) = to_create {

--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -804,7 +804,7 @@ fn parse_settings(matches: &clap::ArgMatches, diag_args: Option<&[OsString]>) ->
                     continue;
                 }
                 // `-o` has no long form.
-                let option = OptionValue::with_names(format.clone(), Some('o'), None);
+                let option = OptionValue::with_names(format, Some('o'), None);
                 // Each field carries its place in the value, so that the caret can
                 // take the one that is at fault out of a long list.
                 for (part, span) in uucore::diagnostics::list_items(format, &[' ', ',', '\t']) {

--- a/src/uu/ln/src/ln.rs
+++ b/src/uu/ln/src/ln.rs
@@ -66,7 +66,7 @@ pub enum LnError {
     #[error("{}", translate!("ln-error-missing-destination", "operand" => _0.quote()))]
     MissingDestination(PathBuf),
 
-    #[error("{}", translate!("ln-error-extra-operand", "operand" => _0.quote(), "program" => _1.clone()))]
+    #[error("{}", translate!("ln-error-extra-operand", "operand" => _0.quote(), "program" => _1))]
     ExtraOperand(OsString, String),
 
     #[error("{}", translate!("ln-failed-to-create-hard-link-dir", "source" => _0.to_string_lossy()))]
@@ -350,7 +350,7 @@ fn link_files_in_dir(files: &[PathBuf], target_dir: &Path, settings: &Settings) 
             all_successful = false;
         }
 
-        linked_destinations.insert(targetpath.clone());
+        linked_destinations.insert(targetpath);
     }
     if all_successful {
         Ok(())

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -580,7 +580,7 @@ fn extract_quoting_style(
             let _ = writeln!(
                 io::stderr(),
                 "{}",
-                translate!("ls-invalid-quoting-style", "program" => std::env::args().next().unwrap_or_else(|| "ls".to_string()), "style" => style.clone())
+                translate!("ls-invalid-quoting-style", "program" => std::env::args().next().unwrap_or_else(|| "ls".to_string()), "style" => style)
             );
         }
 

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -71,7 +71,7 @@ enum MkTempError {
     #[error("{}", translate!("mktemp-error-too-many-templates"))]
     TooManyTemplates,
 
-    #[error("{}", translate!("mktemp-error-not-found", "template_type" => .0.clone(), "template" => .1.quote()))]
+    #[error("{}", translate!("mktemp-error-not-found", "template_type" => .0, "template" => .1.quote()))]
     NotFound(String, PathBuf),
 }
 
@@ -264,12 +264,10 @@ impl Params {
         let prefix_from_template = &template_str[..i];
         let prefix_path = Path::new(&prefix_from_option).join(prefix_from_template);
         if options.treat_as_template && prefix_from_template.contains(MAIN_SEPARATOR) {
-            return Err(MkTempError::PrefixContainsDirSeparator(
-                template_str.clone(),
-            ));
+            return Err(MkTempError::PrefixContainsDirSeparator(template_str));
         }
         if tmpdir.is_some() && Path::new(prefix_from_template).is_absolute() {
-            return Err(MkTempError::InvalidTemplate(template_str.clone().into()));
+            return Err(MkTempError::InvalidTemplate(template_str.into()));
         }
 
         // Split the parent directory from the file part of the prefix.

--- a/src/uu/mktemp/src/mktemp.rs
+++ b/src/uu/mktemp/src/mktemp.rs
@@ -237,7 +237,7 @@ impl Params {
 
         // The template argument must end in 'X' if a suffix option is given.
         if options.suffix.is_some() && !template_str.ends_with('X') {
-            return Err(MkTempError::MustEndInX(template_str.clone()));
+            return Err(MkTempError::MustEndInX(template_str));
         }
 
         // Get the start and end indices of the randomized part of the template.
@@ -250,7 +250,7 @@ impl Params {
                     .chars()
                     .take(template_str.len())
                     .collect::<String>(),
-                None => template_str.clone(),
+                None => template_str,
             };
             return Err(MkTempError::TooFewXs(s));
         };

--- a/src/uu/mv/src/error.rs
+++ b/src/uu/mv/src/error.rs
@@ -8,23 +8,23 @@ use uucore::translate;
 
 #[derive(Debug, Error)]
 pub enum MvError {
-    #[error("{}", translate!("mv-error-no-such-file", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-no-such-file", "path" => .0))]
     NoSuchFile(String),
-    #[error("{}", translate!("mv-error-cannot-stat-not-directory", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-cannot-stat-not-directory", "path" => .0))]
     CannotStatNotADirectory(String),
-    #[error("{}", translate!("mv-error-same-file", "source" => .0.clone(), "target" => .1.clone()))]
+    #[error("{}", translate!("mv-error-same-file", "source" => .0, "target" => .1))]
     SameFile(String, String),
-    #[error("{}", translate!("mv-error-self-target-subdirectory", "source" => .0.clone(), "target" => .1.clone()))]
+    #[error("{}", translate!("mv-error-self-target-subdirectory", "source" => .0, "target" => .1))]
     SelfTargetSubdirectory(String, String),
-    #[error("{}", translate!("mv-error-directory-to-non-directory", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-directory-to-non-directory", "path" => .0))]
     DirectoryToNonDirectory(String),
-    #[error("{}", translate!("mv-error-non-directory-to-directory", "source" => .0.clone(), "target" => .1.clone()))]
+    #[error("{}", translate!("mv-error-non-directory-to-directory", "source" => .0, "target" => .1))]
     NonDirectoryToDirectory(String, String),
-    #[error("{}", translate!("mv-error-not-directory", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-not-directory", "path" => .0))]
     NotADirectory(String),
-    #[error("{}", translate!("mv-error-target-not-directory", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-target-not-directory", "path" => .0))]
     TargetNotADirectory(String),
-    #[error("{}", translate!("mv-error-failed-access-not-directory", "path" => .0.clone()))]
+    #[error("{}", translate!("mv-error-failed-access-not-directory", "path" => .0))]
     FailedToAccessNotADirectory(String),
 }
 

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -94,7 +94,7 @@ fn parse_bytes_option(
             Err(e) => {
                 let message =
                     format_error_message(&e, s, &option_display_name(args, option_name, short));
-                let option = OptionValue::with_names(s.clone(), short, Some(option_name));
+                let option = OptionValue::with_names(s, short, Some(option_name));
                 Err(e.size_value_error(
                     diag_args,
                     &option,

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -162,7 +162,7 @@ impl OdOptions {
                     1,
                     translate!(
                         "od-error-invalid-argument",
-                        "option" => width_display.clone(),
+                        "option" => width_display,
                         "value" => s.quote()
                     ),
                 ));

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -1179,7 +1179,7 @@ fn get_pages(
             // TODO Optimization opportunity: don't bother pushing
             // lines and pages if we aren't going to display it.
             if start_page <= page_num + 1 && end_page.is_none_or(|e| page_num < e) {
-                pages.push((page_num, page.clone()));
+                pages.push((page_num, std::mem::take(&mut page)));
             }
             page_num += 1;
             page.clear();
@@ -1203,7 +1203,7 @@ fn get_pages(
             // and clear the `page` buffer for the next iteration.
             if page.len() >= lines_needed_per_page {
                 if start_page <= page_num + 1 && end_page.is_none_or(|e| page_num < e) {
-                    pages.push((page_num, page.clone()));
+                    pages.push((page_num, std::mem::take(&mut page)));
                 }
                 page_num += 1;
                 page.clear();
@@ -1219,7 +1219,7 @@ fn get_pages(
 
     // Consider all trailing lines as the last page.
     if !page.is_empty() && start_page <= page_num + 1 && end_page.is_none_or(|e| page_num < e) {
-        pages.push((page_num, page.clone()));
+        pages.push((page_num, std::mem::take(&mut page)));
     }
 
     (pages, page_num + 1)
@@ -1249,8 +1249,7 @@ fn group_lines(num_files: usize, lines: Vec<FileLine>) -> Vec<(usize, Vec<FileLi
                 current_group.push(file_line);
             }
             Some(key) => {
-                result.push((key, current_group.clone()));
-                current_group.clear();
+                result.push((key, std::mem::take(&mut current_group)));
                 current_key = Some(group_key(num_files, &file_line));
                 current_group.push(file_line);
             }

--- a/src/uu/sort/src/tmp_dir.rs
+++ b/src/uu/sort/src/tmp_dir.rs
@@ -59,11 +59,10 @@ fn ensure_signal_handler_installed(state: Arc<Mutex<HandlerRegistration>>) -> UR
         return Ok(());
     }
 
-    let handler_state = state.clone();
     if let Err(e) = ctrlc::set_handler(move || {
         // Load the latest lock/path snapshot so the handler cleans the active temp dir.
         let (lock, path) = {
-            let state = handler_state.lock().unwrap();
+            let state = state.lock().unwrap();
             (state.lock.clone(), state.path.clone())
         };
 

--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -38,17 +38,17 @@ use uucore::time::{FormatSystemTimeFallback, format_system_time, system_time_to_
 
 #[derive(Debug, Error)]
 enum StatError {
-    #[error("{}", translate!("stat-error-invalid-quoting-style", "style" => style.clone()))]
+    #[error("{}", translate!("stat-error-invalid-quoting-style", "style" => style))]
     InvalidQuotingStyle { style: String },
-    #[error("{}", translate!("stat-error-invalid-directive", "directive" => directive.clone()))]
+    #[error("{}", translate!("stat-error-invalid-directive", "directive" => directive))]
     InvalidDirective { directive: String },
-    #[error("{}", translate!("stat-error-cannot-read-filesystem", "error" => error.clone()))]
+    #[error("{}", translate!("stat-error-cannot-read-filesystem", "error" => error))]
     CannotReadFilesystem { error: String },
     #[error("{}", translate!("stat-error-stdin-filesystem-mode"))]
     StdinFilesystemMode,
-    #[error("{}", translate!("stat-error-cannot-read-filesystem-info", "file" => file.clone(), "error" => error.clone()))]
+    #[error("{}", translate!("stat-error-cannot-read-filesystem-info", "file" => file, "error" => error))]
     CannotReadFilesystemInfo { file: String, error: String },
-    #[error("{}", translate!("stat-error-cannot-statx", "file" => file.clone(), "error" => error.clone()))]
+    #[error("{}", translate!("stat-error-cannot-statx", "file" => file, "error" => error))]
     CannotStatx { file: String, error: String },
 }
 

--- a/src/uu/stdbuf/src/stdbuf.rs
+++ b/src/uu/stdbuf/src/stdbuf.rs
@@ -91,7 +91,7 @@ enum ProgramOptionsError {
     LineBufferingStdinMeaningless,
     #[error("{}", translate!("stdbuf-error-invalid-mode", "error" => _0.error.to_string()))]
     InvalidMode(Box<ModeError>),
-    #[error("{}", translate!("stdbuf-error-value-too-large", "value" => _0.clone()))]
+    #[error("{}", translate!("stdbuf-error-value-too-large", "value" => _0))]
     ValueTooLarge(String),
 }
 

--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -251,7 +251,7 @@ impl Settings {
             settings.sleep_sec = parse_time::from_str(source, false).map_err(|_| {
                 UUsageError::new(
                     1,
-                    translate!("tail-error-invalid-number-of-seconds", "source" => source.clone()),
+                    translate!("tail-error-invalid-number-of-seconds", "source" => source),
                 )
             })?;
         }

--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -76,7 +76,7 @@ fn uu_tail(settings: &Settings) -> UResult<()> {
 
     // Do an initial tail print of each path's content.
     // Add `path` and `reader` to `files` map if `--follow` is selected.
-    for input in &settings.inputs.clone() {
+    for input in &settings.inputs {
         match input.kind() {
             InputKind::Stdin => {
                 tail_stdin(settings, &mut printer, input, &mut observer)?;
@@ -129,7 +129,7 @@ fn tail_file(
             "{}",
             translate!(
                 "tail-error-cannot-open-no-such-file",
-                "file" => input.display_name.clone(),
+                "file" => input.display_name,
                 "error" => translate!("tail-no-such-file-or-directory")
             )
         );
@@ -145,7 +145,7 @@ fn tail_file(
 
         show_error!(
             "{}",
-            translate!("tail-error-reading-file", "file" => input.display_name.clone(), "error" => err_msg)
+            translate!("tail-error-reading-file", "file" => input.display_name, "error" => err_msg)
         );
         if settings.follow.is_some() {
             let msg = if settings.retry {
@@ -155,7 +155,7 @@ fn tail_file(
             };
             show_error!(
                 "{}",
-                translate!("tail-error-cannot-follow-file-type", "file" => input.display_name.clone(), "msg" => msg)
+                translate!("tail-error-cannot-follow-file-type", "file" => input.display_name, "msg" => msg)
             );
         }
         if !observer.follow_name_retry() {
@@ -198,13 +198,13 @@ fn tail_file(
             Err(e) if e.kind() == ErrorKind::PermissionDenied => {
                 observer.add_bad_path(path, input.display_name.as_str(), false)?;
                 show!(e.map_err_context(|| {
-                    translate!("tail-error-cannot-open-for-reading", "file" => input.display_name.clone())
+                    translate!("tail-error-cannot-open-for-reading", "file" => input.display_name)
                 }));
             }
             Err(e) => {
                 observer.add_bad_path(path, input.display_name.as_str(), false)?;
                 return Err(e.map_err_context(|| {
-                    translate!("tail-error-cannot-open-for-reading", "file" => input.display_name.clone())
+                    translate!("tail-error-cannot-open-for-reading", "file" => input.display_name)
                 }));
             }
         }
@@ -263,7 +263,7 @@ fn tail_stdin(
         set_exit_code(1);
         show_error!(
             "{}",
-            translate!("tail-error-cannot-open-no-such-file", "file" => input.display_name.clone(), "error" => translate!("tail-no-such-file-or-directory"))
+            translate!("tail-error-cannot-open-no-such-file", "file" => input.display_name, "error" => translate!("tail-no-such-file-or-directory"))
         );
         return Ok(());
     }

--- a/src/uu/touch/src/error.rs
+++ b/src/uu/touch/src/error.rs
@@ -13,7 +13,7 @@ use uucore::translate;
 
 #[derive(Debug, Error)]
 pub enum TouchError {
-    #[error("{}", translate!("touch-error-unable-to-parse-date", "date" => .0.clone()))]
+    #[error("{}", translate!("touch-error-unable-to-parse-date", "date" => .0))]
     InvalidDateFormat(String),
 
     /// The source time couldn't be converted to a [`jiff::Zoned`]
@@ -25,7 +25,7 @@ pub enum TouchError {
     ReferenceFileInaccessible(PathBuf, std::io::Error),
 
     /// An error getting a path to stdout on Windows
-    #[error("{}", translate!("touch-error-windows-stdout-path-failed", "code" => .0.clone()))]
+    #[error("{}", translate!("touch-error-windows-stdout-path-failed", "code" => .0))]
     WindowsStdoutPathError(String),
 
     /// A feature that is not available on the current platform

--- a/src/uu/tr/src/operation.rs
+++ b/src/uu/tr/src/operation.rs
@@ -133,7 +133,7 @@ impl Display for BadSequence {
             Self::MultipleCharInEquivalence(s) => write!(
                 f,
                 "{}",
-                translate!("tr-error-multiple-char-in-equivalence", "chars" => s.clone())
+                translate!("tr-error-multiple-char-in-equivalence", "chars" => s)
             ),
         }
     }

--- a/src/uu/who/src/platform/unix.rs
+++ b/src/uu/who/src/platform/unix.rs
@@ -402,7 +402,6 @@ impl Who {
             ut.canon_host().map_err_context(|| {
                 let host = ut.host();
                 translate!("who-canonicalize-error", "host" => host.split(':').next().unwrap_or(&host).quote())
-                .to_string()
             })?
         } else {
             ut.host()

--- a/src/uucore/src/lib/features/selinux.rs
+++ b/src/uucore/src/lib/features/selinux.rs
@@ -21,16 +21,16 @@ pub enum SeLinuxError {
     #[error("{}", translate!("selinux-error-not-enabled"))]
     SELinuxNotEnabled,
 
-    #[error("{}", translate!("selinux-error-file-open-failure", "error" => .0.clone()))]
+    #[error("{}", translate!("selinux-error-file-open-failure", "error" => .0))]
     FileOpenFailure(String),
 
-    #[error("{}", translate!("selinux-error-context-retrieval-failure", "error" => .0.clone()))]
+    #[error("{}", translate!("selinux-error-context-retrieval-failure", "error" => .0))]
     ContextRetrievalFailure(String),
 
-    #[error("{}", translate!("selinux-error-context-set-failure", "context" => .0.clone(), "error" => .1.clone()))]
+    #[error("{}", translate!("selinux-error-context-set-failure", "context" => .0, "error" => .1))]
     ContextSetFailure(String, String),
 
-    #[error("{}", translate!("selinux-error-context-conversion-failure", "context" => .0.clone(), "error" => .1.clone()))]
+    #[error("{}", translate!("selinux-error-context-conversion-failure", "context" => .0, "error" => .1))]
     ContextConversionFailure(String, String),
 
     #[error("{}", translate!("selinux-error-operation-not-supported"))]

--- a/src/uucore/src/lib/features/smack.rs
+++ b/src/uucore/src/lib/features/smack.rs
@@ -25,7 +25,7 @@ pub enum SmackError {
     #[error("{}", translate!("smack-error-label-retrieval-failure", "error" => strip_errno(.0)))]
     LabelRetrievalFailure(io::Error),
 
-    #[error("{}", translate!("smack-error-label-set-failure", "context" => .0.clone(), "error" => strip_errno(.1)))]
+    #[error("{}", translate!("smack-error-label-set-failure", "context" => .0, "error" => strip_errno(.1)))]
     LabelSetFailure(String, io::Error),
 }
 


### PR DESCRIPTION
Avoid unnecessary `clone()` calls in several code paths to reduce redundant allocations and improve efficiency.
