### PR TITLE
sort: match GNU's error for a bad --parallel value

### DIFF
--- a/src/uu/sort/locales/en-US.ftl
+++ b/src/uu/sort/locales/en-US.ftl
@@ -58,6 +58,7 @@ sort-invalid-suffix-in-option-arg = invalid suffix in --{$option} argument {$arg
 sort-invalid-option-arg = invalid --{$option} argument {$arg}
 sort-option-arg-too-large = --{$option} argument {$arg} too large
 sort-error-disorder = {$file}:{$line_number}: disorder: {$line}
+sort-error-parallel-nonzero = number in parallel must be nonzero
 sort-error-buffer-size-too-big = Buffer size {$size} does not fit in address space
 sort-error-no-match-for-key = ^ no match for key
 sort-error-write-failed = write failed: {$output}

--- a/src/uu/sort/locales/fr-FR.ftl
+++ b/src/uu/sort/locales/fr-FR.ftl
@@ -57,6 +57,7 @@ sort-invalid-suffix-in-option-arg = suffixe invalide dans l'argument --{$option}
 sort-invalid-option-arg = argument --{$option} invalide {$arg}
 sort-option-arg-too-large = argument --{$option} {$arg} trop grand
 sort-error-disorder = {$file}:{$line_number}: désordre : {$line}
+sort-error-parallel-nonzero = le nombre en parallèle doit être non nul
 sort-error-buffer-size-too-big = La taille du tampon {$size} ne rentre pas dans l'espace d'adressage
 sort-error-no-match-for-key = ^ aucune correspondance pour la clé
 sort-error-write-failed = échec d'écriture : {$output}

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2249,10 +2249,42 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // WASI doesn't support threads, so we ignore the corresponding option
     #[cfg(not(target_os = "wasi"))]
     {
-        let threads = matches
-            .get_one::<u64>(options::PARALLEL)
-            .copied()
-            .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, |n| n.get() as u64));
+        let threads = if let Some(threads_str) = matches.get_one::<String>(options::PARALLEL) {
+            // GNU accepts a suffix syntactically -- it goes through the same
+            // number-with-suffix parser as `-S` -- but none is ever valid for
+            // a thread count, so the allow list is empty rather than absent.
+            //
+            // `parse_u64` errors on overflow instead of clamping: GNU itself
+            // accepts an arbitrarily large count without erroring, but
+            // `rayon::ThreadPoolBuilder` builds its pool eagerly, so asking
+            // it for anywhere near that many threads hangs rather than
+            // completing quickly. That is a pre-existing limitation already
+            // reachable with an ordinary large-but-in-range count (10000
+            // already hangs); erroring here at least avoids making it
+            // reachable from *more* inputs than it already was.
+            let count = Parser::default()
+                .with_allow_list(&[])
+                .parse_u64(threads_str)
+                .map_err(|error| {
+                    let message = format_error_message(&error, threads_str, options::PARALLEL);
+                    error.size_value_error(
+                        key_args.as_deref(),
+                        &OptionValue::with_names(threads_str, None, Some(options::PARALLEL)),
+                        0,
+                        &message,
+                        USimpleError::new(2, message.clone()),
+                    )
+                })?;
+            if count == 0 {
+                return Err(USimpleError::new(
+                    2,
+                    translate!("sort-error-parallel-nonzero"),
+                ));
+            }
+            count
+        } else {
+            std::thread::available_parallelism().map_or(1, |n| n.get() as u64)
+        };
         let _ = rayon::ThreadPoolBuilder::new()
             .num_threads(threads as usize)
             .build_global();
@@ -2667,7 +2699,7 @@ pub fn uu_app() -> Command {
         Arg::new(options::PARALLEL)
             .long(options::PARALLEL)
             .help(translate!("sort-help-parallel"))
-            .value_parser(clap::value_parser!(u64).range(1..))
+            .allow_hyphen_values(true)
             .value_name("NUM_THREADS"),
     )
     .arg(

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -197,9 +197,34 @@ fn test_version_empty_lines() {
 
 #[test]
 fn test_parallel_invalid() {
-    // clap provided stderr
-    new_ucmd!().arg("--parallel=0").fails().code_is(2);
-    new_ucmd!().arg("--parallel=NaN").fails().code_is(2);
+    new_ucmd!()
+        .arg("--parallel=0")
+        .fails_with_code(2)
+        .stderr_only("sort: number in parallel must be nonzero\n");
+    new_ucmd!()
+        .arg("--parallel=NaN")
+        .fails_with_code(2)
+        .stderr_only("sort: invalid --parallel argument 'NaN'\n");
+    new_ucmd!()
+        .arg("--parallel=-1")
+        .fails_with_code(2)
+        .stderr_only("sort: invalid --parallel argument '-1'\n");
+    new_ucmd!()
+        .arg("--parallel=")
+        .fails_with_code(2)
+        .stderr_only("sort: invalid --parallel argument ''\n");
+    // No unit is ever valid for a thread count, unlike `-S`/`--buffer-size`,
+    // which this shares its parser with.
+    new_ucmd!()
+        .arg("--parallel=2K")
+        .fails_with_code(2)
+        .stderr_only("sort: invalid suffix in --parallel argument '2K'\n");
+    // A separate (not `=`-attached) value starting with `-` is still this
+    // option's value, not a new flag -- as GNU accepts it.
+    new_ucmd!()
+        .args(&["--parallel", "-1"])
+        .fails_with_code(2)
+        .stderr_only("sort: invalid --parallel argument '-1'\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13016 (message wording; the underlying accept-anything bug that issue reported was already fixed in #13024, but the replacement clap-based validation still doesn't say what GNU says).

`--parallel` used clap's built-in ranged `u64` parser, so a bad value got clap's wording instead of GNU's own:

```console
$ sort --parallel=0 f       # ours, before
error: invalid value '0' for '--parallel <NUM_THREADS>': 0 is not in 1..18446744073709551615
$ sort --parallel=0 f       # GNU 9.11
sort: number in parallel must be nonzero

$ sort --parallel=-1 f      # ours, before
error: invalid value '-1' for '--parallel <NUM_THREADS>': invalid digit found in string
$ sort --parallel=-1 f      # GNU
sort: invalid --parallel argument '-1'
```

`--parallel` shares the same number-with-suffix parser `-S`/`--buffer-size` already uses via `format_error_message`, so this reuses that rather than inventing new wording. GNU syntactically accepts a suffix here too (`--parallel=2K` → `invalid suffix in --parallel argument '2K'`, not a plain "invalid argument"), but no suffix is ever semantically valid for a thread count, so the allow list passed to the parser is empty rather than the list `-S` uses.

A value starting with `-` is still accepted as this option's *value*, not a new flag — `sort --parallel -1` — matching GNU. That needed `allow_hyphen_values`, which the old `value_parser!(u64).range(1..)` never had, so `--parallel -1` (space-separated, as opposed to `--parallel=-1`) was already broken before this change; I confirmed that specific breakage on `main` and it isn't something I introduced.

## Deliberately not covered

- GNU accepts an arbitrarily large `--parallel` value without erroring, and apparently does not try to spawn that many OS threads for it. uutils' `rayon::ThreadPoolBuilder` builds its pool eagerly, so asking for anywhere near that many threads hangs rather than completing — a pre-existing limitation already reachable today with an ordinary in-range count (`sort --parallel 10000 f` already hangs on current `main`, confirmed before this PR). Clamping an overflowing value the way `head`/`tail`/`numfmt` do elsewhere in this project would make that hang reachable from an even wider set of inputs (including ordinary overflow past `u64::MAX`), so this keeps the existing behavior of erroring on overflow instead, just with a clearer message. Fixing the hang itself means teaching the thread pool that `--parallel` is a soft upper bound rather than a literal count to build eagerly for, which felt like a distinct problem from an error-message mismatch.
- `-S`/`--buffer-size` has an existing comment in `sort.rs` acknowledging that GNU echoes back whichever spelling was actually typed (`-S` vs `--buffer-size`), and that this isn't implemented — the message always says `--buffer-size` regardless. `--parallel` has no short form, so it doesn't need that distinction, but `-S` still does; not touched here.

## Testing

- Differential sweep against GNU 9.11 covering `--parallel=X` and `--parallel X` (space and `=` forms) for `0`, negative, non-numeric, empty, a suffix, and in-range valid values: 20/21 match; the one that doesn't (an overflowing value) is the deliberate scope boundary above, confirmed GNU itself doesn't error there while uutils does (by design, to avoid the hang).
- Strengthened the existing `test_parallel_invalid` from a bare exit-code check to exact GNU-matching messages, plus new cases for negative, empty, a suffix, and the space-separated negative form; verified to fail without the fix.
- `cargo test --features sort --test tests -- test_sort`: **211 passed, 0 failed** (210 pre-existing — 1 strengthened, not deleted).
- `moz-fluent-lint` on `src/uu/sort/locales`: no errors.
- `cargo fmt --check` and `cargo clippy -p uu_sort --all-targets -- -D warnings`: clean.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy in CONTRIBUTING.md. GNU's behaviour was established by running the installed GNU binary as a black box; I did not read GNU coreutils source. All testing was run locally.
