### PR TITLE
du: match GNU's error for a bad --time value, fix --time-style's help hint

### DIFF
--- a/src/uu/du/locales/en-US.ftl
+++ b/src/uu/du/locales/en-US.ftl
@@ -50,12 +50,20 @@ du-error-invalid-max-depth = invalid maximum depth { $depth }
 du-error-summarize-depth-conflict = summarizing conflicts with --max-depth={ $depth }
 du-error-invalid-time-style = invalid argument { $style } for 'time style'
   Valid arguments are:
-    - 'full-iso'
-    - 'long-iso'
-    - 'iso'
+    - full-iso
+    - long-iso
+    - iso
     - +FORMAT (e.g., +%H:%M) for a 'date'-style format
-  Try '{ $help }' for more information.
+  Try '{ $help } --help' for more information.
 du-error-invalid-time-arg = 'birth' and 'creation' arguments for --time are not supported on this platform.
+du-error-invalid-time-choice = invalid argument '{ $arg }' for '--time'
+  Valid arguments are:
+  { $choices }
+  Try 'du --help' for more information.
+du-error-ambiguous-time-choice = ambiguous argument '{ $arg }' for '--time'
+  Valid arguments are:
+  { $choices }
+  Try 'du --help' for more information.
 du-error-invalid-glob = Invalid exclude syntax: { $error }
 du-error-cannot-read-directory = cannot read directory { $path }
 du-error-cannot-access = cannot access { $path }

--- a/src/uu/du/locales/fr-FR.ftl
+++ b/src/uu/du/locales/fr-FR.ftl
@@ -50,12 +50,20 @@ du-error-invalid-max-depth = profondeur maximale invalide { $depth }
 du-error-summarize-depth-conflict = la synthèse entre en conflit avec --max-depth={ $depth }
 du-error-invalid-time-style = argument invalide { $style } pour 'style de temps'
   Les arguments valides sont :
-    - 'full-iso'
-    - 'long-iso'
-    - 'iso'
+    - full-iso
+    - long-iso
+    - iso
     - +FORMAT (e.g., +%H:%M) pour un format de type 'date'
-  Essayez '{ $help }' pour plus d'informations.
+  Essayez '{ $help } --help' pour plus d'informations.
 du-error-invalid-time-arg = les arguments 'birth' et 'creation' pour --time ne sont pas pris en charge sur cette plateforme.
+du-error-invalid-time-choice = argument '{ $arg }' invalide pour '--time'
+  Les arguments valides sont :
+  { $choices }
+  Essayez 'du --help' pour plus d'informations.
+du-error-ambiguous-time-choice = argument '{ $arg }' ambigu pour '--time'
+  Les arguments valides sont :
+  { $choices }
+  Essayez 'du --help' pour plus d'informations.
 du-error-invalid-glob = Syntaxe d'exclusion invalide : { $error }
 du-error-cannot-read-directory = impossible de lire le répertoire { $path }
 du-error-cannot-access = impossible d'accéder à { $path }

--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -5,7 +5,7 @@
 //
 // spell-checker:ignore fstatat openat dirfd
 
-use clap::{Arg, ArgAction, ArgMatches, Command, builder::PossibleValue};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use glob::{Pattern, PatternError};
 use rustc_hash::FxHashSet as HashSet;
 use std::env;
@@ -35,7 +35,6 @@ use uucore::translate;
 use uucore::parser::parse_block_size;
 use uucore::parser::parse_glob;
 use uucore::parser::parse_size::{ParseSizeError, parse_size_u64};
-use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::time::{FormatSystemTimeFallback, format, format_system_time};
 use uucore::{format_usage, show, show_error, show_warning};
 #[cfg(windows)]
@@ -1095,11 +1094,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         vec![PathBuf::from(".")]
     };
 
-    let time = matches.contains_id(options::TIME).then(|| {
-        matches
-            .get_one::<String>(options::TIME)
-            .map_or(MetadataTimeField::Modification, |s| s.as_str().into())
-    });
+    let time = matches
+        .contains_id(options::TIME)
+        .then(|| match matches.get_one::<String>(options::TIME) {
+            Some(s) => resolve_time_choice(s).map(Into::into),
+            None => Ok(MetadataTimeField::Modification),
+        })
+        .transpose()?;
 
     let size_format = parse_size_format(&matches, diag_args.as_deref())?;
 
@@ -1274,6 +1275,63 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map_err(|_| USimpleError::new(1, translate!("du-error-printing-thread-panicked")))??;
 
     Ok(())
+}
+
+/// The choices `--time`'s value accepts. GNU groups each choice's aliases
+/// on a single line in its error message; `creation`/`birth` is this
+/// implementation's own extension, listed last since GNU's `--time` does
+/// not support it at all.
+const TIME_CHOICE_GROUPS: &[&[&str]] = &[
+    &["atime", "access", "use"],
+    &["ctime", "status"],
+    &["creation", "birth"],
+];
+
+/// The name `value` names among `TIME_CHOICE_GROUPS`, accepting any
+/// unambiguous abbreviation the way GNU does (including one that is
+/// ambiguous between aliases of the *same* choice).
+fn resolve_time_choice(value: &str) -> UResult<&'static str> {
+    let list = || {
+        TIME_CHOICE_GROUPS
+            .iter()
+            .map(|group| {
+                format!(
+                    "  - {}",
+                    group
+                        .iter()
+                        .map(|name| format!("'{name}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let matches: Vec<(usize, &'static str)> = TIME_CHOICE_GROUPS
+        .iter()
+        .enumerate()
+        .flat_map(|(i, group)| group.iter().map(move |name| (i, *name)))
+        .filter(|(_, name)| name.starts_with(value))
+        .collect();
+
+    if !value.is_empty()
+        && let Some(&(_, exact)) = matches.iter().find(|(_, name)| *name == value)
+    {
+        return Ok(exact);
+    }
+    match matches.first() {
+        Some(&(group, name)) if !value.is_empty() && matches.iter().all(|(g, _)| *g == group) => {
+            Ok(name)
+        }
+        Some(_) => Err(USimpleError::new(
+            1,
+            translate!("du-error-ambiguous-time-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+        None => Err(USimpleError::new(
+            1,
+            translate!("du-error-invalid-time-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+    }
 }
 
 // Parse --time-style argument, falling back to environment variable if necessary.
@@ -1540,11 +1598,6 @@ pub fn uu_app() -> Command {
                 .value_name("WORD")
                 .require_equals(true)
                 .num_args(0..)
-                .value_parser(ShortcutValueParser::new([
-                    PossibleValue::new("atime").alias("access").alias("use"),
-                    PossibleValue::new("ctime").alias("status"),
-                    PossibleValue::new("creation").alias("birth"),
-                ]))
                 .help(translate!("du-help-time"))
                 .overrides_with(options::TIME),
         )

--- a/tests/by-util/test_du.rs
+++ b/tests/by-util/test_du.rs
@@ -1137,6 +1137,40 @@ fn test_du_time() {
     }
 }
 
+#[test]
+fn test_du_time_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--time=bogus")
+        .arg(".")
+        .fails()
+        .stderr_is(concat!(
+            "du: invalid argument 'bogus' for '--time'\n",
+            "Valid arguments are:\n",
+            "  - 'atime', 'access', 'use'\n",
+            "  - 'ctime', 'status'\n",
+            "  - 'creation', 'birth'\n",
+            "Try 'du --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_du_time_ambiguous_arg_message() {
+    // 'c' is ambiguous between 'ctime' and this implementation's own
+    // 'creation' extension, which GNU's --time does not accept at all.
+    new_ucmd!()
+        .arg("--time=c")
+        .arg(".")
+        .fails()
+        .stderr_is(concat!(
+            "du: ambiguous argument 'c' for '--time'\n",
+            "Valid arguments are:\n",
+            "  - 'atime', 'access', 'use'\n",
+            "  - 'ctime', 'status'\n",
+            "  - 'creation', 'birth'\n",
+            "Try 'du --help' for more information.\n",
+        ));
+}
+
 #[cfg(feature = "touch")]
 fn birth_supported() -> bool {
     let ts = TestScenario::new(util_name!());
@@ -2001,6 +2035,26 @@ fn test_invalid_time_style() {
         .arg("--time-style=banana")
         .succeeds()
         .stdout_does_not_contain("du: invalid argument 'banana' for 'time style'");
+}
+
+#[test]
+fn test_invalid_time_style_with_time_message() {
+    let result = new_ucmd!()
+        .arg("--time")
+        .arg("--time-style=banana")
+        .arg(".")
+        .fails();
+    result.stderr_contains(concat!(
+        "du: invalid argument 'banana' for 'time style'\n",
+        "Valid arguments are:\n",
+        "  - full-iso\n",
+        "  - long-iso\n",
+        "  - iso\n",
+        "  - +FORMAT (e.g., +%H:%M) for a 'date'-style format\n",
+    ));
+    // The binary path `execution_phrase()` reports varies by how the test is
+    // invoked; only the "du --help" suffix is stable.
+    result.stderr_contains("du --help' for more information.\n");
 }
 
 #[test]


### PR DESCRIPTION
## What

`--time` validates its value with a plain `ShortcutValueParser`, so an
unrecognized or ambiguous value produces clap's own generic wording
instead of GNU's grouped-alias wording:

```
$ du --time=bogus /tmp

# GNU
du: invalid argument 'bogus' for '--time'
Valid arguments are:
  - 'atime', 'access', 'use'
  - 'ctime', 'status'
Try 'du --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--time[=<WORD>...]'

  [possible values: atime, ctime, creation]

For more information, try '--help'.
```

## Fix

Resolve the value against the option's own alias groups by hand,
accepting any unambiguous abbreviation the way GNU does -- including
one that's ambiguous only between aliases of the *same* choice (e.g.
`--time=a` unambiguously means `atime`/`access`/`use`) -- and report
GNU's wording, extended with one more group for this implementation's
own `creation`/`birth` choice, which GNU's `--time` does not support
at all. Since that's a real extra choice this implementation accepts,
`--time=c` is genuinely ambiguous here (between `ctime` and
`creation`) even though it isn't in GNU.

Same fix already shipped for `wc --total`, `date --iso-8601`/`--rfc-3339`,
`sort --parallel`, and `uniq --group`/`--all-repeated` (#14293, #14303,
#14304, #14305).

## Also fixed

An unrelated but adjacent bug in the same error family: `--time-style`'s
own invalid-argument message already had GNU's wording, but its "Try
... for more information" hint used `uucore::execution_phrase()` (just
the invoked binary, e.g. `target/debug/du`) without appending
`--help`, and quoted `full-iso`/`long-iso`/`iso` where GNU does not:

```
# GNU
du: invalid argument 'bogus' for 'time style'
Valid arguments are:
  - full-iso
  - long-iso
  - iso
  - +FORMAT (e.g., +%H:%M) for a 'date'-style format
Try 'du --help' for more information.

# uutils, before this PR
du: invalid argument 'bogus' for 'time style'
Valid arguments are:
  - 'full-iso'
  - 'long-iso'
  - 'iso'
  - +FORMAT (e.g., +%H:%M) for a 'date'-style format
Try 'target/debug/du' for more information.
```

## Testing

- `cargo test -p uu_du` / full `tests/by-util/test_du.rs` suite: 122 passed, 0 failed.
- Added 3 regression tests: an invalid `--time` value, an ambiguous one (`c`), and the fixed `--time-style` hint.
- Manually diffed every `--time` value (all real GNU choices/aliases, `creation`/`birth`, invalid, ambiguous, empty) against GNU du 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_du --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*