### PR TITLE
uniq: drop the "Could not open" prefix from open errors

### DIFF
--- a/src/uu/uniq/locales/en-US.ftl
+++ b/src/uu/uniq/locales/en-US.ftl
@@ -40,5 +40,3 @@ uniq-error-all-repeated-badoption = invalid argument 'badoption' for '--all-repe
 
 uniq-error-counts-and-repeated-meaningless = printing all duplicated lines and repeat counts is meaningless
   Try 'uniq --help' for more information.
-
-uniq-error-could-not-open = Could not open { $path }

--- a/src/uu/uniq/locales/fr-FR.ftl
+++ b/src/uu/uniq/locales/fr-FR.ftl
@@ -39,4 +39,3 @@ uniq-error-all-repeated-badoption = argument invalide 'badoption' pour '--all-re
 
 uniq-error-counts-and-repeated-meaningless = afficher toutes les lignes dupliquées et les nombres de répétitions n'a pas de sens
   Essayez 'uniq --help' pour plus d'informations.
-uniq-error-could-not-open = Impossible d'ouvrir { $path }

--- a/src/uu/uniq/src/uniq.rs
+++ b/src/uu/uniq/src/uniq.rs
@@ -837,9 +837,7 @@ fn get_delimiter(matches: &ArgMatches) -> Delimiters {
 fn open_input_file(in_file_name: Option<&OsStr>) -> UResult<Box<dyn BufRead>> {
     Ok(match in_file_name {
         Some(path) if path != "-" => {
-            let in_file = File::open(path).map_err_context(
-                || translate!("uniq-error-could-not-open", "path" => path.maybe_quote()),
-            )?;
+            let in_file = File::open(path).map_err_context(|| path.maybe_quote().to_string())?;
             Box::new(BufReader::with_capacity(OUTPUT_BUFFER_CAPACITY, in_file))
         }
         _ => Box::new(stdin().lock()),
@@ -850,9 +848,7 @@ fn open_input_file(in_file_name: Option<&OsStr>) -> UResult<Box<dyn BufRead>> {
 fn open_output_file(out_file_name: Option<&OsStr>) -> UResult<Box<dyn Write>> {
     Ok(match out_file_name {
         Some(path) if path != "-" => {
-            let out_file = File::create(path).map_err_context(
-                || translate!("uniq-error-could-not-open", "path" => path.maybe_quote()),
-            )?;
+            let out_file = File::create(path).map_err_context(|| path.maybe_quote().to_string())?;
             Box::new(BufWriter::with_capacity(OUTPUT_BUFFER_CAPACITY, out_file))
         }
         _ => Box::new(BufWriter::with_capacity(

--- a/tests/by-util/test_uniq.rs
+++ b/tests/by-util/test_uniq.rs
@@ -1230,3 +1230,11 @@ fn test_repeated_skip_fields_takes_the_last() {
         .succeeds()
         .stdout_is("x y a\n");
 }
+
+#[test]
+fn test_nonexistent_input_file_error_matches_gnu() {
+    new_ucmd!()
+        .arg("nosuchfile.txt")
+        .fails_with_code(1)
+        .stderr_only("uniq: nosuchfile.txt: No such file or directory\n");
+}


### PR DESCRIPTION
GNU prefixes the failing path only:

```
GNU:  uniq: nosuchfile.txt: No such file or directory
uu:   uniq: Could not open nosuchfile.txt: No such file or directory
```

Same for the output file. Pass the path as the error context, as `nl` and `wc` do, and drop the now-unused `uniq-error-could-not-open` message.

Two remaining differences are platform behaviour rather than message format, so I left them alone: on Linux a directory opens and fails at read time (`error reading '...'`), on Windows the open itself fails.