### PR TITLE
ohos: add aarch64-unknown-linux-ohos support (fsext/hostid/date)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,6 +3478,7 @@ dependencies = [
  "icu_locale",
  "jiff",
  "jiff-icu",
+ "jiff-tzdb",
  "libc",
  "parse_datetime",
  "rustix",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1877,6 +1877,7 @@ dependencies = [
  "icu_locale",
  "jiff",
  "jiff-icu",
+ "jiff-tzdb",
  "libc",
  "parse_datetime",
  "rustix",

--- a/src/uu/date/Cargo.toml
+++ b/src/uu/date/Cargo.toml
@@ -44,6 +44,12 @@ uucore = { workspace = true, features = ["parser", "i18n-datetime"] }
 libc = { workspace = true }
 rustix = { workspace = true, features = ["time"] }
 
+[target.'cfg(target_env = "ohos")'.dependencies]
+# OHOS has no /usr/share/zoneinfo or /etc/localtime: embed IANA tzdata so
+# ohos_system_zone() can resolve the TimeService timezone ID directly (pass-through,
+# no environment injection).
+jiff-tzdb = "0.1"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -32,6 +32,36 @@ use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetS
 
 use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 
+/// OHOS helper: pass through the system time zone ID returned by
+/// TimeService (OH_TimeService_GetTimeZone, e.g. "Asia/Shanghai") and
+/// resolve it against the embedded IANA tzdata (jiff-tzdb) so that
+/// historial DST rules and transitions are preserved. jiff's
+/// `try_system()` is useless on OHOS because both `/etc/localtime` and
+/// the zoneinfo dirs are absent.
+#[cfg(target_env = "ohos")]
+fn ohos_system_zone() -> jiff::tz::TimeZone {
+    use core::ffi::{CStr, c_char};
+
+    #[link(name = "time_service_ndk")]
+    unsafe extern "C" {
+        fn OH_TimeService_GetTimeZone(tz: *mut c_char, len: u32) -> i32;
+    }
+    let mut buf = [0u8; 64];
+    let rc = unsafe { OH_TimeService_GetTimeZone(buf.as_mut_ptr() as *mut c_char, 64) };
+    if rc != 0 {
+        return jiff::tz::TimeZone::UTC;
+    }
+    let id = unsafe { CStr::from_ptr(buf.as_ptr() as *const c_char) }
+        .to_string_lossy()
+        .into_owned();
+    if let Some((name, tzif)) = jiff_tzdb::get(&id) {
+        if let Ok(tz) = jiff::tz::TimeZone::tzif(name, tzif) {
+            return tz;
+        }
+    }
+    jiff::tz::TimeZone::UTC
+}
+
 // Options
 const DATE: &str = "date";
 const HOURS: &str = "hours";
@@ -371,7 +401,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let now = if utc {
         Timestamp::now().to_zoned(TimeZone::UTC)
     } else {
-        Zoned::now()
+        #[cfg(target_env = "ohos")]
+        {
+            Timestamp::now().to_zoned(ohos_system_zone())
+        }
+        #[cfg(not(target_env = "ohos"))]
+        {
+            Zoned::now()
+        }
     };
 
     let set_to = match matches.get_one::<String>(OPT_SET) {
@@ -557,12 +594,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                     translate!("date-error-cannot-set-date", "path" => path.quote(), "error" => e),
                 )
             })?;
+            #[cfg(target_env = "ohos")]
+            let date = ts.to_zoned(ohos_system_zone());
+            #[cfg(not(target_env = "ohos"))]
             let date = ts.to_zoned(TimeZone::try_system().unwrap_or(TimeZone::UTC));
             let iter = std::iter::once(Ok(ParsedDateTime::InRange(date)));
             Box::new(iter)
         }
         DateSource::Resolution => {
             let resolution = get_clock_resolution();
+            #[cfg(target_env = "ohos")]
+            let date = resolution.to_zoned(ohos_system_zone());
+            #[cfg(not(target_env = "ohos"))]
             let date = resolution.to_zoned(TimeZone::system());
             let iter = std::iter::once(Ok(ParsedDateTime::InRange(date)));
             Box::new(iter)

--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -7,11 +7,36 @@
 
 use clap::Command;
 use core::ffi::c_long;
+#[cfg(not(target_env = "ohos"))]
 use libc::gethostid;
 use std::io::{Write, stdout};
 use uucore::{error::UResult, format_usage};
 
 use uucore::translate;
+
+// OHOS SDK libc no longer exports gethostid; replicate the glibc semantics:
+// read /etc/hostid when present, otherwise hash the hostname.
+#[cfg(target_env = "ohos")]
+fn gethostid() -> c_long {
+    use std::fs::read;
+    if let Ok(data) = read("/etc/hostid") {
+        if data.len() >= 4 {
+            let n: u32 = u32::from_ne_bytes([data[0], data[1], data[2], data[3]]);
+            return n as c_long;
+        }
+    }
+    let mut name = [0u8; 256];
+    if unsafe { libc::gethostname(name.as_mut_ptr() as *mut _, name.len()) } == 0 {
+        let end = name.iter().position(|&b| b == 0).unwrap_or(name.len());
+        let mut h: u32 = 0x811c9dc5;
+        for &b in &name[..end] {
+            h ^= b as u32;
+            h = h.wrapping_mul(0x01000193);
+        }
+        return h as c_long;
+    }
+    0
+}
 
 #[uucore::main(no_signals)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -799,7 +799,7 @@ impl FsMeta for StatFs {
     ))]
     fn fs_type(&self) -> i64 {
         #[cfg(all(
-            not(target_env = "musl"),
+            not(any(target_env = "musl", target_env = "ohos")),
             not(target_vendor = "apple"),
             not(target_os = "android"),
             not(target_os = "freebsd"),
@@ -808,7 +808,7 @@ impl FsMeta for StatFs {
         ))]
         return self.f_type;
         #[cfg(all(
-            not(target_env = "musl"),
+            not(any(target_env = "musl", target_env = "ohos")),
             any(
                 target_vendor = "apple",
                 all(target_os = "android", target_pointer_width = "32"),
@@ -820,6 +820,7 @@ impl FsMeta for StatFs {
         return self.f_type.into();
         #[cfg(any(
             target_env = "musl",
+            target_env = "ohos",
             all(target_os = "android", target_pointer_width = "64"),
         ))]
         return self.f_type.try_into().unwrap();


### PR DESCRIPTION
# Add aarch64-unknown-linux-ohos (HarmonyOS) support

Closes #14287

Minimal patch set to build uutils/coreutils natively on HarmonyOS (`aarch64-unknown-linux-ohos`), verified on a HarmonyOS PC (kernel HongMeng 1.13.0, aarch64). All changes are `#[cfg(target_env = "ohos")]`-gated; non-OHOS code paths are untouched (musl `allow(deprecated)` attributes and glibc/musl branch behavior preserved).

This revision:
- **drops the utmpx changes** and defers to #14252, which disables utmpx on OHOS (no utmp data source there). utmpx.rs is identical to upstream in this PR.
- **syncs fuzz/Cargo.lock** (via `cargo fetch` in `fuzz/`) to fix the CI `--locked` failure (Dependencies / MinRustV jobs).

## Changes

| File | Root cause (verified) | Change |
|---|---|---|
| `src/uucore/src/lib/features/fsext.rs` | `statfs.f_type` is `u64` on OHOS (musl-like libc) → E0308 | Include OHOS in the musl `try_into().unwrap()` branch |
| `src/uu/hostid/src/hostid.rs` | `gethostid` not exported by OHOS SDK libc | OHOS-local impl: read `/etc/hostid`, else FNV-1a hostname hash (glibc semantics) |
| `src/uu/date/src/date.rs` | jiff `try_system()` reads `/etc/localtime`/zoneinfo (absent on OHOS) → always UTC | OHOS-only `ohos_system_zone()`: pass through the system time zone ID from `OH_TimeService_GetTimeZone`, resolve via embedded IANA tzdata (`jiff-tzdb`) with `TimeZone::tzif`, preserving DST rules/history. Call sites `cfg`-gated; non-OHOS paths byte-identical to upstream. |
| `src/uu/date/Cargo.toml` | jiff needs tzdata to resolve the ID | `[target.'cfg(target_env = "ohos")'.dependencies] jiff-tzdb = "0.1"` (OHOS-only) |
| `Cargo.lock` / `fuzz/Cargo.lock` | new dependency | `+ jiff-tzdb`; fuzz lock synced via `cargo fetch` |

## Build

Standard upstream flow (unix default `feat_os_unix`; utmpx commands excluded on OHOS per #14252):

```sh
make build                 # per-command binaries
make build MULTICALL=y     # multi-call coreutils
```

## Verification (on-device)

- `date "+%F %T %z %Z"` matches system time: `+0800 CST`
- `date -d 1987-06-01 "+%z %Z"` → `+0900 CDT` (tzdata DST-era rule active; China DST 1986-1991)
- `hostid`/`b2sum`/`arch`/`numfmt` work; builds pass on the non-utmpx feature set
- Negative: OHOS builds exclude who/users/uptime/pinky (utmpx disabled by #14252 — graceful degradation, no utmp data source)

## Known limits (runtime degradation, documented in #14287)

- who/uptime/users/pinky: OHOS keeps no login-session records; utmpx remains disabled per #14252
- `cp --preserve`: sandbox restricts xattr/timestamp writes

Fork: `YodonTan/coreutils`, branch `ohos-pr`. Happy to add an `aarch64-unknown-linux-ohos` CI workflow mirroring `android.yml`/`freebsd.yml` if maintainers are interested.