### PR TITLE
nl: show allowed range when -i/-l negative_num is given

### DIFF
--- a/src/uu/nl/src/nl.rs
+++ b/src/uu/nl/src/nl.rs
@@ -329,7 +329,9 @@ pub fn uu_app() -> Command {
                 .long(options::LINE_INCREMENT)
                 .help(translate!("nl-help-line-increment"))
                 .value_name("NUMBER")
-                .value_parser(clap::value_parser!(i64)),
+                // show range of allowed value when -NUM is passed
+                .allow_hyphen_values(true)
+                .value_parser(clap::value_parser!(i64).range(0..)),
         )
         .arg(
             Arg::new(options::JOIN_BLANK_LINES)
@@ -337,6 +339,8 @@ pub fn uu_app() -> Command {
                 .long(options::JOIN_BLANK_LINES)
                 .help(translate!("nl-help-join-blank-lines"))
                 .value_name("NUMBER")
+                // show range of allowed value when -NUM is passed
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(u64)),
         )
         .arg(


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/pull/14314

We don't need to manually parse it just for showing valid range:
```
> target/debug/nl -i -5 f
error: invalid value '-5' for '--line-increment <NUMBER>': -5 is not in 0..9223372036854775807

For more information, try '--help'.
```