### PR TITLE
ptx: report that -g/-w negatve_num as invalid

### DIFF
--- a/src/uu/ptx/src/ptx.rs
+++ b/src/uu/ptx/src/ptx.rs
@@ -1041,6 +1041,8 @@ pub fn uu_app() -> Command {
             Arg::new(options::GAP_SIZE)
                 .short('g')
                 .long(options::GAP_SIZE)
+                // report -NUM as invalid value
+                .allow_hyphen_values(true)
                 .value_parser(value_parser!(u64).range(1..))
                 .help(translate!("ptx-help-gap-size"))
                 .value_name("NUMBER"),
@@ -1082,6 +1084,8 @@ pub fn uu_app() -> Command {
             Arg::new(options::WIDTH)
                 .short('w')
                 .long(options::WIDTH)
+                // report -NUM as invalid value
+                .allow_hyphen_values(true)
                 .value_parser(value_parser!(u64).range(1..))
                 .help(translate!("ptx-help-width"))
                 .value_name("NUMBER"),


### PR DESCRIPTION
Closes https://github.com/uutils/coreutils/pull/14315

No need to remove clap just for reporting `-g -5` as (invalid) value:
```
> target/debug/ptx -g -5 f
error: invalid value '-5' for '--gap-size <NUMBER>': invalid digit found in string

For more information, try '--help'.
```