### PR TITLE
uucore: fix test_crlf_across_blocks not compiling on Windows

### DIFF
--- a/src/uucore/src/lib/features/sum.rs
+++ b/src/uucore/src/lib/features/sum.rs
@@ -736,14 +736,14 @@ mod tests {
         writer_crlf.write_all(b"\r").unwrap();
         writer_crlf.write_all(b"\n").unwrap();
         writer_crlf.finalize();
-        let result_crlf = digest.result();
+        let result_crlf = digest.result().unwrap();
 
         // We expect "\r\n" to be replaced with "\n" in text mode on Windows.
         let mut digest = Box::new(Md5::default()) as Box<dyn Digest>;
         let mut writer_lf = DigestWriter::new(&mut digest, false);
         writer_lf.write_all(b"\n").unwrap();
         writer_lf.finalize();
-        let result_lf = digest.result();
+        let result_lf = digest.result().unwrap();
 
         assert_eq!(result_crlf, result_lf);
     }


### PR DESCRIPTION
`cargo test -p uucore` does not compile on Windows:

```
error[E0369]: binary operation `==` cannot be applied to type `Result<DigestOutput, std::io::Error>`
   --> src/uucore/src/lib/features/sum.rs:748:9
```

`result()` became fallible in 0d335ebad, but this `#[cfg(windows)]` test still compares the `io::Result` values directly. CI only builds uucore's lib tests on Linux, so it went unnoticed. Unwrapping both makes the test compile and pass.

Note: with this applied, `features::time::tests::test_large_system_time{,_float}` then fail on Windows (`UNIX_EPOCH + 67768036191763200s` overflows a FILETIME). That looks like a separate question about how those tests should behave on Windows, so I left it out of this change.