### PR TITLE
uniq, split: stop reading an obsolete option after --

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -76,6 +76,7 @@ fn handle_obsolete(args: impl uucore::Args) -> (Vec<OsString>, Option<String>) {
     let mut obs_lines = None;
     let mut preceding_long_opt_req_value = false;
     let mut preceding_short_opt_req_value = false;
+    let mut after_double_dash = false;
 
     let filtered_args = args
         .filter_map(|os_slice| {
@@ -84,6 +85,7 @@ fn handle_obsolete(args: impl uucore::Args) -> (Vec<OsString>, Option<String>) {
                 &mut obs_lines,
                 &mut preceding_long_opt_req_value,
                 &mut preceding_short_opt_req_value,
+                &mut after_double_dash,
             )
         })
         .collect();
@@ -98,9 +100,19 @@ fn filter_args(
     obs_lines: &mut Option<String>,
     preceding_long_opt_req_value: &mut bool,
     preceding_short_opt_req_value: &mut bool,
+    after_double_dash: &mut bool,
 ) -> Option<OsString> {
     let filter: Option<OsString>;
     if let Some(slice) = os_slice.to_str() {
+        if *after_double_dash {
+            // Past `--` everything is an operand, so `split -- -1` names a file
+            // rather than setting the line count.
+            return Some(OsString::from(slice));
+        }
+        if slice == "--" {
+            *after_double_dash = true;
+            return Some(OsString::from(slice));
+        }
         if should_extract_obs_lines(
             slice,
             *preceding_long_opt_req_value,

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -375,6 +375,7 @@ fn handle_obsolete(args: impl uucore::Args) -> (Vec<OsString>, Option<usize>, Op
     let mut skip_chars_old = None;
     let mut preceding_long_opt_req_value = false;
     let mut preceding_short_opt_req_value = false;
+    let mut after_double_dash = false;
 
     let filtered_args = args
         .filter_map(|os_slice| {
@@ -384,6 +385,7 @@ fn handle_obsolete(args: impl uucore::Args) -> (Vec<OsString>, Option<usize>, Op
                 &mut skip_chars_old,
                 &mut preceding_long_opt_req_value,
                 &mut preceding_short_opt_req_value,
+                &mut after_double_dash,
             )
         })
         .collect();
@@ -403,9 +405,19 @@ fn filter_args(
     skip_chars_old: &mut Option<String>,
     preceding_long_opt_req_value: &mut bool,
     preceding_short_opt_req_value: &mut bool,
+    after_double_dash: &mut bool,
 ) -> Option<OsString> {
     let filter: Option<OsString>;
     if let Some(slice) = os_slice.to_str() {
+        if *after_double_dash {
+            // Past `--` everything is an operand, so `uniq -- -1` names a file
+            // rather than skipping a field.
+            return Some(OsString::from(slice));
+        }
+        if slice == "--" {
+            *after_double_dash = true;
+            return Some(OsString::from(slice));
+        }
         if should_extract_obs_skip_fields(
             slice,
             *preceding_long_opt_req_value,

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -2218,3 +2218,13 @@ split: invalid number of bytes: '7zq'
             .stderr_is("split: invalid number of bytes: '7zq'\n");
     }
 }
+
+#[test]
+fn test_obsolete_lines_not_read_after_double_dash() {
+    // After `--` there are no more options, so `-1` names a file rather than
+    // being taken as the obsolete `split -1` line-count spelling.
+    new_ucmd!()
+        .args(&["--", "-1"])
+        .fails()
+        .stderr_contains("cannot open '-1' for reading");
+}

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -1238,3 +1238,13 @@ fn test_nonexistent_input_file_error_matches_gnu() {
         .fails_with_code(1)
         .stderr_only("uniq: nosuchfile.txt: No such file or directory\n");
 }
+
+#[test]
+fn test_obsolete_skip_fields_not_read_after_double_dash() {
+    // After `--` there are no more options, so `-1` names a file rather than
+    // being taken as the obsolete "skip 1 field" spelling.
+    new_ucmd!()
+        .args(&["--", "-1"])
+        .fails()
+        .stderr_contains("-1");
+}


### PR DESCRIPTION
`uniq` and `split` both walk the argument list before clap to lift out their obsolete numeric spellings — `uniq -1` for skip-fields, `split -22` for line count. Neither stopped at `--`, so an operand that merely *looked* like the obsolete form was swallowed instead of being treated as a file name.

| Command | GNU | uutils before |
|---|---|---|
| `uniq -- -1` | `uniq: -1: No such file or directory` | reads stdin, exits 0 |
| `split -- -1` | `split: cannot open '-1' for reading: No such file or directory` | reads stdin, exits 0 |

Found by differential testing against GNU coreutils 9.11.

Both walkers already threaded state for "the previous argument was an option expecting a value", so the terminator is tracked the same way: once `--` is seen, everything after it is passed through untouched.

This is the same class of bug as #14248 (`fold`), but the three implementations are separate, so this is a separate change.

## Testing

One regression test each. Verified they catch the bug by reverting the two source files alone — both fail, then pass with them restored.

- `cargo test --features "uniq,split" --no-default-features`: **162 passed, 0 failed** (160 pre-existing, 2 new)
- `cargo fmt --check` and `cargo clippy -p uu_uniq -p uu_split --all-targets`: clean
- `split -- -1` now matches GNU byte for byte

### Noted but not touched

The wording of uniq's own open failure still differs from GNU — `uniq: Could not open -1: No such file or directory` against GNU's `uniq: -1: No such file or directory`. That is unrelated to argument parsing: plain `uniq nosuchfile` differs the same way on an unmodified tree, which I checked before writing the test, so the test asserts only that `-1` reaches the file layer.

`fmt` has the same `--` problem (`fmt -- -1` reads stdin where GNU tries to open `-1`), but it gets there differently — through a positional with `allow_negative_numbers(true)` rather than a pre-clap walk — so fixing it belongs in its own change rather than being bolted on here.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. On the GPL point raised there: expected behavior was established by running the installed GNU binaries as a black box and recording their output. I did not read GNU coreutils source. All testing above was run locally.

