### PR TITLE
ptx: match GNU's error for a bad --gap-size/--width value

### DIFF
--- a/src/uu/ptx/locales/en-US.ftl
+++ b/src/uu/ptx/locales/en-US.ftl
@@ -31,3 +31,4 @@ ptx-error-write-failed = write failed
 ptx-error-extra-operand = extra operand { $operand }
 ptx-error-empty-regexp = A regular expression cannot match a length zero string
 ptx-error-invalid-regexp = Invalid regexp: { $error }
+ptx-error-invalid-number = invalid { $kind }: '{ $value }'

--- a/src/uu/ptx/locales/fr-FR.ftl
+++ b/src/uu/ptx/locales/fr-FR.ftl
@@ -30,3 +30,4 @@ ptx-error-write-failed = échec de l'écriture
 ptx-error-extra-operand = opérande supplémentaire { $operand }
 ptx-error-empty-regexp = Une expression régulière ne peut pas correspondre à une chaîne de longueur zéro
 ptx-error-invalid-regexp = Expression régulière invalide : { $error }
+ptx-error-invalid-number = { $kind } invalide : '{ $value }'

--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write, stdin, stdout};
 use std::path::Path;
 
-use clap::{Arg, ArgAction, Command, value_parser};
+use clap::{Arg, ArgAction, Command};
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use uucore::display::Quotable;
@@ -200,6 +200,19 @@ struct WordRef {
     char_start: usize,
 }
 
+/// Parses `--gap-size`/`--width`'s value the way GNU does: a plain positive
+/// integer, with any other string -- unparseable, zero, or overflowing --
+/// reported the same way as any other.
+fn parse_ptx_number(value: &str, kind: &'static str) -> UResult<u64> {
+    match value.parse::<u64>() {
+        Ok(n) if n > 0 => Ok(n),
+        _ => Err(USimpleError::new(
+            1,
+            translate!("ptx-error-invalid-number", "kind" => kind, "value" => value.to_owned()),
+        )),
+    }
+}
+
 fn get_config(matches: &mut clap::ArgMatches) -> UResult<Config> {
     let mut config = Config::default();
     let err_msg = "parsing options failed";
@@ -245,13 +258,13 @@ fn get_config(matches: &mut clap::ArgMatches) -> UResult<Config> {
             .expect(err_msg)
             .clone_into(&mut config.trunc_str);
     }
-    if matches.contains_id(options::WIDTH) {
-        config.line_width = *matches.get_one::<u64>(options::WIDTH).unwrap() as usize;
+    if let Some(value) = matches.get_one::<String>(options::WIDTH) {
+        config.line_width = parse_ptx_number(value, "line width")? as usize;
     } else if matches.get_flag(options::TYPESET_MODE) {
         config.line_width = 100;
     }
-    if matches.contains_id(options::GAP_SIZE) {
-        config.gap_size = *matches.get_one::<u64>(options::GAP_SIZE).unwrap() as usize;
+    if let Some(value) = matches.get_one::<String>(options::GAP_SIZE) {
+        config.gap_size = parse_ptx_number(value, "gap width")? as usize;
     }
     if let Some(format) = matches.get_one::<String>(options::FORMAT) {
         config.format = match format.as_str() {
@@ -1041,7 +1054,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::GAP_SIZE)
                 .short('g')
                 .long(options::GAP_SIZE)
-                .value_parser(value_parser!(u64).range(1..))
+                .allow_hyphen_values(true)
                 .help(translate!("ptx-help-gap-size"))
                 .value_name("NUMBER"),
         )
@@ -1082,7 +1095,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::WIDTH)
                 .short('w')
                 .long(options::WIDTH)
-                .value_parser(value_parser!(u64).range(1..))
+                .allow_hyphen_values(true)
                 .help(translate!("ptx-help-width"))
                 .value_name("NUMBER"),
         )

--- a/tests/by-util/test_ptx.rs
+++ b/tests/by-util/test_ptx.rs
@@ -9,8 +9,31 @@ use uutests::new_ucmd;
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails_with_code(1);
-    new_ucmd!().arg("-g").arg("0").fails_with_code(1); // clap provided message
-    new_ucmd!().arg("-w").arg("0").fails_with_code(1); // clap provided message
+    new_ucmd!()
+        .arg("-g")
+        .arg("0")
+        .fails_with_code(1)
+        .stderr_is("ptx: invalid gap width: '0'\n");
+    new_ucmd!()
+        .arg("-w")
+        .arg("0")
+        .fails_with_code(1)
+        .stderr_is("ptx: invalid line width: '0'\n");
+}
+
+#[test]
+fn test_gap_size_negative_as_separate_arg() {
+    // A negative value passed as its own argument (not attached with
+    // `-g-5`/`=`) must not be mistaken for a new, unrecognized flag; GNU
+    // still rejects the negative value itself, just with its own wording.
+    new_ucmd!()
+        .args(&["-g", "-5"])
+        .fails_with_code(1)
+        .stderr_is("ptx: invalid gap width: '-5'\n");
+    new_ucmd!()
+        .args(&["--width", "-5"])
+        .fails_with_code(1)
+        .stderr_is("ptx: invalid line width: '-5'\n");
 }
 #[test]
 fn test_reference_format_for_stdin() {


### PR DESCRIPTION
## What

`--gap-size`/`-g` and `--width`/`-w` validate their values with clap's
own `value_parser!(u64).range(1..)`, which causes the same two
problems already fixed for `sort --parallel` (#14303) and `nl`'s
numeric options (#14314):

```
$ ptx -g -5 f

# GNU: still rejects the value, but with its own wording
ptx: invalid gap width: '-5'

# uutils, before this PR: treated as an unrecognized flag instead
error: unexpected argument '-5' found
  tip: to pass '-5' as a value, use '-- -5'
```

```
$ ptx -g bogus f

# GNU
ptx: invalid gap width: 'bogus'

# uutils, before this PR
error: invalid value 'bogus' for '--gap-size <NUMBER>': invalid digit found in string
```

## Fix

Resolve the value by hand: parse as `u64`, reject anything that
doesn't parse as a positive integer (unparseable, zero, negative, or
overflowing) with GNU's wording. Unlike `nl --number-width` (#14314),
GNU does *not* distinguish an overflow from any other invalid value
here -- `--gap-size 99999999999999999999999999` gets the exact same
"invalid gap width: '...'" message as `--gap-size bogus` -- so this
one only needed a single uniform check, confirmed by diffing both
cases against real GNU rather than assuming the nl-style distinction
would apply here too.

## Testing

- `cargo test -p uu_ptx` / full `tests/by-util/test_ptx.rs` suite: 50 passed, 0 failed.
- Strengthened the existing `test_invalid_arg` test (which only checked the exit code, with a comment noting the message was clap-provided) to assert the exact GNU wording.
- Added a regression test for the separate-argument negative-value case (the actual reported bug) on both `-g` and `--width`.
- Manually diffed 12 cases (invalid, negative attached/separate/short-flag, zero, overflow, empty, valid) against GNU ptx 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_ptx --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*