### PR TITLE
tee: match GNU's error for a bad --output-error value

### DIFF
--- a/src/uu/tee/locales/en-US.ftl
+++ b/src/uu/tee/locales/en-US.ftl
@@ -15,6 +15,14 @@ tee-help-output-error-exit-nopipe = exit on write errors to any output that are 
 
 # Error messages
 tee-error-stdin = read error: { $error }
+tee-error-invalid-output-error-choice = invalid argument '{ $arg }' for '--output-error'
+  Valid arguments are:
+  { $choices }
+  Try 'tee --help' for more information.
+tee-error-ambiguous-output-error-choice = ambiguous argument '{ $arg }' for '--output-error'
+  Valid arguments are:
+  { $choices }
+  Try 'tee --help' for more information.
 
 # Other messages
 tee-standard-output = 'standard output'

--- a/src/uu/tee/locales/fr-FR.ftl
+++ b/src/uu/tee/locales/fr-FR.ftl
@@ -15,6 +15,14 @@ tee-help-output-error-exit-nopipe = quitter en cas d'erreurs d'écriture vers to
 
 # Messages d'erreur
 tee-error-stdin = erreur de lecture: { $error }
+tee-error-invalid-output-error-choice = argument '{ $arg }' invalide pour '--output-error'
+  Les arguments valides sont :
+  { $choices }
+  Essayez 'tee --help' pour plus d'informations.
+tee-error-ambiguous-output-error-choice = argument '{ $arg }' ambigu pour '--output-error'
+  Les arguments valides sont :
+  { $choices }
+  Essayez 'tee --help' pour plus d'informations.
 
 # Autres messages
 tee-standard-output = 'sortie standard'

--- a/src/uu/tee/src/tee.rs
+++ b/src/uu/tee/src/tee.rs
@@ -10,7 +10,7 @@ use std::fs::OpenOptions;
 use std::io::{self, Error, ErrorKind, Write};
 use std::path::PathBuf;
 use uucore::display::Quotable;
-use uucore::error::{UResult, strip_errno};
+use uucore::error::{UResult, USimpleError, strip_errno};
 use uucore::{show_error, translate};
 
 mod cli;
@@ -22,9 +22,72 @@ use uucore::signals::ensure_stdout_not_broken;
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use uucore::signals::{disable_pipe_errors, ignore_interrupts};
 
+/// The choices `--output-error`'s value accepts, in the order GNU lists them.
+const OUTPUT_ERROR_CHOICES: &[&str] = &["warn", "warn-nopipe", "exit", "exit-nopipe"];
+
+/// The choice `value` names among `OUTPUT_ERROR_CHOICES`, accepting any
+/// unambiguous abbreviation the way GNU does. Checks for an exact match
+/// first since e.g. 'warn' is itself a prefix of 'warn-nopipe'.
+fn resolve_output_error_choice(value: &str) -> UResult<&'static str> {
+    let list = || {
+        OUTPUT_ERROR_CHOICES
+            .iter()
+            .map(|name| format!("  - '{name}'"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    if !value.is_empty()
+        && let Some(&exact) = OUTPUT_ERROR_CHOICES.iter().find(|name| **name == value)
+    {
+        return Ok(exact);
+    }
+    let mut named = OUTPUT_ERROR_CHOICES
+        .iter()
+        .filter(|name| name.starts_with(value));
+    match (named.next(), named.next()) {
+        (Some(name), None) if !value.is_empty() => Ok(*name),
+        (Some(_), Some(_)) => Err(USimpleError::new(
+            1,
+            translate!("tee-error-ambiguous-output-error-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+        _ => Err(USimpleError::new(
+            1,
+            translate!("tee-error-invalid-output-error-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+    }
+}
+
+/// `--output-error`'s value keeps its `ShortcutValueParser` (rather than
+/// being resolved by hand like the other options in this series) so that
+/// `--help` keeps rendering each choice's own description. Clap's own
+/// wording for a value it rejects doesn't match GNU's, though, so a
+/// rejection specifically on that argument is intercepted and reported with
+/// `resolve_output_error_choice`'s message instead; everything else still
+/// goes through the shared formatter.
+fn get_matches(args: impl uucore::Args) -> UResult<clap::ArgMatches> {
+    match uu_app().try_get_matches_from(args) {
+        Ok(matches) => Ok(matches),
+        Err(clap_error) => {
+            if clap_error.exit_code() == 0 {
+                return Err(clap_error.into());
+            }
+            if clap_error.kind() == clap::error::ErrorKind::InvalidValue
+                && clap_error
+                    .get(clap::error::ContextKind::InvalidArg)
+                    .is_some_and(|arg| arg.to_string().contains(options::OUTPUT_ERROR))
+                && let Some(value) = clap_error.get(clap::error::ContextKind::InvalidValue)
+            {
+                return Err(resolve_output_error_choice(&value.to_string()).unwrap_err());
+            }
+            let formatter = uucore::clap_localization::ErrorFormatter::new(uucore::util_name());
+            formatter.print_error_and_exit_with_callback(&clap_error, 1, || {});
+        }
+    }
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
+    let matches = get_matches(args)?;
 
     let append = matches.get_flag(options::APPEND);
     let ignore_interrupts = matches.get_flag(options::IGNORE_INTERRUPTS);
@@ -36,7 +99,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             "warn-nopipe" => OutputErrorMode::WarnNoPipe,
             "exit" => OutputErrorMode::Exit,
             "exit-nopipe" => OutputErrorMode::ExitNoPipe,
-            _ => unreachable!("clap excluded it"),
+            _ => unreachable!("ShortcutValueParser already restricted it"),
         })
         .or_else(|| ignore_pipe_errors.then_some(OutputErrorMode::WarnNoPipe));
 

--- a/tests/by-util/test_tee.rs
+++ b/tests/by-util/test_tee.rs
@@ -727,6 +727,40 @@ fn test_output_error_flag_without_value_defaults_warn_nopipe() {
     assert!(at.file_exists(file_out));
     assert_eq!(at.read(file_out), content);
 }
+
+#[test]
+fn test_output_error_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--output-error=bogus")
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "tee: invalid argument 'bogus' for '--output-error'\n",
+            "Valid arguments are:\n",
+            "  - 'warn'\n",
+            "  - 'warn-nopipe'\n",
+            "  - 'exit'\n",
+            "  - 'exit-nopipe'\n",
+            "Try 'tee --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_output_error_ambiguous_arg_message() {
+    new_ucmd!()
+        .arg("--output-error=wa")
+        .pipe_in("")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "tee: ambiguous argument 'wa' for '--output-error'\n",
+            "Valid arguments are:\n",
+            "  - 'warn'\n",
+            "  - 'warn-nopipe'\n",
+            "  - 'exit'\n",
+            "  - 'exit-nopipe'\n",
+            "Try 'tee --help' for more information.\n",
+        ));
+}
 // Unix-only: presence-only --output-error should not crash on broken pipe.
 // Current implementation may exit zero; we only assert the process exits to avoid flakiness.
 // TODO: When semantics are aligned with GNU warn-nopipe, strengthen assertions here.


### PR DESCRIPTION
## What

An unrecognized or ambiguous `--output-error` value produces clap's
own generic wording instead of GNU's:

```
$ echo hi | tee --output-error=bogus f

# GNU
tee: invalid argument 'bogus' for '--output-error'
Valid arguments are:
  - 'warn'
  - 'warn-nopipe'
  - 'exit'
  - 'exit-nopipe'
Try 'tee --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--output-error[=<output-error>]'

  [possible values: warn, warn-nopipe, exit, exit-nopipe]

For more information, try '--help'.
```

## Fix

Unlike the other options fixed in this same series (#14293, #14303,
#14304, #14305, #14306, #14307), `--output-error` keeps its
`ShortcutValueParser` rather than being resolved by hand: each of its
choices carries its own description, rendered as clap's "Possible
values:" block in `--help`, e.g.:

```
      --output-error[=<output-error>]
          set write error behavior

          Possible values:
          - warn:        produce warnings for errors writing to any output
          - warn-nopipe: produce warnings for errors that are not pipe errors ...
          ...
```

That per-choice text only a `value_parser` can supply to clap's help
renderer, so dropping the parser (as the other fixes in this series
do) would either lose that `--help` output or require hand-rolling
the same metadata a second time just to feed it back to clap for
display -- not worth it for one option. Instead, this intercepts a
rejection specifically on `--output-error` right after parsing and
re-reports it with GNU's wording (checking for an exact match first,
since `warn` and `exit` are themselves prefixes of `warn-nopipe` and
`exit-nopipe`); every other clap error -- unknown flags, `--help`,
`--version`, etc. -- still goes through the exact same shared
formatter as before, unchanged.

## Testing

- `cargo test -p uu_tee` / full `tests/by-util/test_tee.rs` suite: 37 passed, 0 failed.
- Added 2 regression tests: an invalid value and an ambiguous one (`wa`, between `warn` and `warn-nopipe`).
- Manually diffed every `--output-error` value (all real choices/abbreviations, invalid, ambiguous, empty) against GNU tee 9.11 under `LC_ALL=C`.
- Manually confirmed `--help`/`-h`/`--version` and unrelated errors (e.g. an unknown flag) are unaffected.
- `cargo clippy -p uu_tee --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*