### PR TITLE
ls: round block counts up when scaling to a block size

### DIFF
--- a/src/uu/ls/src/ls.rs
+++ b/src/uu/ls/src/ls.rs
@@ -1342,15 +1342,13 @@ fn write_directory_entries<O: LsOutput>(
     output: &mut O,
 ) -> UResult<()> {
     if config.format == Format::Long || config.alloc_size {
-        let total_size: u64 = entries
+        // GNU adds up the allocated bytes and scales the sum once, so a
+        // partly used block is rounded up for the total, not once per file.
+        let total_bytes: u64 = entries
             .iter()
-            .map(|item| {
-                item.metadata()
-                    .as_ref()
-                    .map_or(0, |md| get_block_size(md, config))
-            })
+            .map(|item| item.metadata().as_ref().map_or(0, |md| get_block_bytes(md)))
             .sum();
-        output.write_total(total_size, config)?;
+        output.write_total(scale_block_bytes(total_bytes, config), config)?;
     }
 
     if matches!(output.stream_mode(), StreamMode::Streaming) {
@@ -1564,23 +1562,22 @@ fn get_metadata_with_deref_opt(p_buf: &Path, dereference: bool) -> std::io::Resu
     }
 }
 
+/// Allocated size of a file in bytes, before it is scaled to the block size.
+///
+/// This is the figure the `total` line sums: GNU scales the sum once, so
+/// scaling every file first and adding the results would round several times
+/// over and overshoot the total.
 #[allow(unused_variables)]
-fn get_block_size(md: &Metadata, config: &Config) -> u64 {
+fn get_block_bytes(md: &Metadata) -> u64 {
     /* GNU ls will display sizes in terms of block size
        md.len() will differ from this value when the file has some holes
     */
     #[cfg(unix)]
     {
-        use uucore::format::human::SizeFormat;
-
-        let raw_blocks = if md.file_type().is_char_device() || md.file_type().is_block_device() {
+        if md.file_type().is_char_device() || md.file_type().is_block_device() {
             0u64
         } else {
             md.blocks() * 512
-        };
-        match config.size_format {
-            SizeFormat::Binary | SizeFormat::Decimal => raw_blocks,
-            SizeFormat::Bytes => raw_blocks / config.block_size,
         }
     }
     #[cfg(not(unix))]
@@ -1588,6 +1585,35 @@ fn get_block_size(md: &Metadata, config: &Config) -> u64 {
         // no way to get block size for windows, fall-back to file size
         md.len()
     }
+}
+
+/// Scale an allocated size in bytes to `config.block_size`.
+///
+/// A partly used block still occupies a whole block, so the division rounds
+/// up: with `--block-size=1000`, 4096 allocated bytes are five blocks, not
+/// four. `-h`/`--si` keep the byte count, which the human-readable formatter
+/// scales itself.
+#[allow(unused_variables)]
+fn scale_block_bytes(bytes: u64, config: &Config) -> u64 {
+    #[cfg(unix)]
+    {
+        use uucore::format::human::SizeFormat;
+
+        match config.size_format {
+            SizeFormat::Binary | SizeFormat::Decimal => bytes,
+            SizeFormat::Bytes => bytes.div_ceil(config.block_size),
+        }
+    }
+    // On non-unix `get_block_bytes` falls back to the file size rather than an
+    // allocation figure, which was never scaled here. Left as it was.
+    #[cfg(not(unix))]
+    {
+        bytes
+    }
+}
+
+fn get_block_size(md: &Metadata, config: &Config) -> u64 {
+    scale_block_bytes(get_block_bytes(md), config)
 }
 
 #[cfg(unix)]

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -6079,6 +6079,46 @@ fn test_posixly_correct_and_block_size_env_vars_with_k() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_ls_block_size_rounds_up() {
+    // A block that is only partly used still occupies a whole block, so
+    // scaling an allocation to the block size rounds up. The total scales the
+    // sum of the allocations once; rounding every file first and adding the
+    // results overshoots it.
+    use std::os::unix::fs::MetadataExt;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkdir("dir");
+    for name in ["dir/a", "dir/b", "dir/c"] {
+        at.write(name, "x");
+    }
+
+    let allocated: Vec<u64> = ["dir/a", "dir/b", "dir/c"]
+        .iter()
+        .map(|name| at.metadata(name).blocks() * 512)
+        .collect();
+    // An allocation that is a whole number of blocks, or none at all, cannot
+    // tell rounding up from rounding down.
+    if allocated
+        .iter()
+        .any(|bytes| bytes == &0 || bytes % 1000 == 0)
+    {
+        return;
+    }
+    let sizes: Vec<u64> = allocated.iter().map(|bytes| bytes.div_ceil(1000)).collect();
+    let total = allocated.iter().sum::<u64>().div_ceil(1000);
+
+    ucmd.arg("-s")
+        .arg("--block-size=1000")
+        .arg("dir")
+        .succeeds()
+        .stdout_is(format!(
+            "total {total}\n{} a\n{} b\n{} c\n",
+            sizes[0], sizes[1], sizes[2]
+        ));
+}
+
+#[test]
 fn test_ls_invalid_block_size() {
     new_ucmd!()
         .arg("--block-size=invalid")


### PR DESCRIPTION
`ls -s --block-size=1000` on a 4096-byte allocation printed 4 blocks. A block
that is only partly used still occupies a whole block, so it is 5:

```console
$ ls -s --block-size=1000 dir     # GNU
total 13
5 a1
5 a2
5 a3
$ ls -s --block-size=1000 dir     # uutils, before
total 12
4 a1
4 a2
4 a3
```

Every block size that is not a divisor of the allocation was off the same way:
`--block-size=M` on a 4 KiB file printed `0`, `--block-size=3000` printed 1
where it should print 2. `--block-size=512`, `2048` and the default `1024`
divide evenly on a 4 KiB allocation, which is why the existing tests never
caught it.

## The `total` line

`total` had a second defect on top of the first. It summed the already scaled
per-file figures, so the rounding error was repeated once per entry:

```console
$ ls -s --block-size=1000 dir     # three 4096-byte allocations
total 13                          # GNU: ceil(12288 / 1000)
total 15                          # what per-file rounding would give
```

GNU adds up the allocated bytes and scales the sum once. Rounding up per file
and then adding, which is what a one-line fix in the scaling function alone
would produce, overshoots by up to one block per entry.

So the two steps are split apart: `get_block_bytes` reports the allocation in
bytes, `scale_block_bytes` scales a byte count to the block size and rounds up.
The per-file cell scales one file; `total` scales the sum. `-h`/`--si` pass the
byte count through, as before, since the human-readable formatter scales it
itself.

Non-unix has no allocation figure and falls back to the file size, which was
never scaled here. `scale_block_bytes` leaves it alone, so that path is
unchanged; `cargo check --target x86_64-pc-windows-gnu` is clean.

## How the GNU behavior was established

By running the installed GNU binary as a black box and recording its output --
the rounding rule and the `total` semantics above are both read off the
transcripts shown here. I did not read GNU coreutils source.

## Testing

- `cargo test --features ls --no-default-features -- test_ls`: **160 passed, 0
  failed** (159 pre-existing, 1 new). No existing test needed a change.
- New `test_ls_block_size_rounds_up` derives its expectations from the
  filesystem's own `blocks()` rather than assuming a 4 KiB granularity, and
  returns early when the allocation divides evenly, so it cannot fail spuriously
  on a filesystem with a different allocation unit.
- Mutation check: reverting `ls.rs` alone (test file untouched) makes the new
  test fail.
- `cargo fmt --all --check` and `cargo clippy -p uu_ls --all-targets`: clean.
- Differential A/B against GNU coreutils 9.7 in `debian:stable-slim`, 17 block
  sizes x 9 flag combinations over a directory of 6 files, a subdirectory, a
  symlink and a FIFO: **63 cases moved from differing to byte-identical, 0
  regressions**. The `LS_BLOCK_SIZE`, `BLOCK_SIZE` and `BLOCKSIZE` paths match
  GNU too, where they did not before.

The 27 cases that still differ are all suffix-only block sizes (`K`, `KB`, `M`),
where GNU prints the unit with the number (`4K`, not `4`). That is a separate
defect in a different place -- the same one #13655 is fixing for `du` -- and the
figures themselves now agree there as well.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy
in CONTRIBUTING.md. Every GNU behavior quoted above came from running the
installed binary, not from reading GPL source. All testing was run locally.
