### PR TITLE
touch: match GNU's error for a bad --time value

### DIFF
--- a/src/uu/touch/locales/en-US.ftl
+++ b/src/uu/touch/locales/en-US.ftl
@@ -27,3 +27,11 @@ touch-error-windows-stdout-path-failed = GetFinalPathNameByHandleW failed with c
 touch-error-invalid-filetime = Source has invalid access or modification time: { $time }
 touch-error-reference-file-inaccessible = failed to get attributes of { $path }: { $error }
 touch-error-stdout-unsupported = touch - (stdout) is not supported on WASI
+touch-error-invalid-time-choice = invalid argument '{$arg}' for '--time'
+  Valid arguments are:
+  {$choices}
+  Try 'touch --help' for more information.
+touch-error-ambiguous-time-choice = ambiguous argument '{$arg}' for '--time'
+  Valid arguments are:
+  {$choices}
+  Try 'touch --help' for more information.

--- a/src/uu/touch/locales/fr-FR.ftl
+++ b/src/uu/touch/locales/fr-FR.ftl
@@ -28,3 +28,11 @@ touch-error-windows-stdout-path-failed = GetFinalPathNameByHandleW a échoué av
 touch-error-invalid-filetime = La source a un temps d'accès ou de modification invalide : { $time }
 touch-error-reference-file-inaccessible = échec d'obtention des attributs de { $path } : { $error }
 touch-error-stdout-unsupported = touch - (sortie standard) n'est pas pris en charge sur WASI
+touch-error-invalid-time-choice = argument '{$arg}' invalide pour '--time'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'touch --help' pour plus d'informations.
+touch-error-ambiguous-time-choice = argument '{$arg}' ambigu pour '--time'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'touch --help' pour plus d'informations.

--- a/src/uu/touch/src/touch.rs
+++ b/src/uu/touch/src/touch.rs
@@ -9,7 +9,7 @@
 pub mod error;
 mod platform;
 
-use clap::builder::{PossibleValue, ValueParser};
+use clap::builder::ValueParser;
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 use filetime::FileTime;
 #[cfg(all(any(not(unix), target_os = "redox"), not(target_os = "wasi")))]
@@ -39,7 +39,6 @@ use uucore::display::Quotable;
 use uucore::error::{FromIo, UResult, USimpleError};
 #[cfg(target_os = "linux")]
 use uucore::libc;
-use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::translate;
 use uucore::{format_usage, show};
 
@@ -258,7 +257,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         no_deref,
         source,
         date,
-        change_times: determine_atime_mtime_change(&matches),
+        change_times: determine_atime_mtime_change(&matches)?,
         strict: false,
     };
 
@@ -342,11 +341,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::TIME)
                 .long(options::TIME)
                 .help(translate!("touch-help-time"))
-                .value_name("WORD")
-                .value_parser(ShortcutValueParser::new([
-                    PossibleValue::new("atime").alias("access").alias("use"),
-                    PossibleValue::new("mtime").alias("modify"),
-                ])),
+                .value_name("WORD"),
         )
         .arg(
             Arg::new(ARG_FILES)
@@ -537,33 +532,89 @@ fn touch_file(
     update_times(path, is_stdout, opts, atime, mtime)
 }
 
+/// The choices `--time`'s value accepts, in the order GNU lists them. Each
+/// choice's aliases are grouped on a single line in the error message the
+/// way GNU's touch does.
+const TIME_CHOICE_GROUPS: &[(&str, &[&str])] =
+    &[("atime", &["access", "use"]), ("mtime", &["modify"])];
+
+/// The canonical name (first element of its group) `value` names among
+/// `TIME_CHOICE_GROUPS`, accepting any unambiguous abbreviation the way
+/// GNU does (including one ambiguous only between aliases of the *same*
+/// choice, e.g. 'a' among 'atime'/'access').
+fn resolve_time_choice(value: &str) -> UResult<&'static str> {
+    let list = || {
+        TIME_CHOICE_GROUPS
+            .iter()
+            .map(|(canonical, aliases)| {
+                let names = std::iter::once(*canonical).chain(aliases.iter().copied());
+                format!(
+                    "  - {}",
+                    names
+                        .map(|name| format!("'{name}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let matches: Vec<(usize, &'static str)> = TIME_CHOICE_GROUPS
+        .iter()
+        .enumerate()
+        .flat_map(|(i, (canonical, aliases))| {
+            std::iter::once(*canonical)
+                .chain(aliases.iter().copied())
+                .map(move |name| (i, name))
+        })
+        .filter(|(_, name)| name.starts_with(value))
+        .collect();
+
+    if !value.is_empty()
+        && let Some(&(group, _)) = matches.iter().find(|(_, name)| *name == value)
+    {
+        return Ok(TIME_CHOICE_GROUPS[group].0);
+    }
+    match matches.first() {
+        Some(&(group, _)) if !value.is_empty() && matches.iter().all(|(g, _)| *g == group) => {
+            Ok(TIME_CHOICE_GROUPS[group].0)
+        }
+        Some(_) => Err(USimpleError::new(
+            1,
+            translate!("touch-error-ambiguous-time-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+        None => Err(USimpleError::new(
+            1,
+            translate!("touch-error-invalid-time-choice", "arg" => value.to_string(), "choices" => list()),
+        )),
+    }
+}
+
 /// Returns which of the times (access, modification) are to be changed.
 ///
 /// Note that "-a" and "-m" may be passed together; this is not an xor.
 /// - If `-a` is passed but not `-m`, only access time is changed
 /// - If `-m` is passed but not `-a`, only modification time is changed
 /// - If neither or both are passed, both times are changed
-fn determine_atime_mtime_change(matches: &ArgMatches) -> ChangeTimes {
+fn determine_atime_mtime_change(matches: &ArgMatches) -> UResult<ChangeTimes> {
     // If `--time` is given, Some(true) if equivalent to `-a`, Some(false) if equivalent to `-m`
     // If `--time` not given, None
-    let time_access_only = if matches.contains_id(options::TIME) {
-        matches
-            .get_one::<String>(options::TIME)
-            .map(|time| time.contains("access") || time.contains("atime") || time.contains("use"))
-    } else {
-        None
-    };
+    let time_access_only = matches
+        .get_one::<String>(options::TIME)
+        .map(|time| resolve_time_choice(time))
+        .transpose()?
+        .map(|canonical| canonical == "atime");
 
     let atime_only = matches.get_flag(options::ACCESS) || time_access_only.unwrap_or_default();
     let mtime_only = matches.get_flag(options::MODIFICATION) || !time_access_only.unwrap_or(true);
 
-    if atime_only && !mtime_only {
+    Ok(if atime_only && !mtime_only {
         ChangeTimes::AtimeOnly
     } else if mtime_only && !atime_only {
         ChangeTimes::MtimeOnly
     } else {
         ChangeTimes::Both
-    }
+    })
 }
 
 /// Updating file access and modification times based on user-specified options
@@ -960,6 +1011,7 @@ mod tests {
         assert_eq!(
             ChangeTimes::Both,
             determine_atime_mtime_change(&uu_app().try_get_matches_from(vec!["touch"]).unwrap())
+                .unwrap()
         );
         assert_eq!(
             ChangeTimes::Both,
@@ -968,6 +1020,7 @@ mod tests {
                     .try_get_matches_from(vec!["touch", "-a", "-m", "--time", "modify"])
                     .unwrap()
             )
+            .unwrap()
         );
         assert_eq!(
             ChangeTimes::AtimeOnly,
@@ -976,12 +1029,14 @@ mod tests {
                     .try_get_matches_from(vec!["touch", "--time", "access"])
                     .unwrap()
             )
+            .unwrap()
         );
         assert_eq!(
             ChangeTimes::MtimeOnly,
             determine_atime_mtime_change(
                 &uu_app().try_get_matches_from(vec!["touch", "-m"]).unwrap()
             )
+            .unwrap()
         );
     }
 

--- a/tests/by-util/test_touch.rs
+++ b/tests/by-util/test_touch.rs
@@ -49,6 +49,24 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_time_invalid_arg_message() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "test_time_invalid_arg_message";
+    at.touch(file);
+
+    ucmd.arg("--time=bogus")
+        .arg(file)
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "touch: invalid argument 'bogus' for '--time'\n",
+            "Valid arguments are:\n",
+            "  - 'atime', 'access', 'use'\n",
+            "  - 'mtime', 'modify'\n",
+            "Try 'touch --help' for more information.\n",
+        ));
+}
+
+#[test]
 fn test_touch_default() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "test_touch_default_file";


### PR DESCRIPTION
## What

`--time` validates its value with a plain `ShortcutValueParser`, so an
unrecognized or ambiguous value produces clap's own generic wording
instead of GNU's grouped-alias wording:

```
$ touch --time=bogus f

# GNU
touch: invalid argument 'bogus' for '--time'
Valid arguments are:
  - 'atime', 'access', 'use'
  - 'mtime', 'modify'
Try 'touch --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--time <WORD>'

  [possible values: atime, mtime]

For more information, try '--help'.
```

## Fix

Same fix already shipped for the same option name on other utilities,
and for other options generally, across this series (#14293, #14303-
#14310): resolve the value against the option's own alias groups by
hand, accepting any unambiguous abbreviation the way GNU does --
including one ambiguous only between aliases of the *same* choice,
e.g. `a` among `atime`/`access`/`use` -- and report GNU's wording when
it does not resolve.

`determine_atime_mtime_change` now returns a `UResult<ChangeTimes>`
instead of a bare `ChangeTimes` to propagate that; the existing unit
test for it (`test_determine_atime_mtime_change`) is updated to
`.unwrap()` accordingly.

## Testing

- `cargo test -p uu_touch` (lib + integration): 6 + 65 passed, 0 failed.
- Added a regression test for the exact GNU wording on an invalid value.
- Manually diffed every `--time` value (all real choices/aliases/abbreviations, invalid, ambiguous, empty) against GNU touch 9.11 under `LC_ALL=C`.
- Manually confirmed `--time=atime`/`--time=mtime` still update the correct timestamp (not just the error path).
- `cargo clippy -p uu_touch --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*