### PR TITLE
dircolors: skip invalid UTF-8 lines instead of truncating the config

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -176,7 +176,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let result = if *file_arg == "-" {
                 let fin = BufReader::new(std::io::stdin());
                 // For example, for echo "owt 40;33"|dircolors -b -
-                parse(fin.lines().map_while(Result::ok), &out_format, "-")
+                parse(config_lines(fin), &out_format, "-")
             } else {
                 let path = Path::new(&file_arg);
                 if path.is_dir() {
@@ -188,11 +188,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 let file = File::open(path)
                     .map_err(|e| USimpleError::new(1, format!("{}: {e}", path.maybe_quote())))?;
                 let fin = BufReader::new(file);
-                parse(
-                    fin.lines().map_while(Result::ok),
-                    &out_format,
-                    &path.to_string_lossy(),
-                )
+                parse(config_lines(fin), &out_format, &path.to_string_lossy())
             };
 
             let string = result.map_err(|s| USimpleError::new(1, s))?;
@@ -311,6 +307,18 @@ enum ParseState {
     Matched,
     Continue,
     Pass,
+}
+
+/// Iterate over the lines of a config file.
+/// GNU dircolors is byte-oriented; invalid UTF-8 maps to an empty line,
+/// which the parser skips but still counts — line numbers stay aligned.
+fn config_lines(fin: impl BufRead) -> impl Iterator<Item = String> {
+    fin.split(b'\n').map_while(Result::ok).map(|mut line| {
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        String::from_utf8(line).unwrap_or_default()
+    })
 }
 
 fn parse<T>(user_input: T, fmt: &OutputFmt, fp: &str) -> Result<String, String>

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -5,7 +5,6 @@
 
 // spell-checker:ignore overridable colorterm
 
-#[cfg(target_os = "linux")]
 use uutests::at_and_ucmd;
 use uutests::new_ucmd;
 
@@ -248,4 +247,59 @@ fn test_invalid_term_glob() {
         .args(&["-b", "-"])
         .succeeds()
         .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
+}
+
+#[test]
+fn test_invalid_utf8_line_file() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let filename = "invalid-utf8-line";
+    std::fs::write(
+        at.plus(filename),
+        b"DIR 01;31\nBAD\xffLINE 99\n*.txt 00;32\n",
+    )
+    .unwrap();
+
+    // a line that fails to decode is skipped without truncating the rest
+    ucmd.args(&["-b", filename])
+        .succeeds()
+        .stdout_contains("di=01;31")
+        .stdout_contains("*.txt=00;32");
+}
+
+#[test]
+fn test_invalid_utf8_line_stdin() {
+    // the bad line must be skipped, not truncate the rest of the config
+    new_ucmd!()
+        .pipe_in(b"DIR 01;31\nBAD\xffLINE 99\n*.txt 00;32\n".to_vec())
+        .args(&["-b", "-"])
+        .succeeds()
+        .stdout_contains("di=01;31")
+        .stdout_contains("*.txt=00;32");
+}
+
+#[test]
+fn test_invalid_utf8_only_bad() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let filename = "invalid-utf8-only";
+    std::fs::write(at.plus(filename), b"BAD\xffLINE 99\n").unwrap();
+
+    // the config holds nothing parseable: empty LS_COLORS, exit 0
+    ucmd.args(&["-b", filename])
+        .succeeds()
+        .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
+}
+
+#[test]
+fn test_invalid_utf8_line_preserves_line_numbers() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    let filename = "invalid-utf8-line-number";
+    std::fs::write(at.plus(filename), b"BAD\xffLINE 99\nONLYKEY\n").unwrap();
+
+    // GNU counts the skipped line, so the error points at the real line 2
+    ucmd.args(&["-b", filename])
+        .fails_with_code(1)
+        .stderr_contains(":2: invalid line");
 }


### PR DESCRIPTION
### Problem

`dircolors` reads the config via `BufRead::lines().map_while(Result::ok)`. On a line that is not valid UTF-8, `lines()` returns an `InvalidData` error and `map_while` ends the iteration: every line after the bad one is silently dropped, and the user gets a truncated `LS_COLORS` with exit code 0.

GNU dircolors tokenizes the file bytewise, so a line that fails to decode is simply ignored and reading continues. With this config:

```
DIR 01;31
BAD\xffLINE 99
*.txt 00;32
```

Current GNU master prints `LS_COLORS='di=01;31:*.txt=00;32:'` and exits 0, while uutils main stops after the first entry.

### Fix

Read the input bytewise with `split(b'\n')` (stripping a trailing `\r`) and decode each line via `String::from_utf8(...).unwrap_or_default()`. A line that fails to decode becomes an empty line: the parser skips it but still counts it, so line numbers in error messages stay aligned with the file. The file and stdin paths share the new `config_lines` helper.

### Known deviation

A line that is both single-token and invalid UTF-8 (e.g. `BAD\xffLINE` alone) makes GNU exit 1 with "invalid line;  missing second token", because its byte tokenizer still sees one token. We normalize such a line to empty and skip it, exiting 0. I don't think this corner justifies byte-tokenizing the parser: the line is malformed either way, and the multi-token case (the realistic one) now matches GNU exactly.

### Tests

Four new tests in `tests/by-util/test_dircolors.rs`:

- bad line in the middle of a file keeps the remaining entries
- same input through stdin
- a file containing only a bad line yields an empty `LS_COLORS` and success
- an error after a skipped bad line still reports the correct line number

Verified against a dircolors binary built from GNU git master (aea70b2) and the 9.11 release: bad line skipped, exit status 0, `LS_COLORS` output identical.

Same bug class as #12920, where `date -f` also silently accepted invalid UTF-8 input (fixed in #14280).
