### PR TITLE
mknod: match GNU's error for a bad MAJOR/MINOR device number

### DIFF
--- a/src/uu/mknod/locales/en-US.ftl
+++ b/src/uu/mknod/locales/en-US.ftl
@@ -32,3 +32,4 @@ mknod-error-invalid-mode = invalid mode ({ $error })
 mknod-error-mode-permission-bits-only = mode must specify only file permission bits
 mknod-error-missing-device-type = missing device type
 mknod-error-invalid-device-type = invalid device type { $type }
+mknod-error-invalid-device-number = invalid { $kind } device number '{ $value }'

--- a/src/uu/mknod/locales/fr-FR.ftl
+++ b/src/uu/mknod/locales/fr-FR.ftl
@@ -32,3 +32,4 @@ mknod-error-invalid-mode = mode invalide ({ $error })
 mknod-error-mode-permission-bits-only = le mode ne doit spécifier que les bits de permission de fichier
 mknod-error-missing-device-type = type de périphérique manquant
 mknod-error-invalid-device-type = type de périphérique invalide { $type }
+mknod-error-invalid-device-number = numéro de périphérique { $kind } invalide '{ $value }'

--- a/src/uu/mknod/src/mknod.rs
+++ b/src/uu/mknod/src/mknod.rs
@@ -138,6 +138,17 @@ fn mknod(file_name: &str, config: Config) -> i32 {
     errno
 }
 
+/// Parses a MAJOR/MINOR device number the way GNU does: a plain `u32`, with
+/// any other string -- unparseable or overflowing -- reported the same way.
+fn parse_device_number(value: &str, kind: &'static str) -> UResult<u32> {
+    value.parse::<u32>().map_err(|_| {
+        USimpleError::new(
+            1,
+            translate!("mknod-error-invalid-device-number", "kind" => kind, "value" => value.to_owned()),
+        )
+    })
+}
+
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<OsString> = args.collect();
@@ -192,11 +203,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     ))]
     let context = matches.get_one::<String>(options::CONTEXT).cloned();
 
-    let dev = match (
-        file_type,
-        matches.get_one::<u32>(options::MAJOR),
-        matches.get_one::<u32>(options::MINOR),
-    ) {
+    let major = matches
+        .get_one::<String>(options::MAJOR)
+        .map(|value| parse_device_number(value, "major"))
+        .transpose()?;
+    let minor = matches
+        .get_one::<String>(options::MINOR)
+        .map(|value| parse_device_number(value, "minor"))
+        .transpose()?;
+
+    let dev = match (file_type, major, minor) {
         (FileType::Fifo, None, None) => 0,
         (FileType::Fifo, _, _) => {
             return Err(UUsageError::new(
@@ -204,7 +220,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 translate!("mknod-error-fifo-no-major-minor"),
             ));
         }
-        (_, Some(&major), Some(&minor)) => makedev(major as _, minor as _) as u64,
+        (_, Some(major), Some(minor)) => makedev(major as _, minor as _) as u64,
         _ => {
             return Err(UUsageError::new(
                 1,
@@ -267,14 +283,12 @@ pub fn uu_app() -> Command {
         .arg(
             Arg::new(options::MAJOR)
                 .value_name(options::MAJOR)
-                .help(translate!("mknod-help-major"))
-                .value_parser(value_parser!(u32)),
+                .help(translate!("mknod-help-major")),
         )
         .arg(
             Arg::new(options::MINOR)
                 .value_name(options::MINOR)
-                .help(translate!("mknod-help-minor"))
-                .value_parser(value_parser!(u32)),
+                .help(translate!("mknod-help-minor")),
         )
         .arg(
             Arg::new(options::SECURITY_CONTEXT)

--- a/tests/by-util/test_mknod.rs
+++ b/tests/by-util/test_mknod.rs
@@ -24,7 +24,7 @@ fn test_mknod_overflow_major_minor() {
         .arg("1")
         .fails_with_code(1)
         .no_stdout()
-        .stderr_contains("invalid value '4294967296'"); //clap generated message, thats fine.
+        .stderr_is("mknod: invalid major device number '4294967296'\n");
 }
 
 #[test]
@@ -115,14 +115,14 @@ fn test_mknod_character_device_requires_major_and_minor() {
         .arg("1")
         .arg("c")
         .fails()
-        .stderr_contains("invalid value 'c'");
+        .stderr_is("mknod: invalid minor device number 'c'\n");
     new_ucmd!()
         .arg("test_file")
         .arg("c")
         .arg("c")
         .arg("1")
         .fails()
-        .stderr_contains("invalid value 'c'");
+        .stderr_is("mknod: invalid major device number 'c'\n");
 }
 
 #[test]


### PR DESCRIPTION
## What

`MAJOR` and `MINOR` validate their values with clap's own
`value_parser!(u32)`, so an unparseable or overflowing value produces
clap's own generic wording instead of GNU's:

```
$ mknod f c 4294967296 1

# GNU
mknod: invalid major device number '4294967296'

# uutils, before this PR
error: invalid value '4294967296' for '[major]': 4294967296 is not in 0..=4294967295
```

## Fix

Resolve the value by hand: parse as `u32`, reject anything that
doesn't fit (unparseable or overflowing) with GNU's wording,
distinguishing which of the two operands (major/minor) it was for --
same wording shape as `ptx --gap-size`/`--width` (#14315), no separate
"value too large" case needed since GNU's own message doesn't
distinguish overflow from any other bad value here either.

A negative value passed as its own positional argument (e.g. `mknod f
c -5 5`) is deliberately left alone, still reported as clap's own
"unexpected argument" rejection: GNU's own `getopt` *also* rejects it,
but as an unrecognized **option** (`invalid option -- '5'`) rather
than an invalid device number -- a different and much deeper mismatch
(clap's vs. getopt's own unknown-argument handling in general, not
anything specific to this option) that's out of scope for this fix.

## Testing

- `cargo test --features mknod -p uu_mknod` / full `tests/by-util/test_mknod.rs` suite: 14 passed, 0 failed.
- Fixed 2 existing tests (3 assertions) that had encoded clap's wrong wording as the expected result, one with a comment explicitly noting it ("clap generated message, thats fine").
- Manually diffed 7 cases (invalid, overflow, valid) on both major and minor, plus the negative-value positional-argument case, against GNU mknod 9.11 under `LC_ALL=C` (via `sudo`, since device-node creation requires it).
- `cargo clippy -p uu_mknod --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*