### PR TITLE
shred: match GNU's error for a bad --remove value

### DIFF
--- a/src/uu/shred/locales/en-US.ftl
+++ b/src/uu/shred/locales/en-US.ftl
@@ -45,6 +45,14 @@ shred-no-such-file-or-directory = {$file}: No such file or directory
 shred-failed-to-open-for-writing-not-a-directory = {$file}: failed to open for writing: Not a directory
 shred-failed-to-open-for-writing-is-a-directory = {$file}: failed to open for writing: Is a directory
 shred-not-a-file = {$file}: Not a file
+shred-invalid-remove-choice = invalid argument '{$arg}' for '--remove'
+  Valid arguments are:
+  {$choices}
+  Try 'shred --help' for more information.
+shred-ambiguous-remove-choice = ambiguous argument '{$arg}' for '--remove'
+  Valid arguments are:
+  {$choices}
+  Try 'shred --help' for more information.
 
 # Option help text
 shred-force-help = change permissions to allow writing if necessary

--- a/src/uu/shred/locales/fr-FR.ftl
+++ b/src/uu/shred/locales/fr-FR.ftl
@@ -44,6 +44,14 @@ shred-no-such-file-or-directory = {$file} : Aucun fichier ou répertoire de ce t
 shred-failed-to-open-for-writing-not-a-directory = {$file} : impossible d'ouvrir en écriture : N'est pas un répertoire
 shred-failed-to-open-for-writing-is-a-directory = {$file} : impossible d'ouvrir en écriture : Est un répertoire
 shred-not-a-file = {$file} : N'est pas un fichier
+shred-invalid-remove-choice = argument '{$arg}' invalide pour '--remove'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'shred --help' pour plus d'informations.
+shred-ambiguous-remove-choice = argument '{$arg}' ambigu pour '--remove'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'shred --help' pour plus d'informations.
 
 # Texte d'aide des options
 shred-force-help = modifier les permissions pour permettre l'écriture si nécessaire

--- a/src/uu/shred/src/shred.rs
+++ b/src/uu/shred/src/shred.rs
@@ -20,7 +20,6 @@ use uucore::diagnostics::OptionValue;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::parser::parse_size::parse_size_u64;
-use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::translate;
 use uucore::{format_usage, show_error, show_if_err};
 
@@ -102,6 +101,42 @@ enum RemoveMethod {
     Unlink,   // The same as 'None' + unlink the file
     Wipe,     // The same as 'Unlink' + obfuscate the file name before unlink
     WipeSync, // The same as 'Wipe' sync the file name changes
+}
+
+/// The choices `--remove`'s value accepts, in the order GNU lists them.
+const REMOVE_CHOICES: &[&str] = &[
+    options::remove::UNLINK,
+    options::remove::WIPE,
+    options::remove::WIPESYNC,
+];
+
+/// The choice `value` names among `REMOVE_CHOICES`, accepting any
+/// unambiguous abbreviation the way GNU does.
+fn resolve_remove_choice(value: &str) -> UResult<&'static str> {
+    let list = || {
+        REMOVE_CHOICES
+            .iter()
+            .map(|name| format!("  - '{name}'"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    if !value.is_empty()
+        && let Some(&exact) = REMOVE_CHOICES.iter().find(|name| **name == value)
+    {
+        return Ok(exact);
+    }
+    let mut named = REMOVE_CHOICES.iter().filter(|name| name.starts_with(value));
+    match (named.next(), named.next()) {
+        (Some(name), None) if !value.is_empty() => Ok(*name),
+        (Some(_), Some(_)) => Err(USimpleError::new(
+            1,
+            translate!("shred-ambiguous-remove-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+        _ => Err(USimpleError::new(
+            1,
+            translate!("shred-invalid-remove-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+    }
 }
 
 /// Iterates over all possible filenames of a certain length using [`NAME_CHARSET`] as an alphabet
@@ -253,6 +288,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         1,
     )?;
 
+    // GNU validates an option's own value (e.g. a bad --remove argument)
+    // during option parsing, before it ever looks at the operands, so this
+    // must run before the missing-file-operand check below.
+    let remove_method = if matches.get_flag(options::WIPESYNC) {
+        RemoveMethod::WipeSync
+    } else if let Some(value) = matches.get_one::<String>(options::REMOVE) {
+        match resolve_remove_choice(value)? {
+            options::remove::UNLINK => RemoveMethod::Unlink,
+            options::remove::WIPE => RemoveMethod::Wipe,
+            options::remove::WIPESYNC => RemoveMethod::WipeSync,
+            _ => unreachable!("resolve_remove_choice only returns a valid choice"),
+        }
+    } else {
+        RemoveMethod::None
+    };
+
     if !matches.contains_id(options::FILE) {
         return Err(UUsageError::new(
             1,
@@ -275,22 +326,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             File::open(filepath).map_err_context(|| filepath.clone())?,
         )),
         None => None,
-    };
-
-    let remove_method = if matches.get_flag(options::WIPESYNC) {
-        RemoveMethod::WipeSync
-    } else if matches.contains_id(options::REMOVE) {
-        match matches
-            .get_one::<String>(options::REMOVE)
-            .map(AsRef::as_ref)
-        {
-            Some(options::remove::UNLINK) => RemoveMethod::Unlink,
-            Some(options::remove::WIPE) => RemoveMethod::Wipe,
-            Some(options::remove::WIPESYNC) => RemoveMethod::WipeSync,
-            _ => unreachable!("should be caught by clap"),
-        }
-    } else {
-        RemoveMethod::None
     };
 
     let force = matches.get_flag(options::FORCE);
@@ -358,11 +393,6 @@ pub fn uu_app() -> Command {
             Arg::new(options::REMOVE)
                 .long(options::REMOVE)
                 .value_name("HOW")
-                .value_parser(ShortcutValueParser::new([
-                    options::remove::UNLINK,
-                    options::remove::WIPE,
-                    options::remove::WIPESYNC,
-                ]))
                 .num_args(0..=1)
                 .require_equals(true)
                 .default_missing_value(options::remove::WIPESYNC)

--- a/tests/by-util/test_shred.rs
+++ b/tests/by-util/test_shred.rs
@@ -23,12 +23,32 @@ fn test_invalid_arg() {
 
 #[test]
 fn test_invalid_remove_arg() {
-    new_ucmd!().arg("--remove=unknown").fails_with_code(1);
+    new_ucmd!()
+        .arg("--remove=unknown")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "shred: invalid argument 'unknown' for '--remove'\n",
+            "Valid arguments are:\n",
+            "  - 'unlink'\n",
+            "  - 'wipe'\n",
+            "  - 'wipesync'\n",
+            "Try 'shred --help' for more information.\n",
+        ));
 }
 
 #[test]
 fn test_ambiguous_remove_arg() {
-    new_ucmd!().arg("--remove=wip").fails_with_code(1);
+    new_ucmd!()
+        .arg("--remove=wip")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "shred: ambiguous argument 'wip' for '--remove'\n",
+            "Valid arguments are:\n",
+            "  - 'unlink'\n",
+            "  - 'wipe'\n",
+            "  - 'wipesync'\n",
+            "Try 'shred --help' for more information.\n",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## What

`--remove` validates its value with a plain `ShortcutValueParser`, so
an unrecognized or ambiguous value produces clap's own generic
wording instead of GNU's:

```
$ shred --remove=bogus f

# GNU
shred: invalid argument 'bogus' for '--remove'
Valid arguments are:
  - 'unlink'
  - 'wipe'
  - 'wipesync'
Try 'shred --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--remove[=<HOW>]'

  [possible values: unlink, wipe, wipesync]

For more information, try '--help'.
```

## Fix

Resolve the value against the option's own choice list by hand,
accepting any unambiguous abbreviation the way GNU does. Two things
this needed that the other utilities in this same series (#14293,
#14303, #14304, #14305, #14306) didn't:

- Check for an **exact match first**, since one choice (`wipe`) is
  itself a prefix of another (`wipesync`) -- without that check,
  `--remove=wipe` would wrongly report itself as ambiguous between the
  two. (Caught by this repo's own existing `test_shred_remove_wipe`
  test, which was already asserting the correct, non-ambiguous
  behavior.)
- Move the resolution **above** the missing-file-operand check: GNU
  validates an option's own value during option parsing, before it
  ever looks at operands, so `shred --remove=wip` (no file at all)
  reports the ambiguous argument, not a missing operand. Doing the
  validation later, in `uumain`'s own logic, had silently changed that
  ordering.

## Testing

- `cargo test -p uu_shred` / full `tests/by-util/test_shred.rs` suite: 29 passed, 0 failed.
- Strengthened the existing `test_invalid_remove_arg`/`test_ambiguous_remove_arg` tests to assert the exact GNU wording instead of just the exit code.
- Manually diffed every `--remove` value (all real choices/abbreviations, invalid, ambiguous, empty, and the no-file-operand ordering case) against GNU shred 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_shred --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*