### PR TITLE
ls: match GNU's error for a bad --format/--sort/--time/etc. value

### DIFF
--- a/src/uu/ls/locales/en-US.ftl
+++ b/src/uu/ls/locales/en-US.ftl
@@ -34,6 +34,14 @@ ls-error-invalid-time-style = invalid --time-style argument {$style}
     - +FORMAT (e.g., +%H:%M) for a 'date'-style format
 
   For more information try --help
+ls-error-invalid-choice = invalid argument '{$arg}' for '--{$option}'
+  Valid arguments are:
+  {$choices}
+  Try 'ls --help' for more information.
+ls-error-ambiguous-choice = ambiguous argument '{$arg}' for '--{$option}'
+  Valid arguments are:
+  {$choices}
+  Try 'ls --help' for more information.
 
 # Help messages
 ls-help-print-help = Print help information.

--- a/src/uu/ls/locales/fr-FR.ftl
+++ b/src/uu/ls/locales/fr-FR.ftl
@@ -32,6 +32,14 @@ ls-error-invalid-time-style = argument --time-style invalide {$style}
     - +FORMAT (e.g., +%H:%M) pour un format de type 'date'
 
   Pour plus d'informations, essayez --help
+ls-error-invalid-choice = argument '{$arg}' invalide pour '--{$option}'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'ls --help' pour plus d'informations.
+ls-error-ambiguous-choice = argument '{$arg}' ambigu pour '--{$option}'
+  Les arguments valides sont :
+  {$choices}
+  Essayez 'ls --help' pour plus d'informations.
 
 # Messages d'aide
 ls-help-print-help = Afficher les informations d'aide.

--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 use uucore::libc::{S_IXGRP, S_IXOTH, S_IXUSR};
 use uucore::{
     display::Quotable,
-    error::{UError, UResult, set_exit_code, strip_errno},
+    error::{UError, UResult, USimpleError, set_exit_code, strip_errno},
     format_usage,
     fs::FileInformation,
     fsext::metadata_get_time,
@@ -115,15 +115,162 @@ impl UError for LsError {
     }
 }
 
+/// The choices each of `WHEN`-style option's value accepts, in the order
+/// GNU lists them. Each choice's aliases are grouped on a single line the
+/// way GNU does; `columns` on `--format` is this implementation's own
+/// extension, which GNU's `--format` does not support at all.
+const WHEN_CHOICES: &[&[&str]] = &[
+    &["always", "yes", "force"],
+    &["never", "no", "none"],
+    &["auto", "tty", "if-tty"],
+];
+
+/// The options in this file that validate an enumerated choice with a
+/// `ShortcutValueParser`. That parser reports an invalid or ambiguous
+/// value with clap's own generic wording, not GNU's; each entry here is
+/// the metadata this module's [`invalid_choice_error`] needs to
+/// reconstruct GNU's wording after clap has already rejected a value.
+struct ChoiceOption {
+    long: &'static str,
+    groups: &'static [&'static [&'static str]],
+}
+
+const CHOICE_OPTIONS: &[ChoiceOption] = &[
+    ChoiceOption {
+        long: options::FORMAT,
+        groups: &[
+            &["verbose", "long"],
+            &["commas"],
+            &["horizontal", "across"],
+            &["vertical"],
+            &["single-column"],
+            &["columns"],
+        ],
+    },
+    ChoiceOption {
+        long: options::HYPERLINK,
+        groups: WHEN_CHOICES,
+    },
+    ChoiceOption {
+        long: QUOTING_STYLE,
+        groups: &[
+            &["literal"],
+            &["shell"],
+            &["shell-always"],
+            &["shell-escape"],
+            &["shell-escape-always"],
+            &["c"],
+            &["c-maybe"],
+            &["escape"],
+            &["locale"],
+            &["clocale"],
+        ],
+    },
+    ChoiceOption {
+        long: options::TIME,
+        groups: &[
+            &["atime", "access", "use"],
+            &["ctime", "status"],
+            &["mtime", "modification"],
+            &["birth", "creation"],
+        ],
+    },
+    ChoiceOption {
+        long: options::SORT,
+        groups: &[
+            &["none"],
+            &["size"],
+            &["time"],
+            &["version"],
+            &["extension"],
+            &["name"],
+            &["width"],
+        ],
+    },
+    ChoiceOption {
+        long: options::COLOR,
+        groups: WHEN_CHOICES,
+    },
+    ChoiceOption {
+        long: options::INDICATOR_STYLE,
+        groups: &[&["none"], &["slash"], &["file-type"], &["classify"]],
+    },
+    ChoiceOption {
+        long: options::indicator_style::CLASSIFY,
+        groups: WHEN_CHOICES,
+    },
+];
+
+/// Rebuilds `clap_error` -- already known to be an `ErrorKind::InvalidValue`
+/// on one of `CHOICE_OPTIONS` -- as GNU's own wording instead of clap's,
+/// or returns `None` if it names none of them (letting the caller fall
+/// back to the shared formatter for everything else).
+fn invalid_choice_error(clap_error: &clap::Error) -> Option<Box<dyn UError>> {
+    let arg = clap_error
+        .get(clap::error::ContextKind::InvalidArg)?
+        .to_string();
+    let value = clap_error
+        .get(clap::error::ContextKind::InvalidValue)?
+        .to_string();
+    let option = CHOICE_OPTIONS
+        .iter()
+        .find(|opt| arg.contains(&format!("--{}", opt.long)))?;
+
+    let list = || {
+        option
+            .groups
+            .iter()
+            .map(|group| {
+                format!(
+                    "  - {}",
+                    group
+                        .iter()
+                        .map(|name| format!("'{name}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let matched_groups = option
+        .groups
+        .iter()
+        .filter(|group| group.iter().any(|name| name.starts_with(&value)))
+        .count();
+    let message = if matched_groups > 1 {
+        translate!("ls-error-ambiguous-choice", "option" => option.long, "arg" => value, "choices" => list())
+    } else {
+        translate!("ls-error-invalid-choice", "option" => option.long, "arg" => value, "choices" => list())
+    };
+    Some(USimpleError::new(1, message))
+}
+
+/// Parses the command line the way
+/// [`uucore::clap_localization::handle_clap_result_with_diagnostics`] does,
+/// except that an `ErrorKind::InvalidValue` naming one of `CHOICE_OPTIONS`
+/// is reported with GNU's wording via [`invalid_choice_error`] instead of
+/// the shared formatter's.
+fn get_matches(args: Vec<OsString>) -> UResult<(clap::ArgMatches, Option<Vec<OsString>>)> {
+    let diag_args = uucore::diagnostics::capture(&args);
+    match uu_app().try_get_matches_from(args) {
+        Ok(matches) => Ok((matches, diag_args)),
+        Err(clap_error) => {
+            if clap_error.kind() == clap::error::ErrorKind::InvalidValue
+                && let Some(err) = invalid_choice_error(&clap_error)
+            {
+                return Err(err);
+            }
+            uucore::clap_localization::handle_clap_error_with_exit_code(clap_error, 2);
+        }
+    }
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // The arguments are kept for the caret in SIZE diagnostics, which echoes
     // the command line.
-    let (matches, diag_args) = uucore::clap_localization::handle_clap_result_with_diagnostics(
-        uu_app(),
-        args.collect(),
-        2,
-    )?;
+    let (matches, diag_args) = get_matches(args.collect())?;
 
     uucore::i18n::collator::init_locale_collation();
 

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -104,15 +104,15 @@ fn test_localized_possible_values() {
         (
             "en_US.UTF-8",
             vec![
-                "error: invalid value 'invalid_test_value' for '--color",
-                "[possible values:",
+                "invalid argument 'invalid_test_value' for '--color'",
+                "Valid arguments are:",
             ],
         ),
         (
             "fr_FR.UTF-8",
             vec![
-                "erreur : valeur invalide 'invalid_test_value' pour '--color",
-                "[valeurs possibles:",
+                "argument 'invalid_test_value' invalide pour '--color'",
+                "Les arguments valides sont :",
             ],
         ),
     ];
@@ -132,6 +132,126 @@ fn test_localized_possible_values() {
     }
 }
 /* spellchecker: enable */
+
+#[test]
+fn test_format_invalid_arg_message() {
+    // `columns` is this implementation's own extra --format choice; GNU's
+    // --format does not accept it at all.
+    new_ucmd!()
+        .arg("--format=bogus")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: invalid argument 'bogus' for '--format'\n",
+            "Valid arguments are:\n",
+            "  - 'verbose', 'long'\n",
+            "  - 'commas'\n",
+            "  - 'horizontal', 'across'\n",
+            "  - 'vertical'\n",
+            "  - 'single-column'\n",
+            "  - 'columns'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_time_ambiguous_arg_message() {
+    new_ucmd!()
+        .arg("--time=bogus")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: invalid argument 'bogus' for '--time'\n",
+            "Valid arguments are:\n",
+            "  - 'atime', 'access', 'use'\n",
+            "  - 'ctime', 'status'\n",
+            "  - 'mtime', 'modification'\n",
+            "  - 'birth', 'creation'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_quoting_style_invalid_arg_message() {
+    // Unlike every other option here, GNU lists each of --quoting-style's
+    // choices on its own line, even 'c' and 'c-maybe', which are aliases
+    // for the same style.
+    new_ucmd!()
+        .arg("--quoting-style=bogus")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: invalid argument 'bogus' for '--quoting-style'\n",
+            "Valid arguments are:\n",
+            "  - 'literal'\n",
+            "  - 'shell'\n",
+            "  - 'shell-always'\n",
+            "  - 'shell-escape'\n",
+            "  - 'shell-escape-always'\n",
+            "  - 'c'\n",
+            "  - 'c-maybe'\n",
+            "  - 'escape'\n",
+            "  - 'locale'\n",
+            "  - 'clocale'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_sort_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--sort=bogus")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: invalid argument 'bogus' for '--sort'\n",
+            "Valid arguments are:\n",
+            "  - 'none'\n",
+            "  - 'size'\n",
+            "  - 'time'\n",
+            "  - 'version'\n",
+            "  - 'extension'\n",
+            "  - 'name'\n",
+            "  - 'width'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_indicator_style_invalid_arg_message() {
+    new_ucmd!()
+        .arg("--indicator-style=bogus")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: invalid argument 'bogus' for '--indicator-style'\n",
+            "Valid arguments are:\n",
+            "  - 'none'\n",
+            "  - 'slash'\n",
+            "  - 'file-type'\n",
+            "  - 'classify'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_hyperlink_ambiguous_arg_message() {
+    new_ucmd!()
+        .arg("--hyperlink=a")
+        .fails_with_code(1)
+        .stderr_is(concat!(
+            "ls: ambiguous argument 'a' for '--hyperlink'\n",
+            "Valid arguments are:\n",
+            "  - 'always', 'yes', 'force'\n",
+            "  - 'never', 'no', 'none'\n",
+            "  - 'auto', 'tty', 'if-tty'\n",
+            "Try 'ls --help' for more information.\n",
+        ));
+}
+
+#[test]
+fn test_classify_when_still_works() {
+    // The --classify=WHEN interception must not disturb normal parsing.
+    new_ucmd!()
+        .arg("--classify=never")
+        .arg("--classify=always")
+        .succeeds();
+}
 
 #[test]
 fn test_invalid_value_returns_2() {


### PR DESCRIPTION
## What

Eight options in `ls` validate an enumerated choice with a
`ShortcutValueParser`: `--format`, `--hyperlink`, `--quoting-style`,
`--time`, `--sort`, `--color`, `--indicator-style`, and `--classify`.
An unrecognized or ambiguous value on any of them produces clap's own
generic wording instead of GNU's grouped-alias one, e.g.:

```
$ ls --time=bogus

# GNU
ls: invalid argument 'bogus' for '--time'
Valid arguments are:
  - 'atime', 'access', 'use'
  - 'ctime', 'status'
  - 'mtime', 'modification'
  - 'birth', 'creation'
Try 'ls --help' for more information.

# uutils, before this PR
error: invalid value 'bogus' for '--time <field>'

  [possible values: atime, ctime, mtime, birth]

For more information, try '--help'.
```

## Fix

Unlike the other options fixed in this series (#14293, #14303-#14312),
none of these eight are resolved by hand: each keeps its
`ShortcutValueParser` completely unchanged, since that's still the
source of truth clap uses both to validate the value *and* to render
e.g. `--quoting-style`'s own `--help` text (several of these already
carry real synonym handling clap needs to keep doing correctly).

Instead, clap errors now go through a small wrapper (`get_matches`)
that, on an `ErrorKind::InvalidValue` naming one of these eight
options, reconstructs GNU's wording from a small metadata table
(`CHOICE_OPTIONS`) describing each option's own choice groups in GNU's
display order. Every other clap error -- unknown flags, `--help`,
`--version`, etc. -- still goes through the exact same shared
formatter as before, unchanged. This mirrors the approach already
used for `tee --output-error` (#14308), which has the same
help-text constraint.

Two things specific to these eight, found only by diffing exhaustively
against real GNU rather than just checking one bad value per option:

- `--format=columns` is this implementation's own choice; GNU's real
  `--format` has no separate word for what it calls `vertical` and
  does not accept `columns` at all. Listed as its own group, same
  precedent as du's `creation`/`birth` (#14306) -- and, as with that
  one, it creates a real ambiguity GNU doesn't have (e.g.
  `--format=co` resolves to `commas` on GNU, but is ambiguous here
  between `commas` and `columns`).
- `--quoting-style` is unusual in the *other* direction: GNU lists
  each of its choices, including `c` and `c-maybe` -- a real alias
  pair -- on its own separate line, rather than grouping aliases
  together the way every other option in this series does.

## Testing

- `cargo test -p uu_ls` / full `tests/by-util/test_ls.rs` suite: 189 passed, 0 failed, 1 pre-existing ignore.
- Updated the existing `test_localized_possible_values` test (which asserted clap's own wording, localized, as the *expected* behavior) to assert GNU's wording instead, in both English and French.
- Added 7 new regression tests covering each of the three message shapes (flat, grouped, one choice per line) and confirming `--classify=WHEN` parsing itself still works.
- Manually diffed every one of the 8 options across invalid, ambiguous, empty, and valid-abbreviation values against GNU ls 9.11 under `LC_ALL=C` (including cases specific to each option's own alias structure, e.g. `--time=a` unambiguous vs `--format=v` ambiguous).
- Manually confirmed ordinary usage (`-la`, `--color=auto`, `--time-style=...`), `--help`, `-h`, `--version`, and an unrelated error (unknown flag, still exit code 2) are all unaffected.
- `cargo clippy -p uu_ls --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*