### PR TITLE
ls: enable locale-aware decimal separator for -h/--human-readable

### DIFF
--- a/src/uu/ls/Cargo.toml
+++ b/src/uu/ls/Cargo.toml
@@ -33,6 +33,7 @@ uucore = { workspace = true, features = [
   "fsext",
   "fsxattr",
   "i18n-collator",
+  "i18n-decimal",
   "parser-size",
   "parser-glob",
   "quoting-style",

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -1766,6 +1766,25 @@ fn test_ls_long_total_size() {
 }
 
 #[test]
+#[cfg(unix)]
+#[cfg_attr(wasi_runner, ignore = "WASI: locale env vars not propagated")]
+fn test_human_readable_uses_locale_decimal_separator() {
+    // GNU's -h/--human-readable fraction follows LC_NUMERIC (e.g. "4,0K"
+    // under fr_FR, not "4.0K"); this implementation's own human-readable
+    // formatter has the same locale-aware logic, but ls's own Cargo.toml
+    // was missing the uucore feature flag that turns it on, so this
+    // silently always used '.' regardless of locale.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("f", &"a".repeat(4000));
+    ucmd.env("LC_ALL", "fr_FR.UTF-8")
+        .arg("-l")
+        .arg("-h")
+        .arg("f")
+        .succeeds()
+        .stdout_contains("4,0K");
+}
+
+#[test]
 #[cfg(not(feature = "selinux"))]
 // Disabled on the SELinux runner for now
 fn test_ls_long_formats() {


### PR DESCRIPTION
## Summary

`ls -lh`'s human-readable size column ignores `LC_NUMERIC`'s decimal separator — it always shows e.g. `4.0K`, even under a locale like `fr_FR.UTF-8` where GNU `ls -lh` shows `4,0K`. `du -h` and `numfmt --to=iec` already handle this correctly in this implementation.

Root cause: `uucore::format::human::human_readable()` has had locale-aware decimal-separator logic all along, gated behind the `i18n-decimal` uucore feature flag (`localize_decimal`, see `src/uucore/src/lib/features/format/human.rs`). `du`'s and `numfmt`'s `Cargo.toml` already enable that feature; `ls`'s did not, so it silently compiled against the feature's no-op fallback and always used `.` regardless of locale.

Fix is a one-line addition of `"i18n-decimal"` to `ls`'s uucore feature list in `src/uu/ls/Cargo.toml`, matching `du` and `numfmt`.

Fixes #14232

## Test plan
- [x] Added `test_human_readable_uses_locale_decimal_separator` in `tests/by-util/test_ls.rs`, asserting `ls -lh` under `LC_ALL=fr_FR.UTF-8` shows `4,0K` for a 4000-byte file
- [x] Verified the new test fails against pre-fix code (reverted the Cargo.toml change locally, confirmed the test fails with `4.0K` instead of `4,0K`)
- [x] `cargo test --features feat_os_unix --test tests -- test_ls` — 187 passed, 1 ignored (WASI-only)
- [x] `cargo clippy -p uu_ls --all-targets -- -D warnings` — clean
- [x] Manually verified against real GNU `ls -lh` under `fr_FR.UTF-8`, `de_DE.UTF-8`, and `LC_NUMERIC=C` (unaffected) — matches in all three cases

---
AI-assisted-by: Claude Opus 5, via Claude Code