### PR TITLE
dd: stop at a zero factor in a multiplier expression

### DIFF
--- a/src/uu/dd/src/parseargs.rs
+++ b/src/uu/dd/src/parseargs.rs
@@ -576,12 +576,24 @@ pub fn parse_bytes_with_opt_multiplier(s: &str) -> Result<u64, ParseError> {
     if parts.len() == 1 {
         parse_bytes_no_x(s, parts[0])
     } else {
-        let mut total: u64 = 1;
+        // The warning is purely lexical, so it is reported for every "0"
+        // factor even though the parsing below stops at the first zero.
         for (i, part) in parts.iter().enumerate() {
             if *part == "0" && i != parts.len() - 1 {
                 show_zero_multiplier_warning();
             }
+        }
+
+        let mut total: u64 = 1;
+        for part in &parts {
             let num = parse_bytes_no_x(s, part)?;
+            // GNU stops at a zero factor and never looks at the rest of the
+            // expression, so the remaining factors must not be parsed: one
+            // of them not fitting in a u64 would otherwise be reported as an
+            // error even though the result is already known to be zero.
+            if num == 0 {
+                return Ok(0);
+            }
             total = total
                 .checked_mul(num)
                 .ok_or_else(|| ParseError::InvalidNumber(s.to_string()))?;
@@ -687,6 +699,31 @@ mod tests {
             2 * 2 * (3 * 2) // (1 * 2) * (2 * 1) * (3 * 2)
         );
     }
+
+    #[test]
+    fn test_parse_bytes_with_opt_multiplier_zero_factor() {
+        // GNU stops at a zero factor and never looks at the rest of the
+        // expression, so a later factor that does not fit in a u64 must not
+        // turn this into an error.
+        assert_eq!(parse_bytes_with_opt_multiplier("0x5").unwrap(), 0);
+        assert_eq!(parse_bytes_with_opt_multiplier("00x5").unwrap(), 0);
+        assert_eq!(
+            parse_bytes_with_opt_multiplier(&format!("0x{BIG}")).unwrap(),
+            0
+        );
+        assert_eq!(
+            parse_bytes_with_opt_multiplier(&format!("00x{BIG}")).unwrap(),
+            0
+        );
+        // The zero does not have to be the leading factor.
+        assert_eq!(
+            parse_bytes_with_opt_multiplier(&format!("2x0x{BIG}")).unwrap(),
+            0
+        );
+        // A trailing zero is still a zero result.
+        assert_eq!(parse_bytes_with_opt_multiplier("5x0").unwrap(), 0);
+    }
+
     #[test]
     fn test_parse_n() {
         for arg in ["1x8x4", "1c", "123b", "123w"] {

--- a/tests/by-util/test_dd.rs
+++ b/tests/by-util/test_dd.rs
@@ -278,6 +278,23 @@ fn test_x_multiplier() {
 }
 
 #[test]
+fn test_zero_factor_skips_the_rest_of_the_multiplier() {
+    // A zero factor makes the whole expression zero, so the factor after it
+    // is never parsed and an oversized one must not be reported as an error.
+    for arg in ["count", "seek", "skip"] {
+        new_ucmd!()
+            .args(&[
+                format!("{arg}=00x9999999999999999999999999999999999999999999999999999999999999")
+                    .as_str(),
+                "status=none",
+            ])
+            .pipe_in("")
+            .succeeds()
+            .no_output();
+    }
+}
+
+#[test]
 fn test_zero_multiplier_warning() {
     for arg in ["count", "seek", "skip"] {
         new_ucmd!()


### PR DESCRIPTION
Fixes #14160.

## The bug

A zero factor makes a whole multiplier expression zero, so the factors after it are never looked at. `parse_bytes_with_opt_multiplier` parsed every factor up front instead, so a later factor that does not fit in a `u64` failed the whole argument:

```console
$ dd count=00x9999999999999999999999999999999999999999999999999999999999999 </dev/null
dd: invalid number: '00x999…': Value too large for defined data type   # exit 1
```

It should copy zero blocks and exit successfully, which it did before 7f9b9a6f0 ("dd: reject a number that does not fit in u64") turned `ParseSizeError::SizeTooBig` into an error rather than `u64::MAX`. The zero factor case was not covered there.

After this change:

```console
$ dd count=00x9999999999999999999999999999999999999999999999999999999999999 </dev/null
0+0 records in
0+0 records out
0 bytes copied, 0.0003494 s, 0.0 B/s                                   # exit 0
```

## The change

Return as soon as a factor parses to zero, so the remaining factors are never parsed. A number that does not fit in a `u64` on its own stays an error, so the behaviour 7f9b9a6f0 added is kept.

The zero-multiplier warning is only a check on the literal text and needs no parsing, so it moved into its own pass over the factors. That keeps it reported once per `"0"` factor — `count=0x0x1` still warns twice, as `test_zero_multiplier_warning` requires. Folding it into the short-circuiting loop would have silently dropped the second warning.

## Tests

Added a unit test in `parseargs.rs` and an end-to-end test in `tests/by-util/test_dd.rs`. Both fail on `main` and pass with the change — verified by reverting just the `if num == 0` block and re-running:

```
test parseargs::tests::test_parse_bytes_with_opt_multiplier_zero_factor ... FAILED
test test_dd::test_zero_factor_skips_the_rest_of_the_multiplier ... FAILED
```

The unit test covers a zero factor leading, in the middle, and trailing, with and without an oversized factor after it.

Run locally on Windows (x86_64-pc-windows-msvc):

- `cargo test -p uu_dd --lib` — 84 passed, 0 failed
- `cargo test --features dd --test tests -- test_dd` — 111 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p uu_dd --all-targets` — no new warnings

## On `tests/dd/misc`

#14160 expects this fix alone to leave GNU's `tests/dd/misc` still failing, on a second difference
(`dd: failed to seek in output file: Illegal seek`). That turns out not to hold — the GNU test job
on this PR reports:

```
Congrats! The gnu test tests/dd/misc is no longer failing!
```

So the whole test passes now, and the second difference either does not reproduce in CI or has been
resolved since the issue was filed. (An earlier version of this description repeated the issue's
expectation as though it still applied.)


