### PR TITLE
head, tail: keep a `+` in an invalid count's error, as GNU does

### DIFF
--- a/src/uu/tail/src/args.rs
+++ b/src/uu/tail/src/args.rs
@@ -102,7 +102,7 @@ impl FilterMode {
                 }
                 Err(e) => {
                     let message =
-                        translate!("tail-error-invalid-number-of-lines", "arg" => arg.quote());
+                        translate!("tail-error-invalid-number-of-lines", "arg" => e.to_string());
                     return Err(raise(message, arg, 'n', "lines", &e));
                 }
             }

--- a/src/uucore/src/lib/features/parser/parse_signed_num.rs
+++ b/src/uucore/src/lib/features/parser/parse_signed_num.rs
@@ -107,6 +107,16 @@ pub fn parse_signed_num_max(src: &str) -> Result<SignedNum, ParseSizeError> {
         return Err(ParseSizeError::ParseFailure(src.to_string()));
     }
 
+    // GNU keeps a `+` in the value it reports back, but drops a `-`: `-5Ki`
+    // is reported as `5Ki`, while `+5Ki` is reported as `+5Ki`. Only `+`
+    // needs the unstripped string; a `-` (or no sign at all) keeps using
+    // `size_string` as before.
+    let reported = if sign == Some(SignPrefix::Plus) {
+        src
+    } else {
+        size_string
+    };
+
     // Remove leading zeros so size is interpreted as decimal, not octal
     let trimmed = size_string.trim_start_matches('0');
     let had_leading_zeros = trimmed.len() != size_string.len();
@@ -120,10 +130,10 @@ pub fn parse_signed_num_max(src: &str) -> Result<SignedNum, ParseSizeError> {
         // Otherwise "0K" would parse as 1KiB (bare suffix means 1).
         // A genuinely bare suffix with no digits at all (e.g. "kiB")
         // still parses as 1 of that unit.
-        parse_count(trimmed).map_err(|e| as_typed(e, size_string))?;
+        parse_count(trimmed).map_err(|e| as_typed(e, reported))?;
         0
     } else {
-        parse_count(trimmed).map_err(|e| as_typed(e, size_string))?
+        parse_count(trimmed).map_err(|e| as_typed(e, reported))?
     };
 
     Ok(SignedNum { value, sign })
@@ -144,10 +154,18 @@ pub fn parse_signed_num(src: &str) -> Result<SignedNum, ParseSizeError> {
         return Err(ParseSizeError::ParseFailure(src.to_string()));
     }
 
+    // GNU keeps a `+` in the value it reports back, but drops a `-`; see
+    // `parse_signed_num_max` for why.
+    let reported = if sign == Some(SignPrefix::Plus) {
+        src
+    } else {
+        size_string
+    };
+
     // Use parse_size_u64 but on failure, create our own error with the raw string
     // (without quotes) so callers can format it as needed
     let value = parse_size_u64(size_string)
-        .map_err(|_| ParseSizeError::ParseFailure(size_string.to_string()))?;
+        .map_err(|_| ParseSizeError::ParseFailure(reported.to_string()))?;
 
     Ok(SignedNum { value, sign })
 }
@@ -171,10 +189,13 @@ pub fn number_offset(src: &str) -> usize {
 ///
 /// Zeros are only removed so the number is read as decimal rather than octal,
 /// which is an implementation detail the message should not leak: GNU reports
-/// `tail: invalid number of bytes: '007z'`, not `'7z'`. The sign is left off,
-/// also matching GNU, which reports `-c-0fb` as `'0fb'`.
-fn as_typed(error: ParseSizeError, size_string: &str) -> ParseSizeError {
-    let quoted = format!("{}", size_string.quote());
+/// `tail: invalid number of bytes: '007z'`, not `'7z'`. `reported` is the
+/// caller's choice of what else to put back: GNU reports `-c-0fb` as `'0fb'`
+/// (the sign left off) but `-c+0fb` as `'+0fb'` (the sign kept), so the
+/// caller passes `src` or the sign-stripped string depending on which sign,
+/// if any, was found.
+fn as_typed(error: ParseSizeError, reported: &str) -> ParseSizeError {
+    let quoted = format!("{}", reported.quote());
     match error {
         // These two carry the quoted operand and nothing else, so it can be
         // swapped for the one that was actually typed.
@@ -290,6 +311,23 @@ mod tests {
         let result = parse_signed_num_max("-2M").unwrap();
         assert_eq!(result.value, 2 * 1024 * 1024);
         assert!(result.has_minus());
+    }
+
+    /// GNU keeps a `+` in the value an error reports, but drops a `-`: the
+    /// same value, `5Ki`, is invalid either way, but the message reads back
+    /// what the user typed only when they typed a `+`.
+    #[test]
+    fn test_error_keeps_plus_but_not_minus() {
+        let plus = parse_signed_num_max("+5Ki").unwrap_err().to_string();
+        assert!(plus.contains("+5Ki"), "{plus}");
+
+        let minus = parse_signed_num_max("-5Ki").unwrap_err().to_string();
+        assert!(!minus.contains('-'), "{minus}");
+        assert!(minus.contains("5Ki"), "{minus}");
+
+        let unsigned = parse_signed_num_max("5Ki").unwrap_err().to_string();
+        assert_eq!(plus.replace('+', ""), unsigned);
+        assert_eq!(minus, unsigned);
     }
 
     #[test]

--- a/tests/by-util/test_head.rs
+++ b/tests/by-util/test_head.rs
@@ -400,6 +400,28 @@ fn test_head_invalid_num() {
         .stderr_is("head: invalid number of bytes: '³'\n");
 }
 
+/// A `-` sign is dropped from the value an error reports, but a `+` is kept,
+/// as GNU does.
+#[test]
+fn test_invalid_num_keeps_a_plus_sign_but_not_a_minus() {
+    new_ucmd!()
+        .args(&["-c", "+5Ki", "emptyfile.txt"])
+        .fails()
+        .stderr_is("head: invalid number of bytes: '+5Ki'\n");
+    new_ucmd!()
+        .args(&["-n", "+5Ki", "emptyfile.txt"])
+        .fails()
+        .stderr_is("head: invalid number of lines: '+5Ki'\n");
+    new_ucmd!()
+        .args(&["-c", "-5Ki", "emptyfile.txt"])
+        .fails()
+        .stderr_is("head: invalid number of bytes: '5Ki'\n");
+    new_ucmd!()
+        .args(&["-n", "-5Ki", "emptyfile.txt"])
+        .fails()
+        .stderr_is("head: invalid number of lines: '5Ki'\n");
+}
+
 #[test]
 fn test_head_num_with_undocumented_sign_bytes() {
     // tail: '-' is not documented (8.32 man pages)

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -5328,3 +5328,25 @@ fn test_invalid_count_keeps_its_leading_zeros() {
         .fails_with_code(1)
         .stderr_is("tail: invalid number of bytes: '0fb'\n");
 }
+
+/// A `-` sign is dropped from the value an error reports, but a `+` is kept,
+/// as GNU does; `-n` and `-c` must agree, since they share the same parser.
+#[test]
+fn test_invalid_count_keeps_a_plus_sign_but_not_a_minus() {
+    new_ucmd!()
+        .args(&["-c", "+5Ki", "/dev/null"])
+        .fails_with_code(1)
+        .stderr_is("tail: invalid number of bytes: '+5Ki'\n");
+    new_ucmd!()
+        .args(&["-n", "+5Ki", "/dev/null"])
+        .fails_with_code(1)
+        .stderr_is("tail: invalid number of lines: '+5Ki'\n");
+    new_ucmd!()
+        .args(&["-c", "-5Ki", "/dev/null"])
+        .fails_with_code(1)
+        .stderr_is("tail: invalid number of bytes: '5Ki'\n");
+    new_ucmd!()
+        .args(&["-n", "-5Ki", "/dev/null"])
+        .fails_with_code(1)
+        .stderr_is("tail: invalid number of lines: '5Ki'\n");
+}


### PR DESCRIPTION
`head`/`tail`'s `-c`/`-n` share a parser (`parse_signed_num_max`) that always dropped the sign from the value an error names — matching GNU only for `-`, not for `+`:

```console
$ tail -c -5Ki f      # GNU and ours agree
tail: invalid number of bytes: '5Ki'

$ tail -c +5Ki f      # ours, before
tail: invalid number of bytes: '5Ki'
$ tail -c +5Ki f      # GNU 9.11
tail: invalid number of bytes: '+5Ki'
```

GNU's own rule, worked out by probing every sign/no-sign combination: a `-` is dropped from the reported value, a `+` is kept. `head` shows this identically for both `-c` and `-n`.

## What changed

- `parse_signed_num_max` (and its unused-but-public sibling `parse_signed_num`, which has the identical bug and the same doc comment already promising "the raw string") now report the original string when the sign is `+`, and the sign-stripped one otherwise.
- `tail`'s own `-n` branch in `args.rs` had a second, independent bug: it built its message from `arg.quote()` directly rather than from the error the parser already constructed, so it never went through the sign-handling above at all — unlike its `-c` sibling two lines above it, which already used the error. Both now use the error, matching `head`, which was already consistent between its two branches.

## How I found it

A differential sweep across head/tail size suffixes (`K`/`M`/`Ki`/`B`/etc., `+`/`-`/unsigned, `-c`/`-n`) run against the multiplier-suffix behavior from the most recently merged commit — this bug predates that commit and isn't related to it, the sweep just happened to be checking that area.

## Getting this right took two passes

My first attempt at a fix used the original string unconditionally, which passed the case above but failed three existing tests (`test_head_invalid_num`, `test_invalid_count_keeps_its_leading_zeros`, `test_tail_obsolete_error_cases`) — because GNU really does drop the sign for `-`, so those tests were already correct. Comparing GNU's exact output across `-abc`/`+abc`/`-5xyz`/`+5xyz`/etc. showed the sign-dependent split described above, which is what's implemented and what the new tests check for both signs together, so a future change can't silently swap back to unconditional.

## Not covered

Reproducing this exposed a separate, unrelated, pre-existing gap: `head -c "-³"` reports `'³'` where GNU reports the octal-escaped bytes `'\302\263'` — the same non-ASCII quoting difference already known from other utilities. Unchanged by this PR either way.

## Testing

- 351-case differential sweep against GNU 9.11 across `head`/`tail` × `-c`/`-n` × unsigned/`+`/`-` × 23 suffixes (valid and invalid) plus a handful of the exact edge cases from existing tests: 350 match, the 1 remaining mismatch is the pre-existing octal-escaping gap above (confirmed identical on `main`).
- New tests in both `test_head.rs` and `test_tail.rs` covering `+`/`-` on both `-c` and `-n`; the `test_tail.rs` one verified to fail without the `args.rs` fix.
- New unit test in `parse_signed_num.rs` for the sign-dependent behavior directly.
- `cargo test --features head,tail --test tests -- test_head test_tail`: **247 passed, 0 failed** (245 pre-existing, 2 new); `cargo test -p uucore --features parser-size`: 32 passed, 0 failed (1 new).
- `cargo fmt --check` and `cargo clippy -p uu_head -p uu_tail -p uucore --all-targets -- -D warnings`: clean.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. GNU's behaviour was established by running the installed GNU binary as a black box; I did not read GNU coreutils source. All testing was run locally.
