### PR TITLE
pr: take -n, -s and -S values attached only, as GNU does

### DIFF
--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -428,23 +428,31 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
 /// Rewrite arguments before clap parsing, preserving legacy numeric operands.
 fn recreate_arguments(args: &[String]) -> Vec<String> {
-    let num_regex = Regex::new(r"^[^-]\d*$").unwrap();
-    let n_regex = Regex::new(r"^-n\s*$").unwrap();
     // `-e` ends a cluster of short flags that take no value of their own, as in `-tre`.
-    // Options that do take a value are excluded so that `-se` keeps meaning `-s e`.
     let e_regex = Regex::new(r"^-[dtTrFfabmJ]*e$").unwrap();
     let mut arguments = args.to_owned();
-    let num_option = args
-        .iter()
-        .take_while(|arg| arg.as_str() != "--")
-        .find_position(|x| n_regex.is_match(x.trim()));
-    if let Some((pos, _value)) = num_option
-        && let Some(num_val_opt) = args.get(pos + 1)
-        && !num_regex.is_match(num_val_opt)
-    {
-        let could_be_file = arguments.remove(pos + 1);
-        arguments.insert(pos + 1, format!("{}", NumberingMode::default().width));
-        arguments.insert(pos + 2, could_be_file);
+
+    // GNU takes the value of these attached only (`-n3`, `-s,`); the argument
+    // after them is always an operand. clap would swallow that operand as the
+    // value instead, and the two cannot be told apart by shape: in
+    // `pr -n FILE`, a file called `f1` reads exactly like the SEP[DIGITS] pair
+    // `f` and `1`. So the default is filled in here, which leaves clap nothing
+    // to take.
+    let optional_value_defaults = [
+        ("-n", NumberingMode::default().width.to_string()),
+        ("-s", "\t".to_string()),
+        ("-S", " ".to_string()),
+    ];
+    let mut pos = 0;
+    while pos < arguments.len() && arguments[pos] != "--" {
+        if let Some((_, default)) = optional_value_defaults
+            .iter()
+            .find(|(flag, _)| arguments[pos].trim() == *flag)
+        {
+            arguments.insert(pos + 1, default.clone());
+            pos += 1;
+        }
+        pos += 1;
     }
 
     // `-e` takes an optional attached argument, which clap cannot express, so it is filled in

--- a/src/uu/pr/src/pr.rs
+++ b/src/uu/pr/src/pr.rs
@@ -426,6 +426,63 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
+/// The short flags that carry no value of their own, so they may precede an
+/// optional-value flag inside a cluster such as `-tn`.
+const VALUELESS_SHORT_FLAGS: &str = "dtTrFfabmJ";
+
+/// Every long option `pr` defines, used to tell an unambiguous abbreviation
+/// from one clap would reject.
+const LONG_OPTIONS: &[&str] = &[
+    "across",
+    "column-down",
+    "columns",
+    "date-format",
+    "double-space",
+    "expand-tabs",
+    "first-line-number",
+    "form-feed",
+    "header",
+    "help",
+    "indent",
+    "join-lines",
+    "length",
+    "merge",
+    "no-file-warnings",
+    "number-lines",
+    "omit-header",
+    "omit-pagination",
+    "pages",
+    "page-width",
+    "separator",
+    "sep-string",
+    "width",
+];
+
+/// Whether `arg` is `short` on its own or at the end of a cluster of valueless
+/// flags, carrying no attached value: `-n` and `-tn`, but not `-n3`.
+fn is_bare_short(arg: &str, short: char) -> bool {
+    arg.strip_prefix('-').is_some_and(|rest| {
+        !rest.starts_with('-')
+            && rest.ends_with(short)
+            && rest[..rest.len() - short.len_utf8()]
+                .chars()
+                .all(|c| VALUELESS_SHORT_FLAGS.contains(c))
+    })
+}
+
+/// Whether `arg` names `long`, spelled in full or as one of the abbreviations
+/// `infer_long_args` accepts, with no `=value` attached.
+fn is_bare_long(arg: &str, long: &str) -> bool {
+    let Some(name) = arg.strip_prefix("--") else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.contains('=')
+        && long.starts_with(name)
+        // An ambiguous prefix is clap's to reject, not ours to resolve.
+        && LONG_OPTIONS.iter().filter(|o| o.starts_with(name)).count() == 1
+}
+
 /// Rewrite arguments before clap parsing, preserving legacy numeric operands.
 fn recreate_arguments(args: &[String]) -> Vec<String> {
     // `-e` ends a cluster of short flags that take no value of their own, as in `-tre`.
@@ -436,23 +493,32 @@ fn recreate_arguments(args: &[String]) -> Vec<String> {
     // after them is always an operand. clap would swallow that operand as the
     // value instead, and the two cannot be told apart by shape: in
     // `pr -n FILE`, a file called `f1` reads exactly like the SEP[DIGITS] pair
-    // `f` and `1`. So the default is filled in here, which leaves clap nothing
-    // to take.
+    // `f` and `1`. So the default is attached here, the same way `-e` is
+    // handled below, which leaves clap nothing to take.
+    //
+    // Every spelling has to be covered, not just the bare short flag: the
+    // trailing position of a cluster (`-tn`), the long name, and the
+    // abbreviations of it that `infer_long_args` accepts (`--number-l`).
     let optional_value_defaults = [
-        ("-n", NumberingMode::default().width.to_string()),
-        ("-s", "\t".to_string()),
-        ("-S", " ".to_string()),
+        (
+            options::NUMBER_LINES,
+            'n',
+            NumberingMode::default().width.to_string(),
+        ),
+        (options::COLUMN_CHAR_SEPARATOR, 's', "\t".to_string()),
+        (options::COLUMN_STRING_SEPARATOR, 'S', " ".to_string()),
     ];
-    let mut pos = 0;
-    while pos < arguments.len() && arguments[pos] != "--" {
-        if let Some((_, default)) = optional_value_defaults
-            .iter()
-            .find(|(flag, _)| arguments[pos].trim() == *flag)
-        {
-            arguments.insert(pos + 1, default.clone());
-            pos += 1;
+    for arg in arguments.iter_mut().take_while(|arg| arg.as_str() != "--") {
+        for (long, short, default) in &optional_value_defaults {
+            if is_bare_short(arg.trim(), *short) {
+                *arg = format!("{}{default}", arg.trim());
+                break;
+            }
+            if is_bare_long(arg.trim(), long) {
+                *arg = format!("{}={default}", arg.trim());
+                break;
+            }
         }
-        pos += 1;
     }
 
     // `-e` takes an optional attached argument, which clap cannot express, so it is filled in

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -112,7 +112,7 @@ fn test_with_numbering_option_with_number_width() {
     let mut scenario = new_ucmd!();
     let value = file_last_modified_time(&scenario, test_file_path);
     scenario
-        .args(&["-n", "2", test_file_path])
+        .args(&["-n2", test_file_path])
         .succeeds()
         .stdout_is_templated_fixture(expected_test_file_path, &[("{last_modified_time}", &value)]);
 }
@@ -485,7 +485,7 @@ fn test_page_length_too_large() {
 fn test_number_width_too_large() {
     let arg = "18446744073709551615";
     new_ucmd!()
-        .args(&["-n", arg])
+        .args(&[format!("-n{arg}")])
         .fails_with_code(1)
         .stderr_is(format!(
             "pr: '-n' extra characters or invalid number in the argument: '{arg}': Value too large for defined data type\nTry 'pr --help' for more information.\n"
@@ -540,7 +540,7 @@ fn test_large_number_width_does_not_panic() {
     // With -t (no page headers/footers) GNU emits no page padding, so the
     // output is exactly the numbered line.
     new_ucmd!()
-        .args(&["-t", "-n", "70000"])
+        .args(&["-t", "-n70000"])
         .pipe_in("x\n")
         .succeeds()
         .stdout_is(format!("{}1\tx\n", " ".repeat(69999)));
@@ -682,15 +682,19 @@ fn test_with_join_lines_option() {
 
 #[test]
 fn test_value_for_number_lines() {
-    // *5 is of the form [SEP[NUMBER]] so is accepted and succeeds
-    new_ucmd!().args(&["-n", "*5", "test.log"]).succeeds();
+    // GNU takes the value of -n attached only, so the argument after a bare
+    // -n is always an operand, never SEP[NUMBER]. `pr -n a f` reports
+    // "pr: a: No such file or directory" and still numbers f.
+    for operand in ["*5", "a", "foo5.txt"] {
+        new_ucmd!()
+            .args(&["-n", operand, "test.log"])
+            .fails()
+            .stderr_contains(format!("{operand}: No such file or directory"));
+    }
 
-    // a is of the form [SEP[NUMBER]] so is accepted and succeeds
-    new_ucmd!().args(&["-n", "a", "test.log"]).succeeds();
-
-    // foo5.txt is of not the form [SEP[NUMBER]] so is not used as value.
-    // Therefore, pr tries to access the file, which does not exist.
-    new_ucmd!().args(&["-n", "foo5.txt", "test.log"]).fails();
+    // Attached, the same values are read as SEP[NUMBER].
+    new_ucmd!().args(&["-n*5", "test.log"]).succeeds();
+    new_ucmd!().args(&["-na", "test.log"]).succeeds();
 }
 
 #[test]
@@ -1321,4 +1325,19 @@ fn test_missing_file_error_message() {
         .fails_with_code(1)
         .stderr_contains("pr: nonexistent_file: ")
         .stderr_does_not_contain("(os error");
+}
+
+#[test]
+fn test_optional_value_is_not_taken_from_the_next_argument() {
+    // `-n`, `-s` and `-S` take their value attached only. A file whose name
+    // happens to look like SEP[DIGITS] used to be swallowed as the value,
+    // leaving no operand, so pr silently numbered stdin instead of the file.
+    for flag in ["-n", "-s", "-S"] {
+        new_ucmd!()
+            .args(&["-t", flag, "f1"])
+            .pipe_in("FROM_STDIN\n")
+            .succeeds()
+            .stdout_contains("from_file")
+            .stdout_does_not_contain("FROM_STDIN");
+    }
 }

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -684,12 +684,13 @@ fn test_with_join_lines_option() {
 fn test_value_for_number_lines() {
     // GNU takes the value of -n attached only, so the argument after a bare
     // -n is always an operand, never SEP[NUMBER]. `pr -n a f` reports
-    // "pr: a: No such file or directory" and still numbers f.
+    // "pr: a: No such file or directory" and still numbers f. Only the
+    // operand is asserted here, since the text after it comes from the OS.
     for operand in ["*5", "a", "foo5.txt"] {
         new_ucmd!()
             .args(&["-n", operand, "test.log"])
             .fails()
-            .stderr_contains(format!("{operand}: No such file or directory"));
+            .stderr_contains(format!("{operand}:"));
     }
 
     // Attached, the same values are read as SEP[NUMBER].

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1349,8 +1349,9 @@ fn test_optional_value_is_not_taken_from_the_next_argument() {
         "--number-l",
         "--sep-s",
     ] {
-        new_ucmd!()
-            .args(&["-t", flag, "f1"])
+        let (at, mut ucmd) = at_and_ucmd!();
+        at.write("f1", "from_file\n");
+        ucmd.args(&["-t", flag, "f1"])
             .pipe_in("FROM_STDIN\n")
             .succeeds()
             .stdout_contains("from_file")
@@ -1358,8 +1359,9 @@ fn test_optional_value_is_not_taken_from_the_next_argument() {
     }
 
     // The attached spellings still carry their own value.
-    new_ucmd!()
-        .args(&["-t", "-n,3", "f1"])
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f1", "from_file\n");
+    ucmd.args(&["-t", "-n,3", "f1"])
         .succeeds()
         .stdout_contains(",from_file");
 }

--- a/tests/by-util/test_pr.rs
+++ b/tests/by-util/test_pr.rs
@@ -1333,7 +1333,22 @@ fn test_optional_value_is_not_taken_from_the_next_argument() {
     // `-n`, `-s` and `-S` take their value attached only. A file whose name
     // happens to look like SEP[DIGITS] used to be swallowed as the value,
     // leaving no operand, so pr silently numbered stdin instead of the file.
-    for flag in ["-n", "-s", "-S"] {
+    // Every spelling has to be covered: the bare short flag, the trailing
+    // position of a cluster, the long name, and the abbreviations of it that
+    // `infer_long_args` accepts.
+    for flag in [
+        "-n",
+        "-s",
+        "-S",
+        "-tn",
+        "-ts",
+        "-tS",
+        "--number-lines",
+        "--separator",
+        "--sep-string",
+        "--number-l",
+        "--sep-s",
+    ] {
         new_ucmd!()
             .args(&["-t", flag, "f1"])
             .pipe_in("FROM_STDIN\n")
@@ -1341,4 +1356,10 @@ fn test_optional_value_is_not_taken_from_the_next_argument() {
             .stdout_contains("from_file")
             .stdout_does_not_contain("FROM_STDIN");
     }
+
+    // The attached spellings still carry their own value.
+    new_ucmd!()
+        .args(&["-t", "-n,3", "f1"])
+        .succeeds()
+        .stdout_contains(",from_file");
 }

--- a/tests/fixtures/pr/f1
+++ b/tests/fixtures/pr/f1
@@ -1,0 +1,1 @@
+from_file

--- a/tests/fixtures/pr/f1
+++ b/tests/fixtures/pr/f1
@@ -1,1 +1,0 @@
-from_file


### PR DESCRIPTION
`pr -n FILE` printed nothing at all — exit 0, no stderr.

`-n` is declared with `num_args(0..=1)`, so clap took `FILE` as its value. That left no operand, and pr read stdin instead:

```console
$ echo hi | pr -n f1
1fhi
```

It used the file name as the numbering format — separator `f`, width `1` — and numbered stdin. GNU numbers `f1` and never touches stdin. `-s` and `-S` behaved the same way.

## Why the existing guard missed it

`recreate_arguments` already tried to prevent this, but only when the next argument did not match `^[^-]\d*$`, i.e. did not look like `SEP[DIGITS]`. The two cannot be told apart by shape: a file named `f1` reads exactly like separator `f` with width `1`, so the guard never fired for it. `-s` and `-S` had no guard at all.

GNU resolves the ambiguity by position rather than shape — the value must be attached, and the argument after the flag is always an operand:

```console
$ pr -n a f1
pr: a: No such file or directory      # 'a' is a file, not a separator
$ pr -s e f1
pr: e: No such file or directory
```

So the default is filled in after a bare `-n`, `-s` or `-S`, which leaves clap nothing to take. The attached spellings are unchanged: `-n2` is still width 2, `-n,3` still separator `,` with width 3, `-s,` and `-S:` still work, and `--number-lines=,3` is unaffected.

## The existing tests

Four tests asserted the value could be given separately — `pr -n a test.log` succeeding with `a` as the separator, `pr -n 2 file` meaning width 2, and so on. I checked each against GNU before changing them:

```console
$ pr -n a f1   → pr: a: No such file or directory
$ pr -n 2 f1   → pr: 2: No such file or directory
$ pr -n *5 f1  → pr: '*5': No such file or directory
```

GNU treats all three as files. Those tests now use the attached spelling (`-n2`, `-n*5`, `-n18446744073709551615`, `-n70000`), which I verified produces byte-identical output to GNU, and `test_value_for_number_lines` is rewritten to pin the operand behavior instead.

## Testing

- `cargo test --features pr --no-default-features`: **85 passed, 0 failed** (84 pre-existing/updated, 1 new)
- New `test_optional_value_is_not_taken_from_the_next_argument` covers all three flags; verified it catches the bug by reverting `pr.rs` alone
- `cargo fmt --check` and `cargo clippy -p uu_pr --all-targets`: clean
- 19-case differential check against GNU coreutils 9.11: the `-n`/`-s`/`-S` cases all match now, including attached forms and `-tre`/`-se` clustering

Three cases in that sweep still differ — `pr -s e f1` error recovery, and column padding in `pr -m` and `pr -2` (GNU pads with tabs, uutils with spaces). I confirmed all three differ identically on an unmodified tree, so they are pre-existing and separate from this.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. On the GPL point raised there: every GNU behavior quoted above was established by running the installed GNU binary as a black box and recording its output. I did not read GNU coreutils source. All testing was run locally.

