### PR TITLE
tail: avoid copying each chunk buffer

### DIFF
--- a/src/uu/tail/src/chunks.rs
+++ b/src/uu/tail/src/chunks.rs
@@ -289,14 +289,14 @@ impl BytesChunkBuffer {
         // fill chunks with all bytes from reader and reuse already instantiated chunks if possible
         while chunk.fill(reader)?.is_some() {
             self.bytes += chunk.bytes as u64;
-            self.chunks.push_back(chunk.clone());
+            self.chunks.push_back(chunk);
 
             let first = &self.chunks[0];
             if self.bytes - first.bytes as u64 > self.num_print {
                 chunk = self.chunks.pop_front().unwrap();
                 self.bytes -= chunk.bytes as u64;
             } else {
-                *chunk = BytesChunk::new();
+                chunk = Box::new(BytesChunk::new());
             }
         }
 
@@ -563,15 +563,14 @@ impl LinesChunkBuffer {
 
         while chunk.fill(reader)?.is_some() {
             self.lines += chunk.lines as u64;
-            self.chunks.push_back(chunk.clone());
+            self.chunks.push_back(chunk);
 
             let first = &self.chunks[0];
             if self.lines - first.lines as u64 > self.num_print {
                 chunk = self.chunks.pop_front().unwrap();
-
                 self.lines -= chunk.lines as u64;
             } else {
-                *chunk = LinesChunk::new(self.delimiter);
+                chunk = Box::new(LinesChunk::new(self.delimiter));
             }
         }
 


### PR DESCRIPTION
Using deepseek v4 flash found another improvement.   Validated tests pass and validated with codex as well.

The example below is pretty silly tbh - not really likely that you'd pipe a 400mb file, but shows the logic is sound.

LLM below here:
---
`BytesChunkBuffer::fill` and `LinesChunkBuffer::fill` deep-copied every 8 KiB
backing buffer with `push_back(chunk.clone())`, then reused the original as the
next scratch. This moves the chunk into the deque instead and takes the next
working chunk from `pop_front()` or a fresh allocation.

In the steady state (piped input larger than `num_print`), this removes one
8 KiB heap allocation and one 8 KiB memcpy per chunk read. The `Box::new` on
the fill path is bounded to the initial fill and replaces — not adds to — the
clone's allocation, so per-chunk allocations are unchanged or fewer. No
observable behavior change.

## Allocation accounting

Steady state (large piped input — exactly what `BytesChunkBuffer`/`LinesChunkBuffer` serve, file ≫ `num_print`, so every iteration
is the `if` branch):

|          | push                             | scratch                      | per-chunk              |
|----------|----------------------------------|------------------------------|------------------------|
| baseline | `clone()` = 1 alloc + 8 KiB memcpy | `pop_front()` reuse, 0      | 1 alloc + 8 KiB memcpy |
| proposed | `move` = 0                       | `pop_front()` reuse, 0      | 0 alloc + 0 memcpy     |

For a 400 MB piped input that's ~49k heap allocs + ~400 MB of memcpy eliminated.

Small-file case (file < `num_print`, else branch every time — the only place the concern applies):

|          | push                             | scratch                            | per-chunk              |
|----------|----------------------------------|------------------------------------|------------------------|
| baseline | `clone()` = 1 alloc + 8 KiB memcpy | `*chunk = new()` in place, 0      | 1 alloc + memcpy       |
| proposed | `move` = 0                       | `Box::new()` = 1 alloc + zero-init | 1 alloc + zero-init    |



Release multicall binary: 14,000,712 -> 14,000,456 bytes (-256 B).
