### PR TITLE
fix(deps): refactor rustix/nix package configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,15 +1930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,7 +1967,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -757,13 +757,7 @@ selinux = { workspace = true, optional = true }
 #pin_cc = { version="1.0.61, < 1.0.62", package="cc" } ## cc v1.0.62 has compiler errors for MinRustV v1.32.0, requires 1.34 (for `std::str::split_ascii_whitespace()`)
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { workspace = true, features = [
-  "process",
-  "signal",
-  "socket",
-  "term",
-  "user",
-] }
+nix = { workspace = true, features = ["fs", "signal"] }
 rlimit = { workspace = true }
 rustix = { workspace = true, features = ["net"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,8 +481,7 @@ rstest = "0.26.0"
 rstest_reuse = "0.7.0"
 rustc-hash = "2.1.1"
 rust-ini = "0.21.0"
-# raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
-rustix = { version = "1.1.4", features = ["param", "use-libc-auxv", "time"] }
+rustix = { version = "1.1.4", default-features = false }
 self_cell = "1.0.4"
 selinux = "0.6"
 string-interner = "0.20.0"
@@ -746,8 +745,11 @@ hex-literal = "1.0.0"
 rstest.workspace = true
 rstest_reuse.workspace = true
 
+[target.'cfg(all(any(target_os = "linux", all(target_os = "android", target_pointer_width = "64")), not(target_env = "musl")))'.dependencies]
+# raw-backend's linux_execfn is not supported on linux < 6.4 if /proc is not mounted. So use-libc-auxv is needed
+rustix = { workspace = true, features = ["param", "use-libc-auxv"] }
+
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-rustix.workspace = true
 selinux = { workspace = true, optional = true }
 
 # * pinned transitive dependencies
@@ -763,8 +765,7 @@ nix = { workspace = true, features = [
   "user",
 ] }
 rlimit = { workspace = true }
-rustix.workspace = true
-
+rustix = { workspace = true, features = ["net"] }
 
 [build-dependencies]
 phf_codegen.workspace = true

--- a/src/uu/base32/Cargo.toml
+++ b/src/uu/base32/Cargo.toml
@@ -17,9 +17,11 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
 uucore = { workspace = true, features = ["encoding"] }
 fluent = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [lints]
 workspace = true

--- a/src/uu/basenc/Cargo.toml
+++ b/src/uu/basenc/Cargo.toml
@@ -24,9 +24,11 @@ fluent = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
-rustix = { workspace = true, features = ["fs", "stdio"] }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+rustix = { workspace = true, features = ["fs", "stdio"] }
 
 [lints]
 workspace = true

--- a/src/uu/cat/Cargo.toml
+++ b/src/uu/cat/Cargo.toml
@@ -18,7 +18,6 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 memchr = { workspace = true }
-rustix = { workspace = true, features = ["fs"] }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["fast-inc", "fs", "pipes", "signals"] }
 fluent = { workspace = true }
@@ -28,11 +27,11 @@ divan = { workspace = true }
 tempfile = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
-
-[target.'cfg(unix)'.dev-dependencies]
-rustix = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/uu/chroot/Cargo.toml
+++ b/src/uu/chroot/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["process"] }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = ["entries", "fs"] }
 fluent = { workspace = true }

--- a/src/uu/cp/Cargo.toml
+++ b/src/uu/cp/Cargo.toml
@@ -35,10 +35,12 @@ walkdir = { workspace = true }
 indicatif = { workspace = true }
 thiserror = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 selinux = { workspace = true, optional = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "wasi"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["fs"] }
@@ -48,9 +50,6 @@ windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
 ] }
-
-[target.'cfg(target_os = "wasi")'.dependencies]
-rustix = { workspace = true, features = ["fs"] }
 
 [[bin]]
 name = "cp"

--- a/src/uu/cp/src/cp.rs
+++ b/src/uu/cp/src/cp.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore (ToDO) copydir fiemap ftruncate linkgs lstat nlink nlinks pathbuf pwrite reflink strs xattrs symlinked deduplicated advcpmv nushell IRWXG IRWXO IRWXU IRWXUGO IRWXU IRWXG IRWXO IRWXUGO sflag
+// spell-checker:ignore (ToDO) copydir fiemap linkgs lstat nlink nlinks pathbuf reflink strs xattrs symlinked deduplicated advcpmv nushell IRWXG IRWXO IRWXU IRWXUGO IRWXU IRWXG IRWXO IRWXUGO sflag
 // spell-checker:ignore RDONLY futimens utimensat
 
 use std::cmp::Ordering;

--- a/src/uu/cp/src/platform/linux.rs
+++ b/src/uu/cp/src/platform/linux.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore reflink ftruncate pwrite fiemap lseek nofollow
+// spell-checker:ignore reflink ftruncate fiemap lseek nofollow
 
 use rustix::fs::{SeekFrom, ftruncate, ioctl_ficlone, seek};
 use std::fs::File;

--- a/src/uu/dd/Cargo.toml
+++ b/src/uu/dd/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 clap = { workspace = true }
 gcd = { workspace = true }
 libc = { workspace = true }
-rustix = { workspace = true }
 uucore = { workspace = true, features = [
   "format",
   "parser-size",
@@ -29,6 +28,9 @@ uucore = { workspace = true, features = [
 ] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [[bin]]
 name = "dd"

--- a/src/uu/env/Cargo.toml
+++ b/src/uu/env/Cargo.toml
@@ -23,7 +23,7 @@ uucore = { workspace = true, features = ["signals"] }
 fluent = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["signal"] }
+nix = { workspace = true, features = ["process", "signal"] }
 
 [features]
 diagnostics = ["uucore/diagnostics"]

--- a/src/uu/expand/Cargo.toml
+++ b/src/uu/expand/Cargo.toml
@@ -18,9 +18,11 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/id/Cargo.toml
+++ b/src/uu/id/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["process"] }
 uucore = { workspace = true, features = ["entries", "process"] }
 fluent = { workspace = true }
 

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -29,7 +29,7 @@ uucore = { workspace = true, default-features = true, features = [
 fluent = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["fs"] }
 selinux = { workspace = true, optional = true }
 
 [features]

--- a/src/uu/install/Cargo.toml
+++ b/src/uu/install/Cargo.toml
@@ -20,11 +20,12 @@ thiserror = { workspace = true }
 uucore = { workspace = true, default-features = true, features = [
   "backup-control",
   "buf-copy",
+  "entries",
   "fs",
   "mode",
   "perms",
-  "entries",
   "process",
+  "safe-traversal",
 ] }
 fluent = { workspace = true }
 

--- a/src/uu/mknod/Cargo.toml
+++ b/src/uu/mknod/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 clap = { workspace = true }
 uucore = { workspace = true, features = ["fs", "mode"] }
 fluent = { workspace = true }
-nix = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
 
 [features]
 diagnostics = ["uucore/diagnostics"]

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -20,7 +20,7 @@ clap = { workspace = true }
 fs_extra = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }
-nix = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true, features = [

--- a/src/uu/nohup/Cargo.toml
+++ b/src/uu/nohup/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 libc = { workspace = true }
-rustix = { workspace = true, features = ["process", "stdio"] }
+rustix = { workspace = true, features = ["stdio"] }
 uucore = { workspace = true, features = ["fs"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }

--- a/src/uu/od/Cargo.toml
+++ b/src/uu/od/Cargo.toml
@@ -17,10 +17,12 @@ path = "src/od.rs"
 [dependencies]
 clap = { workspace = true }
 half = { workspace = true }
-rustix = { workspace = true, features = ["stdio"] }
 uucore = { workspace = true, features = ["fs", "parser-size", "pipes"] }
 fluent = { workspace = true }
 libc.workspace = true
+
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+rustix = { workspace = true, features = ["stdio"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/uu/split/Cargo.toml
+++ b/src/uu/split/Cargo.toml
@@ -18,10 +18,12 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 memchr = { workspace = true }
-rustix = { workspace = true }
 uucore = { workspace = true, features = ["fs", "parser-size"] }
 thiserror = { workspace = true }
 fluent = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [[bin]]
 name = "split"

--- a/src/uu/stat/Cargo.toml
+++ b/src/uu/stat/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
+rustix = { workspace = true, features = ["fs"] }
 uucore = { workspace = true, features = [
   "entries",
   "libc",

--- a/src/uu/sum/Cargo.toml
+++ b/src/uu/sum/Cargo.toml
@@ -18,9 +18,11 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
 uucore = { workspace = true }
 fluent = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [lints]
 workspace = true

--- a/src/uu/tee/Cargo.toml
+++ b/src/uu/tee/Cargo.toml
@@ -18,13 +18,18 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true, features = ["stdio", "fs"] }
 uucore = { workspace = true, features = ["fs", "parser", "signals"] }
 fluent = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
 uucore = { workspace = true, features = ["benchmark"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+rustix = { workspace = true, features = ["fs"] }
+
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+rustix = { workspace = true, features = ["stdio"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 rustix = { workspace = true, features = ["pipe"] }

--- a/src/uu/unexpand/Cargo.toml
+++ b/src/uu/unexpand/Cargo.toml
@@ -18,9 +18,11 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+rustix = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/wc/Cargo.toml
+++ b/src/uu/wc/Cargo.toml
@@ -31,7 +31,7 @@ unicode-width = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
-rustix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs", "param"] }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/src/uu/who/Cargo.toml
+++ b/src/uu/who/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true, features = ["termios"] }
+rustix = { workspace = true, features = ["fs", "termios"] }
 uucore = { workspace = true, features = ["utmpx"] }
 fluent = { workspace = true }
 

--- a/src/uu/yes/Cargo.toml
+++ b/src/uu/yes/Cargo.toml
@@ -19,8 +19,10 @@ doctest = false
 clap = { workspace = true }
 itertools = { workspace = true }
 fluent = { workspace = true }
-rustix = { workspace = true, features = ["stdio", "pipe"] }
 uucore = { workspace = true, features = ["fs", "pipes"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+rustix = { workspace = true, features = ["stdio", "pipe"] }
 
 [lints]
 workspace = true

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -37,7 +37,7 @@ libc = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
 os_display = { workspace = true }
 rustc-hash = { workspace = true }
-rustix = { workspace = true, features = ["fs", "net", "pipe", "process"] }
+rustix = { workspace = true, optional = true }
 # Not optional: os_display already pulls unicode-width into every uucore build,
 # so making it a direct dependency here is free and keeps char_width available
 # on all targets (a feature-gated optional dep failed to activate on wasm).
@@ -144,12 +144,12 @@ default = ["signals"]
 backup-control = []
 colors = []
 diagnostics = ["dep:ariadne"]
-checksum = ["quoting-style", "sum", "base64-simd"]
+checksum = ["base64-simd", "quoting-style", "rustix/fs", "sum"]
 encoding = ["data-encoding", "data-encoding-macro", "z85", "base64-simd"]
-entries = ["libc"]
+entries = ["libc", "rustix/fs"]
 extendedbigdecimal = ["bigdecimal", "num-traits"]
 fast-inc = []
-fs = ["dunce", "libc", "windows-sys"]
+fs = ["dunce", "libc", "rustix/fs", "windows-sys"]
 fsext = ["libc", "windows-sys", "bstr"]
 fsxattr = ["xattr", "itertools", "libc"]
 hardware = []
@@ -176,15 +176,15 @@ i18n-datetime = [
   "jiff-icu",
   "jiff",
 ]
-mode = ["libc"]
+mode = ["libc", "rustix/process"]
 perms = ["entries", "libc", "walkdir"]
-buf-copy = []
+buf-copy = ["pipes"]
 parser-num = ["extendedbigdecimal", "num-traits"]
 parser-size = ["parser-num", "procfs"]
 parser-glob = ["glob"]
 parser = ["parser-num", "parser-size", "parser-glob"]
-pipes = ["fs"]
-process = ["libc", "windows-sys"]
+pipes = ["fs", "rustix/pipe"]
+process = ["libc", "rustix/process", "windows-sys"]
 proc-info = ["tty", "walkdir"]
 quoting-style = ["i18n-common"]
 ranges = []
@@ -220,7 +220,7 @@ version-cmp = []
 wide = []
 tty = []
 time = ["jiff"]
-uptime = ["jiff", "libc", "windows-sys", "utmpx", "utmp-classic"]
+uptime = ["jiff", "libc", "rustix/time", "utmp-classic", "utmpx", "windows-sys"]
 benchmark = ["divan", "itertools", "tempfile"]
 
 [lints]

--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -103,15 +103,7 @@ time = { workspace = true, optional = true, features = [
   "local-offset",
   "macros",
 ] }
-nix = { workspace = true, features = [
-  "dir",
-  "fs",
-  "poll",
-  "signal",
-  "uio",
-  "user",
-  "zerocopy",
-] }
+nix = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
 xattr = { workspace = true, optional = true }
 
@@ -177,23 +169,23 @@ i18n-datetime = [
   "jiff",
 ]
 mode = ["libc", "rustix/process"]
-perms = ["entries", "libc", "walkdir"]
+perms = ["entries", "libc", "safe-traversal", "walkdir"]
 buf-copy = ["pipes"]
 parser-num = ["extendedbigdecimal", "num-traits"]
 parser-size = ["parser-num", "procfs"]
 parser-glob = ["glob"]
 parser = ["parser-num", "parser-size", "parser-glob"]
 pipes = ["fs", "rustix/pipe"]
-process = ["libc", "rustix/process", "windows-sys"]
+process = ["libc", "nix/user", "rustix/process", "windows-sys"]
 proc-info = ["tty", "walkdir"]
 quoting-style = ["i18n-common"]
 ranges = []
 ringbuffer = []
 safe-copy = []
-safe-traversal = ["libc"]
+safe-traversal = ["libc", "nix/fs", "nix/dir", "nix/user"]
 selinux = ["dep:selinux"]
 smack = ["xattr"]
-signals = []
+signals = ["nix/fs", "nix/signal", "nix/poll"]
 sum = [
   "digest",
   "hex",

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -77,10 +77,7 @@ pub mod mode;
 pub mod entries;
 #[cfg(all(unix, feature = "perms"))]
 pub mod perms;
-#[cfg(all(
-    any(target_os = "linux", target_os = "android"),
-    any(feature = "pipes", feature = "buf-copy")
-))]
+#[cfg(all(feature = "pipes", any(target_os = "linux", target_os = "android")))]
 pub mod pipes;
 #[cfg(all(target_os = "linux", feature = "proc-info"))]
 pub mod proc_info;

--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -86,6 +86,7 @@ pub mod process;
 #[cfg(all(unix, feature = "safe-copy"))]
 pub mod safe_copy;
 #[cfg(all(
+    feature = "safe-traversal",
     unix,
     not(any(target_os = "aix", target_os = "hurd", target_os = "redox"))
 ))]

--- a/src/uucore/src/lib/features/pipes.rs
+++ b/src/uucore/src/lib/features/pipes.rs
@@ -5,8 +5,6 @@
 
 //! Zero-copy-related functions.
 
-#![cfg(any(target_os = "linux", target_os = "android"))]
-
 use crate::io::{RawReader, RawWriter};
 use rustix::pipe::{SpliceFlags, fcntl_setpipe_size};
 use std::{

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -104,6 +104,7 @@ pub use crate::features::process;
 #[cfg(all(unix, feature = "safe-copy"))]
 pub use crate::features::safe_copy;
 #[cfg(all(
+    feature = "safe-traversal",
     unix,
     not(any(target_os = "aix", target_os = "hurd", target_os = "redox"))
 ))]

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -97,10 +97,7 @@ pub use crate::features::mode;
 pub use crate::features::entries;
 #[cfg(all(unix, feature = "perms"))]
 pub use crate::features::perms;
-#[cfg(all(
-    any(target_os = "linux", target_os = "android"),
-    any(feature = "pipes", feature = "buf-copy")
-))]
+#[cfg(all(feature = "pipes", any(target_os = "linux", target_os = "android")))]
 pub use crate::features::pipes;
 #[cfg(all(any(unix, windows), feature = "process"))]
 pub use crate::features::process;

--- a/tests/uutests/Cargo.toml
+++ b/tests/uutests/Cargo.toml
@@ -36,7 +36,7 @@ uucore = { workspace = true, features = [
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["process", "signal", "term", "user"] }
+nix = { workspace = true, features = ["fs", "term"] }
 rlimit = { workspace = true }
 
 [target.'cfg(all(unix, not(any(target_vendor = "apple", target_os = "openbsd"))))'.dependencies]


### PR DESCRIPTION
Refactor `rustix` and `nix` dependency configuration to use explicit, target-specific features.

### Benefits

- Avoid enabling unused features on platforms where they aren't needed.
- Keep platform-specific dependencies scoped to the relevant targets.
- Make the Cargo configuration easier to understand and maintain.
- Reduce unnecessary dependency features and cross-platform coupling.