### PR TITLE
date: match GNU's error for a bad --iso-8601 or --rfc-3339 value

### DIFF
--- a/src/uu/date/locales/en-US.ftl
+++ b/src/uu/date/locales/en-US.ftl
@@ -110,3 +110,11 @@ date-error-format-modifier-width-too-large = format modifier width '{$width}' is
 date-error-format-missing-plus = the argument {$arg} lacks a leading '+';
   when using an option to specify date(s), any non-option
   argument must be a format string beginning with '+'
+date-error-invalid-choice = invalid argument '{$arg}' for '--{$option}'
+  Valid arguments are:
+  {$choices}
+  Try 'date --help' for more information.
+date-error-ambiguous-choice = ambiguous argument '{$arg}' for '--{$option}'
+  Valid arguments are:
+  {$choices}
+  Try 'date --help' for more information.

--- a/src/uu/date/locales/fr-FR.ftl
+++ b/src/uu/date/locales/fr-FR.ftl
@@ -105,3 +105,11 @@ date-error-format-modifier-width-too-large = la largeur du modificateur de forma
 date-error-format-missing-plus = l'argument {$arg} ne commence pas par un signe '+';
  lorsqu'une option est utilisée pour spécifier une ou plusieurs dates, tout argument autre
   qu'une option doit être une chaîne de format commençant par un signe '+'.
+date-error-invalid-choice = argument '{$arg}' invalide pour '--{$option}'
+  Arguments valides :
+  {$choices}
+  Essayez 'date --help' pour plus d'informations.
+date-error-ambiguous-choice = argument '{$arg}' ambigu pour '--{$option}'
+  Arguments valides :
+  {$choices}
+  Essayez 'date --help' pour plus d'informations.

--- a/src/uu/date/src/date.rs
+++ b/src/uu/date/src/date.rs
@@ -30,8 +30,6 @@ use uucore::{format_usage, show};
 #[cfg(windows)]
 use windows_sys::Win32::{Foundation::SYSTEMTIME, System::SystemInformation::SetSystemTime};
 
-use uucore::parser::shortcut_value_parser::ShortcutValueParser;
-
 // Options
 const DATE: &str = "date";
 const HOURS: &str = "hours";
@@ -125,7 +123,7 @@ impl From<&str> for Iso8601Format {
             SECONDS => Self::Seconds,
             NS => Self::Ns,
             DATE => Self::Date,
-            // Note: This is caught by clap via `possible_values`
+            // Note: only reached with a name `resolve_choice` already validated.
             _ => unreachable!(),
         }
     }
@@ -143,9 +141,42 @@ impl From<&str> for Rfc3339Format {
             DATE => Self::Date,
             SECONDS => Self::Seconds,
             NS => Self::Ns,
-            // Should be caught by clap
-            _ => panic!("Invalid format: {s}"),
+            // Note: only reached with a name `resolve_choice` already validated.
+            _ => unreachable!(),
         }
+    }
+}
+
+/// The choices `--iso-8601`'s value accepts, in the order GNU lists them.
+const ISO_8601_CHOICES: &[&str] = &[HOURS, MINUTES, DATE, SECONDS, NS];
+
+/// The choices `--rfc-3339`'s value accepts, in the order GNU lists them.
+const RFC_3339_CHOICES: &[&str] = &[DATE, SECONDS, NS];
+
+/// The choice `value` names among `choices`, accepting any unambiguous
+/// abbreviation the way GNU does. `option` is the long name to report the
+/// error against if it names none, or more than one.
+fn resolve_choice<'a>(value: &str, option: &'static str, choices: &[&'a str]) -> UResult<&'a str> {
+    let list = || {
+        choices
+            .iter()
+            .map(|name| format!("  - '{name}'"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let mut named = choices.iter().filter(|name| name.starts_with(value));
+    match (named.next(), named.next()) {
+        // No choice abbreviates another, so a single match is the answer
+        // whether or not it is the whole word.
+        (Some(name), None) if !value.is_empty() => Ok(*name),
+        (Some(_), Some(_)) => Err(USimpleError::new(
+            1,
+            translate!("date-error-ambiguous-choice", "arg" => value.to_string(), "option" => option, "choices" => list()),
+        )),
+        _ => Err(USimpleError::new(
+            1,
+            translate!("date-error-invalid-choice", "arg" => value.to_string(), "option" => option, "choices" => list()),
+        )),
     }
 }
 
@@ -348,16 +379,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         Format::Custom(fmt)
     } else if let Some(fmt) = matches
         .get_many::<String>(OPT_ISO_8601)
-        .map(|mut iter| iter.next().unwrap_or(&DATE.to_string()).as_str().into())
+        .map(|mut iter| iter.next().map_or(DATE, String::as_str))
     {
-        Format::Iso8601(fmt)
+        Format::Iso8601(resolve_choice(fmt, OPT_ISO_8601, ISO_8601_CHOICES)?.into())
     } else if matches.get_flag(OPT_RFC_EMAIL) {
         Format::Rfc5322
-    } else if let Some(fmt) = matches
-        .get_one::<String>(OPT_RFC_3339)
-        .map(|s| s.as_str().into())
-    {
-        Format::Rfc3339(fmt)
+    } else if let Some(fmt) = matches.get_one::<String>(OPT_RFC_3339) {
+        Format::Rfc3339(resolve_choice(fmt, OPT_RFC_3339, RFC_3339_CHOICES)?.into())
     } else if matches.get_flag(OPT_RESOLUTION) {
         Format::Resolution
     } else {
@@ -657,9 +685,6 @@ pub fn uu_app() -> Command {
                 .short('I')
                 .long(OPT_ISO_8601)
                 .value_name("FMT")
-                .value_parser(ShortcutValueParser::new([
-                    DATE, HOURS, MINUTES, SECONDS, NS,
-                ]))
                 .num_args(0..=1)
                 .default_missing_value(OPT_DATE)
                 .help(translate!("date-help-iso-8601")),
@@ -686,7 +711,6 @@ pub fn uu_app() -> Command {
             Arg::new(OPT_RFC_3339)
                 .long(OPT_RFC_3339)
                 .value_name("FMT")
-                .value_parser(ShortcutValueParser::new([DATE, SECONDS, NS]))
                 .help(translate!("date-help-rfc-3339")),
         )
         .arg(

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -249,6 +249,55 @@ fn test_date_rfc_3339_invalid_arg() {
 }
 
 #[test]
+fn test_date_iso_8601_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--iso-8601=foo")
+        .fails()
+        .stderr_is(concat!(
+            "date: invalid argument 'foo' for '--iso-8601'\n",
+            "Valid arguments are:\n",
+            "  - 'hours'\n",
+            "  - 'minutes'\n",
+            "  - 'date'\n",
+            "  - 'seconds'\n",
+            "  - 'ns'\n",
+            "Try 'date --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_date_iso_8601_ambiguous_arg_message() {
+    new_ucmd!()
+        .arg("--iso-8601=")
+        .fails()
+        .stderr_is(concat!(
+            "date: ambiguous argument '' for '--iso-8601'\n",
+            "Valid arguments are:\n",
+            "  - 'hours'\n",
+            "  - 'minutes'\n",
+            "  - 'date'\n",
+            "  - 'seconds'\n",
+            "  - 'ns'\n",
+            "Try 'date --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_date_rfc_3339_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--rfc-3339=foo")
+        .fails()
+        .stderr_is(concat!(
+            "date: invalid argument 'foo' for '--rfc-3339'\n",
+            "Valid arguments are:\n",
+            "  - 'date'\n",
+            "  - 'seconds'\n",
+            "  - 'ns'\n",
+            "Try 'date --help' for more information.\n",
+        ));
+}
+
+#[test]
 fn test_date_rfc_8601_default() {
     let re = Regex::new(r"^\d{4}-\d{2}-\d{2}\n$").unwrap();
     for param in ["--iso-8601", "--i"] {


### PR DESCRIPTION
## What

`--iso-8601` and `--rfc-3339` validate their value with a plain
`ShortcutValueParser`, so an unrecognized or ambiguous value produces
clap's own generic wording instead of GNU's.

```
$ date --iso-8601=bogus

# GNU
date: invalid argument 'bogus' for '--iso-8601'
Valid arguments are:
  - 'hours'
  - 'minutes'
  - 'date'
  - 'seconds'
  - 'ns'
Try 'date --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--iso-8601 [<FMT>]'

  [possible values: date, hours, minutes, seconds, ns]

For more information, try '--help'.
```

## Fix

Resolve the value against each option's own choice list by hand
(matching GNU's per-option order), accepting any unambiguous
abbreviation the way GNU does, and report GNU's wording -- including
its distinct "ambiguous argument" message when the value could name
more than one choice -- when it does not resolve. Same fix already
shipped for `wc --total`, `sort --parallel`, and `uniq
--group`/`--all-repeated` (#14293, #14303, #14304).

Note: `date --rfc-3339` with *no* value supplied at all (not even an
empty string) still gets clap's own "a value is required for ... but
none was supplied" message rather than GNU's "option '--rfc-3339'
requires an argument". That's a separate, shared-infrastructure
mismatch in `clap_localization.rs`'s handling of `ErrorKind::InvalidValue`
that affects other utilities too, not something specific to this
option -- left out of this PR to keep it focused.

## Testing

- `cargo test -p uu_date` / full `tests/by-util/test_date.rs` suite: 154 passed, 0 failed.
- Added 3 regression tests asserting the exact GNU wording for an invalid `--iso-8601` value, an ambiguous `--iso-8601` value, and an invalid `--rfc-3339` value.
- Manually diffed every `--iso-8601`/`--rfc-3339` value (valid, invalid, ambiguous prefix, empty) against GNU date 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_date --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*