### PR TITLE
fmt: default the width to goal + 10 when only --goal is given

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -54,6 +54,8 @@ const DEFAULT_GOAL: usize = 70;
 const DEFAULT_WIDTH: usize = 75;
 // by default, goal is 93% of width
 const DEFAULT_GOAL_TO_WIDTH_RATIO: usize = 93;
+// When only --goal is given, GNU sets the maximum width to goal + 10.
+const DEFAULT_GOAL_WIDTH_SLACK: usize = 10;
 
 mod options {
     pub const CROWN_MARGIN: &str = "crown-margin";
@@ -149,7 +151,7 @@ impl FmtOptions {
                 if g > DEFAULT_WIDTH {
                     return Err(FmtError::GoalGreaterThanWidth.into());
                 }
-                let w = (g * 100 / DEFAULT_GOAL_TO_WIDTH_RATIO).max(g + 3);
+                let w = g + DEFAULT_GOAL_WIDTH_SLACK;
                 (w, g)
             }
             (None, None) => (DEFAULT_WIDTH, DEFAULT_GOAL),

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -455,3 +455,32 @@ fn test_fmt_width_multiplication_overflow() {
         .fails_with_code(1)
         .stderr_is("fmt: invalid width: '267672676527678256'\n");
 }
+
+#[test]
+fn test_fmt_goal_only_defaults_width_to_goal_plus_ten() {
+    // GNU defaults the width to goal + 10 when only --goal is given, so `-g G`
+    // has to lay a paragraph out exactly as `-w G+10 -g G` does.
+    for goal in [5, 10, 20, 30, 50, 65] {
+        let widened = new_ucmd!()
+            .args(&[
+                "one-word-per-line.txt",
+                "-w",
+                &(goal + 10).to_string(),
+                "-g",
+                &goal.to_string(),
+            ])
+            .succeeds()
+            .stdout_move_str();
+
+        new_ucmd!()
+            .args(&["one-word-per-line.txt", "-g", &goal.to_string()])
+            .succeeds()
+            .stdout_is(&widened);
+    }
+
+    // The whole 37-column paragraph therefore fits on one line at goal 30.
+    new_ucmd!()
+        .args(&["one-word-per-line.txt", "--goal", "30"])
+        .succeeds()
+        .stdout_is("this is a file with one word per line\n");
+}


### PR DESCRIPTION
GNU documents the width as "75, or goal + 10 if goal is provided", and `fmt -g N` is byte-identical to `fmt -w N+10 -g N` there. We derived the width by inverting the 93% goal ratio instead, which comes out narrower and breaks lines GNU keeps together:

```
$ printf 'this\nis\na\nfile\nwith\none\nword\nper\nline\n' | fmt -g 30
GNU:  this is a file with one word per line
uu:   this is a file with one word
      per line
```

With `-g 30` our width was 33 rather than 40, so the 37-column paragraph did not fit.

Refs #5162. That issue also covers a second difference which this does not address: once the width matches, the line-breaking cost function still disagrees with GNU, because it penalises a line for overshooting the goal as heavily as for undershooting it. The two `#[ignore]`d tests in `test_fmt.rs` need that part too, so they stay ignored here.