### PR TITLE
csplit: accept a hyphen-leading --suffix-format value

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -680,6 +680,7 @@ pub fn uu_app() -> Command {
                 .short('b')
                 .long(options::SUFFIX_FORMAT)
                 .value_name("FORMAT")
+                .allow_hyphen_values(true)
                 .help(translate!("csplit-help-suffix-format")),
         )
         .arg(

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -1446,6 +1446,20 @@ fn precision_format() {
 }
 
 #[test]
+fn suffix_format_hyphen_leading_as_separate_arg() {
+    // A hyphen-leading suffix format passed as its own argument (not
+    // attached with `-b-%02d`/`=`) must not be mistaken for a new,
+    // unrecognized flag.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "10", "--suffix-format", "-%02d"])
+        .succeeds()
+        .stdout_only("18\n123\n");
+
+    assert_eq!(at.read("xx-00"), generate(1, 10));
+    assert_eq!(at.read("xx-01"), generate(10, 51));
+}
+
+#[test]
 fn zero_precision_format() {
     let (at, mut ucmd) = at_and_ucmd!();
     ucmd.args(&["numbers50.txt", "10", "--suffix-format", "%.0d"])


### PR DESCRIPTION
## What

`--suffix-format`'s value was rejected as an unrecognized flag when
given as its own argument:

```
$ csplit --suffix-format -%02d f /pat/

# GNU: accepts it, splits normally with files named xx-00, xx-01, ...
# uutils, before this PR:
error: unexpected argument '-%' found
  tip: to pass '-%' as a value, use '-- -%'
```

The attached forms (`-b-%02d`, `--suffix-format=-%02d`) already
worked; only the separate-argument form broke -- the same
`allow_hyphen_values` gap already fixed this session for several other
options (`sort --parallel`, `nl`'s numeric options, `ptx
--gap-size`/`--width`, `join -t`).

## Testing

- `cargo test -p uu_csplit` / full `tests/by-util/test_csplit.rs` suite: 93 passed, 0 failed.
- Added a regression test for the separate-argument hyphen-leading case, checking both stdout and the actual split filenames produced.
- Manually diffed `--suffix-format -%02d` and `--suffix-format=z%02d` (both output and the resulting filenames) against GNU csplit 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_csplit --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*