### PR TITLE
tests_cp.rs: ensure error of ioctl is catched when --reflink=always

### DIFF
--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1056,6 +1056,24 @@ fn test_cp_reflink_always_failure_dest_cleanup() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_cp_reflink_always_failure() {
+    let scene = TestScenario::new(util_name!());
+    scene
+        .ucmd()
+        .args(&["--reflink=always", "/dev/null", "/dev/full"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("Invalid argument");
+    scene
+        .ucmd()
+        .args(&["--reflink=always", "/dev/null", "target"])
+        .fails()
+        .no_stdout()
+        .stderr_contains("Invalid cross-device link");
+}
+
+#[test]
 fn test_cp_arg_no_clobber() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.arg(TEST_HELLO_WORLD_SOURCE)


### PR DESCRIPTION
https://github.com/uutils/coreutils/pull/14136 started showing ficlone's error when reflink is forced which is actually compatible with GNU.