### PR TITLE
basename: fix trailing-separator handling for dot components

### DIFF
--- a/src/uu/basename/src/basename.rs
+++ b/src/uu/basename/src/basename.rs
@@ -9,7 +9,7 @@ use clap::builder::ValueParser;
 use clap::{Arg, ArgAction, Command};
 use std::ffi::OsString;
 use std::io::{Write, stdout};
-use std::path::PathBuf;
+use std::path::{PathBuf, is_separator};
 use uucore::display::Quotable;
 use uucore::error::{UResult, UUsageError};
 use uucore::format_usage;
@@ -121,8 +121,20 @@ pub fn uu_app() -> Command {
 fn basename(fullname: &OsString, suffix: &OsString) -> UResult<Vec<u8>> {
     let fullname_bytes = uucore::os_str_as_bytes(fullname)?;
 
-    // Handle special case where path ends with /.
-    if fullname_bytes.ends_with(b"/.") {
+    // Path::components() normalizes a trailing `.` away. Inspect a trimmed view
+    // first so `foo/./` yields `.`, while using the original path below keeps
+    // platform-specific root paths intact.
+    let mut path_end = fullname_bytes;
+    while path_end
+        .last()
+        .is_some_and(|&byte| is_separator(char::from(byte)))
+    {
+        path_end = &path_end[..path_end.len() - 1];
+    }
+    if path_end.len() > 1
+        && path_end.ends_with(b".")
+        && is_separator(char::from(path_end[path_end.len() - 2]))
+    {
         return Ok(b".".into());
     }
 

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -48,6 +48,31 @@ fn test_file() {
 }
 
 #[test]
+fn test_trailing_separators() {
+    for (path, expected) in [
+        ("foo/bar", "bar\n"),
+        ("foo/bar/", "bar\n"),
+        ("foo/bar///", "bar\n"),
+        ("foo/./", ".\n"),
+        ("foo/.//", ".\n"),
+    ] {
+        new_ucmd!().arg(path).succeeds().stdout_only(expected);
+    }
+
+    let separator = std::path::MAIN_SEPARATOR;
+    let native_dot_path = format!("foo{separator}.{separator}{separator}");
+    new_ucmd!()
+        .arg(native_dot_path)
+        .succeeds()
+        .stdout_only(".\n");
+
+    let root = if cfg!(windows) { "\\\n" } else { "/\n" };
+    for path in ["/", "//", "///"] {
+        new_ucmd!().arg(path).succeeds().stdout_only(root);
+    }
+}
+
+#[test]
 fn test_remove_suffix() {
     new_ucmd!()
         .args(&["/usr/local/bin/reallylongexecutable.exe", ".exe"])


### PR DESCRIPTION
## Summary
- inspect operands after temporarily trimming platform path separators
- preserve a final `.` component instead of allowing `Path::components()` to normalize it away
- process the original operand afterward so root-like paths retain established behavior
- add focused tests for normal paths, single and repeated separators, native separators, and root-like inputs

## Reproduction
Before the fix, `basename 'foo/.//'` returned `foo` rather than `.`.

## Validation
- `docker run --rm -v "$PWD":/workspace -w /workspace rust:1.88.0 sh -c 'cargo test --locked --no-default-features --features basename --test tests test_basename::test_trailing_separators'`
- `docker run --rm -v "$PWD":/workspace -w /workspace rust:1.88.0 sh -c 'cargo test --locked --no-default-features --features basename --test tests test_basename::'`

<!-- repo-agent-case:24d4afa1-e1c4-41ea-b173-05d15638f024 -->