### PR TITLE
join, od: report a hyphen-leading value instead of rejecting it

### DIFF
--- a/src/uu/join/src/join.rs
+++ b/src/uu/join/src/join.rs
@@ -931,6 +931,7 @@ pub fn uu_app() -> Command {
             Arg::new("j")
                 .short('j')
                 .value_name("FIELD")
+                .allow_hyphen_values(true)
                 .help(translate!("join-help-j")),
         )
         .arg(
@@ -952,12 +953,14 @@ pub fn uu_app() -> Command {
             Arg::new("1")
                 .short('1')
                 .value_name("FIELD")
+                .allow_hyphen_values(true)
                 .help(translate!("join-help-1")),
         )
         .arg(
             Arg::new("2")
                 .short('2')
                 .value_name("FIELD")
+                .allow_hyphen_values(true)
                 .help(translate!("join-help-2")),
         )
         .arg(

--- a/src/uu/od/src/od.rs
+++ b/src/uu/od/src/od.rs
@@ -338,14 +338,16 @@ pub fn uu_app() -> Command {
                 .short('j')
                 .long(options::SKIP_BYTES)
                 .help(translate!("od-help-skip-bytes"))
-                .value_name("BYTES"),
+                .value_name("BYTES")
+                .allow_hyphen_values(true),
         )
         .arg(
             Arg::new(options::READ_BYTES)
                 .short('N')
                 .long(options::READ_BYTES)
                 .help(translate!("od-help-read-bytes"))
-                .value_name("BYTES"),
+                .value_name("BYTES")
+                .allow_hyphen_values(true),
         )
         .arg(
             Arg::new(options::ENDIAN)

--- a/tests/by-util/test_join.rs
+++ b/tests/by-util/test_join.rs
@@ -805,3 +805,16 @@ join: invalid field number: 'x'
             .stderr_is("join: invalid field number: 'x'\n");
     }
 }
+
+#[test]
+fn test_hyphen_leading_field_number_is_reported_as_invalid() {
+    // GNU hands the argument after the option to that option even when it
+    // starts with a hyphen, so it is reported as an invalid field number
+    // rather than as an unknown option.
+    for opt in ["-1", "-2", "-j"] {
+        new_ucmd!()
+            .args(&[opt, "-1", "empty.txt", "empty.txt"])
+            .fails()
+            .stderr_contains("invalid field number: '-1'");
+    }
+}

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -1498,3 +1498,17 @@ od: invalid suffix in -N argument '3zz'
             .stderr_is("od: invalid suffix in -N argument '3zz'\n");
     }
 }
+
+#[test]
+fn test_hyphen_leading_byte_count_is_reported_as_invalid() {
+    // GNU hands the argument after the option to that option even when it
+    // starts with a hyphen, so it is reported as an invalid argument rather
+    // than as an unknown option.
+    for opt in ["-N", "-j"] {
+        new_ucmd!()
+            .args(&[opt, "-1"])
+            .pipe_in("")
+            .fails()
+            .stderr_contains(format!("invalid {opt} argument '-1'"));
+    }
+}


### PR DESCRIPTION
GNU hands the argument after an option to that option even when it begins with a hyphen, and then reports it as invalid. `join` and `od` refused it as an unknown option instead.

| Command | GNU | uutils before |
|---|---|---|
| `join -1 -1 a b` | `join: invalid field number: '-1'` | `error: a value is required for '-1 <FIELD>' but none was supplied` |
| `join -j -1 a b` | `join: invalid field number: '-1'` | same clap error |
| `od -N -1 a` | `od: invalid -N argument '-1'` | `error: unexpected argument '-1' found` |
| `od -j -1 a` | `od: invalid -j argument '-1'` | `error: unexpected argument '-1' found` |

The validation that produces GNU's exact wording is already present in both — `join -1 abc` and `od -N abc` match GNU byte for byte today. The hyphen-leading value simply never reached it, so this just lets it through with `allow_hyphen_values`; the existing code then produces the right message unchanged.

Found by differential testing against GNU coreutils 9.11. Follows the same idea as #14256, but those were options where GNU *succeeds*; these are ones where both fail and only the diagnostic differs, so they are kept separate.

## Testing

One regression test per utility, each covering every affected option (`-1`, `-2`, `-j` for join; `-N`, `-j` for od). Verified they catch the bug by reverting the two source files alone — both fail, then pass with them restored.

- `cargo test --features "join,od" --no-default-features`: **116 passed, 0 failed** (114 pre-existing, 2 new)
- `cargo fmt --check` and `cargo clippy -p uu_join -p uu_od --all-targets`: clean
- 10-case differential check covering the fixed forms plus ordinary ones (`od -N 4`, `od -j 1`, `join -1 1 -2 1`, `join -1 abc`) as regression cover: all 10 match GNU exactly

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. On the GPL point raised there: expected behavior was established by running the installed GNU binaries as a black box and recording their output. I did not read GNU coreutils source. All testing above was run locally.

