### PR TITLE
numfmt: accept hyphen-leading -d/--suffix/--padding values

### DIFF
--- a/src/uu/numfmt/src/numfmt.rs
+++ b/src/uu/numfmt/src/numfmt.rs
@@ -577,6 +577,7 @@ pub fn uu_app() -> Command {
                 .long(DELIMITER)
                 .value_name("X")
                 .value_parser(ValueParser::os_string())
+                .allow_hyphen_values(true)
                 .help(translate!("numfmt-help-delimiter")),
         )
         .arg(
@@ -626,7 +627,8 @@ pub fn uu_app() -> Command {
             Arg::new(PADDING)
                 .long(PADDING)
                 .help(translate!("numfmt-help-padding"))
-                .value_name("N"),
+                .value_name("N")
+                .allow_hyphen_values(true),
         )
         .arg(
             Arg::new(HEADER)
@@ -656,7 +658,8 @@ pub fn uu_app() -> Command {
             Arg::new(SUFFIX)
                 .long(SUFFIX)
                 .help(translate!("numfmt-help-suffix"))
-                .value_name("SUFFIX"),
+                .value_name("SUFFIX")
+                .allow_hyphen_values(true),
         )
         .arg(
             Arg::new(UNIT_SEPARATOR)

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -144,6 +144,41 @@ fn test_negative_padding() {
 }
 
 #[test]
+fn test_negative_padding_as_separate_arg() {
+    // A negative padding value passed as its own argument (not attached
+    // with `=`) must not be mistaken for a new, unrecognized flag.
+    new_ucmd!()
+        .args(&["--from=si", "--padding", "-8"])
+        .pipe_in("1K\n1.1M\n0.1G")
+        .succeeds()
+        .stdout_is("1000    \n1100000 \n100000000");
+}
+
+#[test]
+fn test_suffix_hyphen_leading_as_separate_arg() {
+    // A hyphen-leading suffix value passed as its own argument (not
+    // attached with `=`) must not be mistaken for a new, unrecognized
+    // flag.
+    new_ucmd!()
+        .args(&["--suffix", "-x"])
+        .pipe_in("5\n")
+        .succeeds()
+        .stdout_is("5-x\n");
+}
+
+#[test]
+fn test_delimiter_hyphen_leading_as_separate_arg() {
+    // A hyphen-leading delimiter value passed as its own argument (not
+    // attached with `-d-x`/`=`) must not be mistaken for a new,
+    // unrecognized flag.
+    new_ucmd!()
+        .args(&["-d", "-x", "--field=1"])
+        .pipe_in("5-x6")
+        .fails()
+        .stderr_contains("the delimiter must be a single character");
+}
+
+#[test]
 fn test_header() {
     new_ucmd!()
         .args(&["--from=si", "--header=2"])


### PR DESCRIPTION
## What

`-d`/`--delimiter`, `--suffix`, and `--padding` all had the same gap
already fixed this session for several other options: their value was
rejected as an unrecognized flag when given as its own argument, since
the `Arg`s were missing `allow_hyphen_values`:

```
$ echo 5 | numfmt --padding -8
# GNU: left-justifies (negative padding is meaningful)
5       ...
# uutils, before this PR:
error: unexpected argument '-8' found

$ echo 5 | numfmt --suffix -x
# GNU: 5-x
# uutils, before this PR: error: unexpected argument '-x' found

$ echo "5:6" | numfmt -d -x --field=1
# GNU: numfmt: the delimiter must be a single character
# uutils, before this PR: error: unexpected argument '-x' found
```

The attached form (`--padding=-8`, etc.) already worked; only the
separate-argument form broke -- the same gap already fixed this
session for `sort --parallel`, `nl`'s numeric options, `ptx
--gap-size`/`--width`, `join -t`, `csplit --suffix-format`, and `paste
-d`.

`--padding` already parsed its value as a signed `isize`, so no change
was needed there beyond letting clap route the value to it in the
first place.

## Testing

- `cargo test -p uu_numfmt` / full `tests/by-util/test_numfmt.rs` suite: 188 passed, 0 failed.
- Added 3 regression tests, one per option, for the separate-argument hyphen-leading case.
- Manually diffed `--suffix -x`/`x`, `--padding -5`/`5`/`-0`, and `-d -x`/`:` against GNU numfmt 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_numfmt --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*