### PR TITLE
paste: accept a hyphen-leading -d delimiter list

### DIFF
--- a/src/uu/paste/src/paste.rs
+++ b/src/uu/paste/src/paste.rs
@@ -65,6 +65,7 @@ pub fn uu_app() -> Command {
                 .value_name("LIST")
                 .default_value("\t")
                 .hide_default_value(true)
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(OsString)),
         )
         .arg(

--- a/tests/by-util/test_paste.rs
+++ b/tests/by-util/test_paste.rs
@@ -167,6 +167,19 @@ fn test_invalid_arg() {
 }
 
 #[test]
+fn test_delimiter_hyphen_leading_as_separate_arg() {
+    // A hyphen-leading delimiter value passed as its own argument (not
+    // attached with `-d-x`/`=`) must not be mistaken for a new,
+    // unrecognized flag.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f1", "a\nb\n");
+    at.write("f2", "1\n2\n");
+    ucmd.args(&["-d", "-x", "f1", "f2"])
+        .succeeds()
+        .stdout_is("a-1\nb-2\n");
+}
+
+#[test]
 fn test_combine_pairs_of_lines() {
     for s in ["-s", "--serial"] {
         for d in ["-d", "--delimiters"] {


### PR DESCRIPTION
## What

`-d`'s value was rejected as an unrecognized flag when given as its
own argument:

```
$ paste -d -x f1 f2

# GNU: accepts it, uses '-' as the delimiter (first char of the cycle)
a-1
b-2

# uutils, before this PR:
error: unexpected argument '-x' found
  tip: to pass '-x' as a value, use '-- -x'
```

The attached forms (`-d-x`, `-d=-x`) already worked; only the
separate-argument form broke -- the same `allow_hyphen_values` gap
already fixed this session for several other options (`sort
--parallel`, `nl`'s numeric options, `ptx --gap-size`/`--width`, `join
-t`, `csplit --suffix-format`).

## Testing

- `cargo test -p uu_paste` / full `tests/by-util/test_paste.rs` suite: 21 passed, 0 failed.
- Added a regression test for the separate-argument hyphen-leading case.
- Manually diffed `-d -x`, `-d ,`, `-d -`, `-d --` against GNU paste 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_paste --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*