### PR TITLE
stat: fix overflow on out-of-range octal escape

### DIFF
--- a/src/uu/stat/src/stat.rs
+++ b/src/uu/stat/src/stat.rs
@@ -943,11 +943,14 @@ impl Stater {
             '"' => Token::Byte(b'"'),   // Double quote
             '0'..='7' => {
                 // Parse octal escape sequence (up to 3 digits)
-                let mut value = 0u8;
+                // Accumulate in a wider type: three octal digits can reach 511,
+                // and only the low byte is kept, which is what GNU prints for
+                // an out-of-range escape such as `\400`.
+                let mut value = 0u32;
                 let mut count = 0;
                 while *i < bound && count < 3 {
                     if let Some(digit) = chars[*i].to_digit(8) {
-                        value = value * 8 + digit as u8;
+                        value = value * 8 + digit;
                         *i += 1;
                         count += 1;
                     } else {
@@ -955,7 +958,7 @@ impl Stater {
                     }
                 }
                 *i -= 1; // Adjust index to account for the outer loop increment
-                Token::Byte(value)
+                Token::Byte(value as u8)
             }
             'x' => {
                 // Parse hexadecimal escape sequence (\xNN format)

--- a/tests/by-util/test_stat.rs
+++ b/tests/by-util/test_stat.rs
@@ -622,6 +622,17 @@ fn test_printf_octal_2() {
 }
 
 #[test]
+fn test_printf_octal_out_of_range() {
+    // Octal escapes whose value exceeds 255 wrap around, as they do in GNU stat.
+    let ts = TestScenario::new(util_name!());
+    let expected_stdout = vec![0x00, 0xFF]; // \400 -> 256 & 0xFF, \777 -> 511 & 0xFF
+    ts.ucmd()
+        .args(&["--printf=\\400\\777", "."])
+        .succeeds()
+        .stdout_is_bytes(expected_stdout);
+}
+
+#[test]
 fn test_printf_incomplete_hex() {
     let ts = TestScenario::new(util_name!());
     ts.ucmd()


### PR DESCRIPTION
## What was wrong

`stat --printf '\400'` (and any `\NNN` escape from `\400` through `\777`) aborted instead of printing a byte:

```console
$ ./target/debug/coreutils stat --printf '\400' . >/dev/null
thread 'main' panicked at src/uu/stat/src/stat.rs:950:33:
attempt to multiply with overflow
$ echo $?
101
```

Any build with overflow-checks enabled (debug builds by default, or release with `-C overflow-checks`) hits this.

## Root cause

`handle_escape_sequences` accumulated the octal escape in a `u8`:

```rust
let mut value = 0u8;
…
value = value * 8 + digit as u8;
```

Three octal digits can encode values up to 511, so as soon as the accumulated value passes `u8::MAX` the multiply overflows.

## The fix

Accumulate in a `u32` — three octal digits reach at most 511, so the arithmetic can no longer overflow — and keep the low byte when building the `Token::Byte`. That makes `\400` print `0x00` and `\777` print `0xFF`, matching what GNU `stat` outputs for an out-of-range octal escape. In-range escapes are unaffected. Only `--printf` is affected: `generate_tokens` interprets backslash escapes for `--printf` and treats them literally for `-c`/`--format`, matching GNU.

The fix was written from scratch; no GNU source was consulted or copied, only GNU's observable output for these escapes.

## How it was tested

- New regression test `test_printf_octal_out_of_range` in `tests/by-util/test_stat.rs` asserts that `--printf=\400\777` succeeds and emits the bytes `00 ff`. It fails on `main` (the command exits 101) and passes with this change.
- The full `stat` test suite passes: `cargo test --no-default-features --features stat --test tests test_stat` → 34 passed, 0 failed.
- `cargo clippy -p uu_stat --no-default-features --all-targets` is clean, and `cargo fmt` reports no changes.

Fixes #14346