### PR TITLE
rm: match GNU's error for a bad --preserve-root value

### DIFF
--- a/src/uu/rm/locales/en-US.ftl
+++ b/src/uu/rm/locales/en-US.ftl
@@ -50,6 +50,7 @@ rm-error-and-preserve-root-all-in-effect = and --preserve-root=all is in effect
 rm-error-cannot-remove = cannot remove {$file}
 rm-error-cannot-remove-changed = cannot remove {$file}: File changed while removing
 rm-error-may-not-abbreviate-no-preserve-root = you may not abbreviate the --no-preserve-root option
+rm-error-unrecognized-preserve-root-argument = unrecognized --preserve-root argument: '{$arg}'
 rm-error-standard-output = standard output: {$error}
 
 # Verbose messages

--- a/src/uu/rm/locales/fr-FR.ftl
+++ b/src/uu/rm/locales/fr-FR.ftl
@@ -48,6 +48,7 @@ rm-error-refusing-to-remove-directory = refus de supprimer le répertoire '.' ou
 rm-error-cannot-remove = impossible de supprimer {$file}
 rm-error-cannot-remove-changed = impossible de supprimer {$file} : Le fichier a changé pendant la suppression
 rm-error-may-not-abbreviate-no-preserve-root = Vous ne pouvez pas abréger l'option --no-preserve-root
+rm-error-unrecognized-preserve-root-argument = argument --preserve-root non reconnu : '{$arg}'
 rm-error-standard-output = sortie standard : {$error}
 
 # Messages verbeux

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -264,9 +264,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let preserve_root = !matches.get_flag(OPT_NO_PRESERVE_ROOT);
-    let preserve_root_all = matches
-        .get_one::<String>(OPT_PRESERVE_ROOT)
-        .is_some_and(|value| value == "all");
+    let preserve_root_all = match matches.get_one::<String>(OPT_PRESERVE_ROOT) {
+        Some(value) if value == "all" => true,
+        Some(value) => {
+            return Err(USimpleError::new(
+                1,
+                translate!("rm-error-unrecognized-preserve-root-argument", "arg" => value.clone()),
+            ));
+        }
+        None => false,
+    };
     let recursive = matches.get_flag(OPT_RECURSIVE);
 
     let options = Options {
@@ -428,8 +435,7 @@ pub fn uu_app() -> Command {
                 // additionally refuses to cross into another file system.
                 .num_args(0..=1)
                 .require_equals(true)
-                .value_name("all")
-                .value_parser(["all"]),
+                .value_name("all"),
         )
         .arg(
             Arg::new(OPT_RECURSIVE)

--- a/tests/by-util/test_rm.rs
+++ b/tests/by-util/test_rm.rs
@@ -249,7 +249,19 @@ fn test_preserve_root_rejects_unknown_value() {
         .arg("-rf")
         .arg("anything")
         .fails()
-        .stderr_contains("invalid value 'bogus'");
+        .stderr_is("rm: unrecognized --preserve-root argument: 'bogus'\n");
+}
+
+#[test]
+fn test_preserve_root_rejects_abbreviation() {
+    // Unlike --interactive and friends, --preserve-root does not accept
+    // abbreviations of its one value at all: GNU rejects even 'a'.
+    new_ucmd!()
+        .arg("--preserve-root=a")
+        .arg("-rf")
+        .arg("anything")
+        .fails()
+        .stderr_is("rm: unrecognized --preserve-root argument: 'a'\n");
 }
 
 #[test]


### PR DESCRIPTION
## What

`--preserve-root` validates its value with clap's plain
`value_parser(["all"])`, so an unrecognized value produces clap's own
generic wording instead of GNU's:

```
$ rm --preserve-root=bogus -rf anything

# GNU
rm: unrecognized --preserve-root argument: 'bogus'

# uutils, before this PR
error: invalid value 'bogus' for '--preserve-root[=<all>]'
  [possible values: all]

For more information, try '--help'.
```

Found this one while working on `--interactive` in the same file
(#14309) -- it's the same underlying problem (clap's own wording
instead of GNU's) but not the same class of bug as the rest of this
series (#14293, #14303-#14309): those all had a `ShortcutValueParser`
producing a "invalid/ambiguous argument ... Valid arguments are: ..."
shape with abbreviation support. `--preserve-root` uses clap's built-in
possible-values parser instead, GNU's real message is a single,
simpler line with no "Try --help" hint, and no abbreviation is
accepted at all -- GNU rejects even `a` for `all`.

## Fix

Resolve the value by hand (an exact match against `"all"`, nothing
else) and report GNU's own wording exactly.

Also fixes the existing `test_preserve_root_rejects_unknown_value`
test, which was asserting clap's wrong wording (`"invalid value
'bogus'"`) as though it were correct -- it had been written to match
the bug rather than GNU.

## Testing

- `cargo test -p uu_rm` / full `tests/by-util/test_rm.rs` suite: 84 passed, 0 failed.
- Fixed the existing test to assert GNU's actual message, and added a regression test for the no-abbreviations-accepted case (`--preserve-root=a`).
- Manually diffed `--preserve-root` with `all`, `a`, `bogus`, empty, `All`, `ALL`, and no value at all against GNU rm 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_rm --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*