### PR TITLE
split: keep a suffix start at the top of the range from overflowing

### DIFF
--- a/src/uu/split/src/filenames.rs
+++ b/src/uu/split/src/filenames.rs
@@ -199,9 +199,11 @@ impl Suffix {
         // Auto pre-calculate new suffix length (auto-width) if necessary
         if let Strategy::Number(number_type) = strategy {
             let chunks = number_type.num_chunks();
-            let required_length = ((start as u64 + chunks) as f64)
-                .log(stype.radix() as f64)
-                .ceil() as usize;
+            // The last suffix is the start plus the chunk count, and either of
+            // those alone can be as large as the type allows, so the sum needs
+            // room the type does not have.
+            let last = start as u128 + u128::from(chunks);
+            let required_length = (last as f64).log(stype.radix() as f64).ceil() as usize;
 
             if (start as u64) < chunks && !(is_length_cmd_opt && length > 0) {
                 // with auto-width ON the auto-widening is OFF

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -942,6 +942,42 @@ fn test_suffix_length_req() {
         .stderr_only("split: the suffix length needs to be at least 2\n");
 }
 
+/// The width the suffixes need is worked out from the start value plus the
+/// number of chunks, and either of those on its own can be the largest value
+/// there is, so the sum of them does not fit where they do.
+#[test]
+fn test_suffix_start_at_the_top_of_the_range() {
+    new_ucmd!()
+        .args(&["-n", "5", "--numeric-suffixes=18446744073709551615", "-"])
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_only("split: the suffix length needs to be at least 20\n");
+
+    // The hexadecimal start is read in base 16, so it takes fewer digits to
+    // reach the same place.
+    new_ucmd!()
+        .args(&["-n", "5", "--hex-suffixes=ffffffffffffffff", "-"])
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_only("split: the suffix length needs to be at least 16\n");
+
+    // A suffix wide enough for the start is accepted, and the first name is
+    // the start itself.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&[
+        "-n",
+        "5",
+        "--numeric-suffixes=18446744073709551615",
+        "-a",
+        "20",
+        "-",
+    ])
+    .pipe_in("")
+    .fails_with_code(1)
+    .stderr_only("split: output file suffixes exhausted\n");
+    assert!(at.file_exists("x18446744073709551615"));
+}
+
 #[test]
 fn test_large_suffix_length_is_rejected() {
     new_ucmd!()

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -945,7 +945,13 @@ fn test_suffix_length_req() {
 /// The width the suffixes need is worked out from the start value plus the
 /// number of chunks, and either of those on its own can be the largest value
 /// there is, so the sum of them does not fit where they do.
+///
+/// `u64::MAX` only reaches `--numeric-suffixes`'s `start` at all on a target
+/// where `usize` is 64 bits -- on a 32-bit target the value is already
+/// rejected by the `usize` parse, before the overflow this guards against
+/// could occur.
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn test_suffix_start_at_the_top_of_the_range() {
     new_ucmd!()
         .args(&["-n", "5", "--numeric-suffixes=18446744073709551615", "-"])


### PR DESCRIPTION
Fixes #13749.

`split` works out how wide the suffixes need to be from the start value plus the number of chunks. Either of those on its own can be as large as the type allows, so their sum is not always a value the type can hold:

```console
$ split -n 5 --numeric-suffixes=18446744073709551615 /dev/null
thread 'main' panicked at src/uu/split/src/filenames.rs:202:36:
attempt to add with overflow

$ split -n 5 --hex-suffixes=ffffffffffffffff /dev/null
thread 'main' panicked at src/uu/split/src/filenames.rs:202:36:
attempt to add with overflow
```

With overflow checks off the add wraps instead, and the width computed from the wrapped sum is too small. Adding in `u128` leaves room for the sum, so the width comes out right and the value is refused the way any other too-wide start already is:

```console
$ split -n 5 --numeric-suffixes=18446744073709551615 /dev/null
split: the suffix length needs to be at least 20
$ split -n 5 --hex-suffixes=ffffffffffffffff /dev/null
split: the suffix length needs to be at least 16
```

@leeewee's report also names a third route to the same add — a huge `-n` with a nonzero start — and that one stops panicking too.

## Scope

This is the panic only. Two neighbouring differences are left alone, and neither is touched by the change:

- The wording differs from GNU for a start that is too wide, whether or not it overflows: GNU says `numerical suffix start value is too large for the suffix length`, we say `the suffix length needs to be at least N`. `split -n 5 --numeric-suffixes=99999` already showed that on `main`, with no overflow involved.
- Given a wide enough `-a`, GNU carries the suffix past `u64` (`x18446744073709551616`, and for hex it walks the ASCII past `f` into `xfffffffffffffff:`); our `FixedWidthNumber` is `u64`-backed and stops with `output file suffixes exhausted`. Before this change that case panicked, so it is an improvement rather than a match.

## Testing

- Old-vs-new comparison over **509 invocations** — `-n`/`-l`/`-b`/`-C`/`-n l/N`/`-n r/N` crossed with `--numeric-suffixes`/`--hex-suffixes` at starts from 0 to 99999, `-a` from 1 to 10, `-d`, `-x` and `--additional-suffix`, comparing stdout, stderr, exit code **and the resulting file names**: **509 identical, 0 changed**. Nothing in range moves.
- The out-of-range cases were checked against GNU 9.11 individually; all now exit 1 with a message instead of aborting.
- New `test_suffix_start_at_the_top_of_the_range`, verified to fail on `main`.
- `cargo test --features split --test tests -- test_split`: **141 passed, 0 failed** (140 pre-existing, 1 new); `cargo test -p uu_split`: 23 passed.
- `cargo fmt --check` and `cargo clippy -p uu_split --all-targets -- -D warnings`: clean.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. GNU's behaviour was established by running the installed GNU binary as a black box; I did not read GNU coreutils source. All testing was run locally.
