### PR TITLE
stat: accept a hyphen-leading --format/--printf/-c value

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -1540,12 +1540,14 @@ pub fn uu_app() -> Command {
                 .short('c')
                 .long(options::FORMAT)
                 .help(translate!("stat-help-format"))
-                .value_name("FORMAT"),
+                .value_name("FORMAT")
+                .allow_hyphen_values(true),
         )
         .arg(
             Arg::new(options::PRINTF)
                 .long(options::PRINTF)
                 .value_name("FORMAT")
+                .allow_hyphen_values(true)
                 .help(translate!("stat-help-printf")),
         )
         .arg(

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -25,6 +25,25 @@ fn test_invalid_option() {
     new_ucmd!().arg("-w").arg("-q").arg("/").fails();
 }
 
+#[test]
+fn test_format_hyphen_leading_as_separate_arg() {
+    // A hyphen-leading format string passed as its own argument (not
+    // attached with `=`) must not be mistaken for a new, unrecognized
+    // flag.
+    new_ucmd!()
+        .args(&["--format", "-%n", "/"])
+        .succeeds()
+        .stdout_is("-/\n");
+    new_ucmd!()
+        .args(&["--printf", "-%n", "/"])
+        .succeeds()
+        .stdout_is("-/");
+    new_ucmd!()
+        .args(&["-c", "-%n", "/"])
+        .succeeds()
+        .stdout_is("-/\n");
+}
+
 #[cfg(unix)]
 const NORMAL_FORMAT_STR: &str =
     "%a %A %b %B %d %D %f %F %g %G %h %i %m %n %o %s %u %U %x %X %y %Y %z %Z"; // avoid "%w %W" (birth/creation) due to `stat` limitations and linux kernel & rust version capability variations


### PR DESCRIPTION
## What

`--format` (`-c`) and `--printf`'s value was rejected as an
unrecognized flag when given as its own argument:

```
$ stat --format -x /tmp

# GNU: outputs "-x" literally (a format string with no % directives)
-x

# uutils, before this PR:
error: unexpected argument '-x' found
  tip: to pass '-x' as a value, use '-- -x'
```

The attached forms (`-c-x`, `--format=-x`) already worked; only the
separate-argument form broke -- the same `allow_hyphen_values` gap
already fixed this session for several other options (`sort
--parallel`, `nl`'s numeric options, `ptx --gap-size`/`--width`, `join
-t`, `csplit --suffix-format`, `paste -d`, `numfmt`
`-d`/`--suffix`/`--padding`).

## Testing

- `cargo test --features stat -p uu_stat` / full `tests/by-util/test_stat.rs` suite: 44 passed, 0 failed.
- Added a regression test covering all three spellings (`--format`, `--printf`, `-c`) with the separate-argument hyphen-leading case.
- Manually diffed `--format -x`, `--printf -x`, `-c -x` against GNU stat 9.11 under `LC_ALL=C`.
- `cargo clippy -p uu_stat --all-targets -- -D warnings` and `cargo fmt --check`: clean.

----

*This PR was written with AI assistance (Claude Opus 5, via Claude Code). I've tested the changes but please review the code carefully.*