### PR TITLE
date: report invalid UTF-8 lines in -f file/stdin input

### DIFF
--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -1090,12 +1090,22 @@ fn parse_dates_from_reader<R: Read + 'static>(
 ) -> Box<
     dyn Iterator<Item = Result<ParsedDateTime, (String, parse_datetime::ParseDateTimeError)>> + '_,
 > {
-    let lines = BufReader::new(reader).lines();
-    Box::new(
-        lines
-            .map_while(Result::ok)
-            .map(move |s| parse_date(s, now, dbg_opts, allow_extended)),
-    )
+    let lines = BufReader::new(reader).split(b'\n');
+    Box::new(lines.map_while(Result::ok).map(move |mut bytes| {
+        // Strip a trailing '\r' (CRLF input; GNU's lexer ignores it too)
+        if bytes.last() == Some(&b'\r') {
+            bytes.pop();
+        }
+        match String::from_utf8(bytes) {
+            Ok(s) => parse_date(s, now, dbg_opts, allow_extended),
+            // Report lines with invalid UTF-8 (with non-printable bytes
+            // octal-escaped like GNU) instead of silently stopping the input
+            Err(e) => Err((
+                escape_invalid_bytes(e.as_bytes()),
+                parse_datetime::ParseDateTimeError::InvalidInput,
+            )),
+        }
+    }))
 }
 
 /// Parse a string into either an in-range [`Zoned`] value or an extended date.

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -598,6 +598,46 @@ fn test_date_for_file() {
 }
 
 #[test]
+fn test_date_file_invalid_utf8_line() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_date_file_invalid_utf8";
+    // A 0xFF byte makes the whole line invalid UTF-8
+    at.write_bytes(file, b"Hello\xffx\n");
+
+    // GNU date: "date: invalid date 'Hello\377x'" on stderr, exit code 1
+    let result = ucmd.args(&["-u", "-f", file]).fails_with_code(1);
+    result.no_stdout();
+    result.stderr_contains("date: invalid date 'Hello\\377x'");
+}
+
+#[test]
+fn test_date_file_invalid_utf8_line_continues() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_date_file_mixed_invalid_utf8";
+    at.write_bytes(
+        file,
+        b"2024-01-15 12:00:00\nHello\xffx\n2024-01-16 13:00:00\n",
+    );
+
+    // GNU date reports the invalid line but still processes the other lines,
+    // exiting with code 1
+    let result = ucmd.args(&["-u", "-f", file]).fails_with_code(1);
+    result.stdout_contains("Mon Jan 15 12:00:00 UTC 2024");
+    result.stdout_contains("Tue Jan 16 13:00:00 UTC 2024");
+    result.stderr_contains("date: invalid date 'Hello\\377x'");
+}
+
+#[test]
+fn test_date_stdin_invalid_utf8_line() {
+    // `date -f -` reads from stdin through the same path
+    new_ucmd!()
+        .args(&["-u", "-f", "-"])
+        .pipe_in(b"Hello\xffx\n".to_vec())
+        .fails_with_code(1)
+        .stderr_contains("date: invalid date 'Hello\\377x'");
+}
+
+#[test]
 fn test_date_for_file_mtime() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "reference_file";


### PR DESCRIPTION
### Problem

`date -f` reads lines via `BufRead::lines().map_while(Result::ok)`. On a line that is not valid UTF-8, `lines()` yields an `InvalidData` error and `map_while` silently ends the iterator: the offending line and everything after it vanish with no diagnostic, and `date` exits 0 — even with `--debug`, which stays silent because it never sees the line.

GNU date (current git master) instead reports the line (non-printable bytes octal-escaped), keeps processing the rest of the input and exits 1:

```
$ printf 'Hello\xffx\n' > bad.txt && date -f bad.txt
date: invalid date 'Hello\377x'
```

### Fix

Read the input with `split(b'\n')`, stripping a trailing `\r`, and decode each chunk as UTF-8. A chunk that fails to decode becomes an invalid-date error via the existing `escape_invalid_bytes` helper (already used for the same diagnostic for the `-d` argument), producing the GNU-style `invalid date 'Hello\377x'` message; iteration continues with the remaining lines and the final exit status is 1, matching GNU.

### Tests

Three new tests in `tests/by-util/test_date.rs`:

- a file with a single invalid-UTF-8 line fails with code 1 and the GNU-shaped message on stderr
- a mixed file still prints the valid dates around the bad line while failing with code 1
- the same input through stdin (`-f -`) behaves identically

Verified against a date binary built from GNU git master (aea70b2): same diagnostic (byte-for-byte in the C locale — GNU renders typographic quotes under UTF-8 locales), same exit code, remaining lines still processed.

Fixes #12920