### PR TITLE
sort: apply -n to the key, not the whole line

### DIFF
--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -20,9 +20,7 @@ use self_cell::self_cell;
 use uucore::error::{UResult, USimpleError, strip_errno};
 use uucore::translate;
 
-use crate::{
-    GeneralBigDecimalParseResult, GlobalSettings, Line, SortMode, numeric_str_cmp::NumInfo,
-};
+use crate::{GeneralBigDecimalParseResult, GlobalSettings, Line, numeric_str_cmp::NumInfo};
 
 const ALLOC_CHUNK_SIZE: usize = 64 * 1024;
 const MAX_TOKEN_BUFFER_BYTES: usize = 4 * 1024 * 1024;
@@ -312,7 +310,7 @@ fn parse_lines<'a>(
             .parsed_floats
             .reserve(estimated.saturating_mul(settings.precomputed.floats_per_line));
     }
-    if settings.mode == SortMode::Numeric {
+    if settings.precomputed.whole_line_numeric {
         line_data.line_num_floats.reserve(estimated);
     }
     let mut start = 0usize;

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -332,6 +332,7 @@ struct Precomputed {
     fast_lexicographic: bool,
     fast_locale_collation: bool,
     fast_ascii_insensitive: bool,
+    whole_line_numeric: bool,
     tokenize_blank_thousands_sep: bool,
     tokenize_allow_unit_after_blank: bool,
 }
@@ -397,6 +398,27 @@ impl GlobalSettings {
         self.precomputed.fast_locale_collation =
             disable_fast_lexicographic && self.can_use_fast_lexicographic();
         self.precomputed.fast_ascii_insensitive = self.can_use_fast_ascii_insensitive();
+        self.precomputed.whole_line_numeric = self.can_use_whole_line_numeric();
+    }
+
+    /// Returns true when a number parsed from the whole line can stand in for
+    /// the key.
+    ///
+    /// `-n` parses the line once up front and compares those numbers before
+    /// looking at any key. That is only the same comparison when the single
+    /// key spans the entire line: `-n -k1.2` sorts on the line's second
+    /// character onwards, and `-n -t. -k2` on its second field, neither of
+    /// which the line as a whole stands for. A key of its own `r` also has to
+    /// go the long way, since the shortcut only knows the global one.
+    fn can_use_whole_line_numeric(&self) -> bool {
+        self.mode == SortMode::Numeric && self.selectors.len() == 1 && {
+            let selector = &self.selectors[0];
+            selector.settings.mode == SortMode::Numeric
+                && !selector.settings.reverse
+                && selector.from.field == 1
+                && selector.from.char == 1
+                && selector.to.is_none()
+        }
     }
 
     /// Returns true when the fast lexicographic path can be used safely.
@@ -654,7 +676,7 @@ impl<'a> Line<'a> {
             || settings.precomputed.selections_per_line > 0
             || settings.precomputed.num_infos_per_line > 0
             || settings.precomputed.floats_per_line > 0
-            || settings.mode == SortMode::Numeric;
+            || settings.precomputed.whole_line_numeric;
         if !needs_line_data {
             return Self { line, index };
         }
@@ -667,7 +689,7 @@ impl<'a> Line<'a> {
                 &settings.precomputed,
             );
         }
-        if settings.mode == SortMode::Numeric {
+        if settings.precomputed.whole_line_numeric {
             // exclude inf, nan, scientific notation; GNU -n does not treat '+' as a sign
             let line_num_float = (!line.iter().any(u8::is_ascii_alphabetic))
                 .then(|| std::str::from_utf8(line).ok())

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -326,6 +326,56 @@ fn test_numeric_sort_rejects_leading_plus_sign() {
 }
 
 #[test]
+fn test_numeric_sort_uses_the_key_not_the_whole_line() {
+    // `-n` compares a number parsed from the line as a whole, which only
+    // stands for the key when the key is the whole line.
+
+    // Character offset: the key is "9" and "1", so 21 comes first. Comparing
+    // the lines instead puts 19 first.
+    new_ucmd!()
+        .args(&["-n", "-k1.2"])
+        .pipe_in("19\n21\n")
+        .succeeds()
+        .stdout_is("21\n19\n");
+
+    // Field: with '.' as the separator the key is "9" and "1" again, while
+    // both lines parse as numbers on their own.
+    new_ucmd!()
+        .args(&["-n", "-t.", "-k2"])
+        .pipe_in("1.9\n2.1\n")
+        .succeeds()
+        .stdout_is("2.1\n1.9\n");
+
+    // A key that reverses on its own: the shortcut only knows the global
+    // ordering, so it has to go the long way.
+    new_ucmd!()
+        .args(&["-n", "-k1r"])
+        .pipe_in("19\n21\n3\n")
+        .succeeds()
+        .stdout_is("3\n21\n19\n");
+
+    // Equal keys fall back to comparing the lines byte by byte, not
+    // numerically.
+    new_ucmd!()
+        .args(&["-n", "-k1.2"])
+        .pipe_in("1\n10\n2\n20\n3\n")
+        .succeeds()
+        .stdout_is("1\n10\n2\n20\n3\n");
+
+    // The whole-line cases keep working.
+    new_ucmd!()
+        .arg("-n")
+        .pipe_in("19\n21\n3\n")
+        .succeeds()
+        .stdout_is("3\n19\n21\n");
+    new_ucmd!()
+        .args(&["-n", "-k1"])
+        .pipe_in("19\n21\n3\n")
+        .succeeds()
+        .stdout_is("3\n19\n21\n");
+}
+
+#[test]
 fn test_check_zero_terminated_failure() {
     new_ucmd!()
         .arg("-z")


### PR DESCRIPTION
```console
$ printf '19\n21\n' | sort -n -k1.2     # GNU
21
19
$ printf '19\n21\n' | sort -n -k1.2     # uutils, before
19
21
```

`-k1.2` selects from the second character on, so the keys are `9` and `1` and
21 sorts first. uutils compared 19 against 21 instead.

`-n` parses a number out of every line once, up front, and `compare_by` compares
those numbers before it reaches the key loop. That is the same comparison only
when the key happens to span the whole line, and nothing checked that it did.
`--debug` shows the key was selected correctly all along -- it was simply not
what got compared:

```console
$ printf '19\n21\n' | uutils sort --debug -n -k1.2
19
 _        <- the key is "9"
21
 _        <- the key is "1"
        ...and the output is still 19, 21
```

Two more shapes of the same defect:

```console
$ printf '1.9\n2.1\n' | sort -n -t. -k2   # keys "9" and "1"
GNU: 2.1, 1.9        uutils: 1.9, 2.1

$ printf '19\n21\n3\n' | sort -n -k1r     # the key reverses on its own
GNU: 3, 21, 19       uutils: 3, 19, 21
```

The last one cannot work through the shortcut at all: it compares with the
global ordering, and a key's own `r` never reaches it.

It also broke the last-resort comparison. When every key is equal, GNU falls
back to comparing the lines byte by byte:

```console
$ printf '1\n10\n2\n20\n3\n' | sort -n -k1.2   # every key empty or "0"
GNU: 1, 10, 2, 20, 3       uutils: 1, 2, 3, 10, 20
```

## The fix

`can_use_whole_line_numeric` guards the shortcut, in the shape the neighboring
`can_use_fast_lexicographic` and `can_use_fast_ascii_insensitive` already use:
one key, numeric, not reversed, starting at the first character of the first
field and running to the end of the line. Plain `-n` and `-n -k1` still take it,
so the optimization is kept where it is correct -- `sort -n` over 300k shuffled
integers is unchanged (0.051s patched vs 0.079s before, same ballpark, the
shortcut is still in play). `sort -n -k1.2` goes the long way now and costs
about 18% more, which is the price of the right answer.

`-h`, `-g`, `-M` and `-V` never had a whole-line shortcut, which is why they
were already correct here.

## How the GNU behavior was established

By running the installed GNU binary as a black box and recording its output --
every transcript above is from `debian:stable-slim` with GNU coreutils 9.7. I
did not read GNU coreutils source.

## Testing

- `cargo test --features sort --no-default-features -- test_sort`: **188 passed,
  0 failed** (187 pre-existing, 1 new). No existing test needed a change.
- New `test_numeric_sort_uses_the_key_not_the_whole_line` covers the character
  offset, the field, the key-local `r`, the last-resort fallback, and the two
  whole-line cases that must keep working.
- Mutation check: reverting `sort.rs` and `chunks.rs` alone (test file
  untouched) makes the new test fail.
- `cargo fmt --all --check` and `cargo clippy -p uu_sort --all-targets`: clean.
- Differential A/B against GNU coreutils 9.7: 12 inputs (integers, floats,
  leading blanks, negatives, `nan`/`inf`, comma- and dot-separated fields,
  non-numeric lines) x 21 flag combinations: **33 cases moved from differing to
  byte-identical, 0 regressions**.

Two cases still differ, identically before and after this change, so they are
pre-existing and unrelated: `sort -n -c` truncates the offending line in its
diagnostic (`1.10` reported as `1.1`, `nan` as `NaN`).

Also noticed while sweeping, and left alone as a separate question: GNU treats a
key's `b` as an ordering option, so `sort -n -k1b` sorts lexicographically,
while uutils applies the global `-n` to it. That is about which modifiers count
as ordering options, not about which text gets compared.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy
in CONTRIBUTING.md. Every GNU behavior quoted above came from running the
installed binary, not from reading GPL source. All testing was run locally.
