### PR TITLE
truncate, paste, uniq: let a repeated option override the earlier one

### DIFF
--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -48,6 +48,8 @@ pub fn uu_app() -> Command {
         .about(translate!("paste-about"))
         .override_usage(format_usage(&translate!("paste-usage")))
         .infer_long_args(true)
+        // GNU lets a later -d override an earlier one.
+        .args_override_self(true)
         .arg(
             Arg::new(options::SERIAL)
                 .long(options::SERIAL)

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -162,7 +162,9 @@ pub fn uu_app() -> Command {
         .about(translate!("truncate-about"))
         .override_usage(format_usage(&translate!("truncate-usage")))
         .after_help(translate!("truncate-after-help"))
-        .infer_long_args(true);
+        .infer_long_args(true)
+        // GNU lets a later -s override an earlier one.
+        .args_override_self(true);
     uucore::clap_localization::configure_localized_command(cmd)
         .arg(
             Arg::new(options::IO_BLOCKS)

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -712,6 +712,8 @@ pub fn uu_app() -> Command {
         .about(translate!("uniq-about"))
         .override_usage(format_usage(&translate!("uniq-usage")))
         .infer_long_args(true)
+        // GNU lets a later -f/-s/-w override an earlier one.
+        .args_override_self(true)
         .after_help(translate!("uniq-after-help"));
     uucore::clap_localization::configure_localized_command(cmd)
         .arg(

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -510,3 +510,13 @@ fn test_dev_zero_closed_pipe() {
         .run()
         .fails_silently();
 }
+
+#[test]
+fn test_repeated_delimiter_takes_the_last() {
+    // GNU lets a later -d override an earlier one rather than erroring.
+    new_ucmd!()
+        .args(&["-d", ",", "-d", ":", "-s", "-"])
+        .pipe_in("a\nb\n")
+        .succeeds()
+        .stdout_is("a:b\n");
+}

--- a/tests/by-util/test_truncate.rs
+++ b/tests/by-util/test_truncate.rs
@@ -540,3 +540,12 @@ mod diagnostics {
             .stderr_contains("Invalid number: '10fb'");
     }
 }
+
+#[test]
+fn test_repeated_size_takes_the_last() {
+    // GNU lets a later -s override an earlier one rather than erroring.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.make_file("repeated");
+    ucmd.args(&["-s", "1", "-s", "2", "repeated"]).succeeds();
+    assert_eq!(at.metadata("repeated").len(), 2);
+}

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -1220,3 +1220,13 @@ fn test_failed_write_is_reported() {
         .fails()
         .stderr_is("uniq: write error: No space left on device\n");
 }
+
+#[test]
+fn test_repeated_skip_fields_takes_the_last() {
+    // GNU lets a later -f override an earlier one rather than erroring.
+    new_ucmd!()
+        .args(&["-f", "1", "-f", "2"])
+        .pipe_in("x y a\nz w a\n")
+        .succeeds()
+        .stdout_is("x y a\n");
+}


### PR DESCRIPTION
GNU reads options left to right, so giving the same one twice keeps the last value. These three rejected the repeat outright.

| Command | GNU | uutils before |
|---|---|---|
| `truncate -s 1 -s 2 f` | truncates to 2 | `error: the argument '--size <SIZE>' cannot be used multiple times` |
| `paste -d, -d: f1 f2` | joins with `:` | `error: the argument '--delimiters <LIST>' cannot be used multiple times` |
| `uniq -f 1 -f 2 f` | skips 2 fields | `error: the argument '--skip-fields <N>' cannot be used multiple times` |

Fixed with `args_override_self(true)`, the same way `cut` already does it. For `uniq` this covers `-s` and `-w` as well, both checked against GNU.

Found by differential testing against GNU coreutils 9.11.

**This is deliberately not applied everywhere.** `cut -f1 -f2` and `join -1 1 -1 2` are errors in GNU too — just different ones ("only one list may be specified", "incompatible join fields 0, 1") — so those are left alone rather than swept up. `cut` in particular already documents in a comment why it uses `ArgAction::Append` to count occurrences.

## Testing

One regression test per utility. Verified they catch the bug by reverting the three source files alone — all three fail, then pass with them restored.

- `cargo test --features "truncate,paste,uniq" --no-default-features`: **99 passed, 0 failed** (96 pre-existing, 3 new)
- `cargo fmt --check` and `cargo clippy -p uu_truncate -p uu_paste -p uu_uniq --all-targets`: clean
- 9-case differential check covering the repeated forms plus the single-option ones (`truncate -s 3`, `paste -d,`, `uniq -f 1`, bare `uniq`) as regression cover: all 9 match GNU

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. On the GPL point raised there: expected behavior was established by running the installed GNU binaries as a black box and recording their output. I did not read GNU coreutils source. All testing above was run locally.

