### PR TITLE
tsort: include filename in error message

### DIFF
--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -17,7 +17,7 @@ use string_interner::StringInterner;
 use string_interner::backend::BucketBackend;
 use thiserror::Error;
 use uucore::display::Quotable;
-use uucore::error::{UError, UResult, USimpleError};
+use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::{format_usage, show, translate};
 
 // short types for switching interning behavior on the fly.
@@ -62,7 +62,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 return Err(TsortError::IsDir(input.to_string_lossy().to_string()).into());
             }
         }
-        let file = File::open(input)?;
+        let file = File::open(input).map_err_context(|| input.maybe_quote().to_string())?;
         // advise the OS we will access the data sequentially if possible
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         let _ = rustix::fs::fadvise(&file, 0, None, rustix::fs::Advice::Sequential);

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -243,3 +243,11 @@ fn test_only_one_input_file() {
         .fails_with_code(1)
         .stderr_only(TSORT_EXTRA_OPERAND_ERROR);
 }
+
+#[test]
+fn test_nonexistent_file_error_includes_filename() {
+    new_ucmd!()
+        .arg("nosuchfile.txt")
+        .fails_with_code(1)
+        .stderr_only("tsort: nosuchfile.txt: No such file or directory\n");
+}


### PR DESCRIPTION
GNU `tsort` names the file it could not open, ours did not:

```
GNU:  tsort: nosuchfile.txt: No such file or directory
uu:   tsort: No such file or directory
```

The `File::open` error was propagated without context. Fixed with `map_err_context`, as `nl` and `wc` already do. Added a regression test.