### PR TITLE
tail: don't panic on '-c -N' with a huge N

### DIFF
--- a/src/uu/tail/src/tail.rs
+++ b/src/uu/tail/src/tail.rs
@@ -469,7 +469,11 @@ fn bounded_tail(file: &mut File, settings: &Settings) -> UResult<()> {
             file.seek(SeekFrom::End(0)).unwrap();
         }
         FilterMode::Bytes(Signum::Negative(count)) => {
-            if file.seek(SeekFrom::End(-(*count as i64))).is_err() {
+            // A count above `i64::MAX` has no negative counterpart to seek by,
+            // and reaches further back than any file can be long, so treat it
+            // like any other offset landing before the start of the file.
+            let offset = i64::try_from(*count).ok();
+            if offset.is_none_or(|offset| file.seek(SeekFrom::End(-offset)).is_err()) {
                 file.seek(SeekFrom::Start(0)).unwrap();
             }
             limit = Some(*count);

--- a/tests/by-util/test_tail.rs
+++ b/tests/by-util/test_tail.rs
@@ -1377,6 +1377,20 @@ fn test_positive_bytes_file_offset_past_seek_limit() {
         .no_stdout();
 }
 
+// `tail -c -N` on a seekable file larger than the block size seeks back `N`
+// bytes from the end. An `N` that does not fit in an `i64` must not abort the
+// process; it should print the whole file, like any other too-large count.
+#[test]
+fn test_negative_bytes_file_count_past_seek_limit() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    // Larger than tail's `sane_blksize` (~4 KiB) so the seek path is taken.
+    let data = "a".repeat(8192);
+    at.write("big", &data);
+    ucmd.args(&["-c", "-9223372036854775808", "big"])
+        .succeeds()
+        .stdout_is(&data);
+}
+
 #[test]
 fn test_num_with_undocumented_sign_bytes() {
     // tail: '-' is not documented (8.32 man pages)


### PR DESCRIPTION
Fixes #14353.

`tail -c -9223372036854775808 FILE` on a seekable file larger than the block size aborts with `attempt to negate with overflow` (exit 101) in a build with overflow checks, and wraps silently in a release build.

`bounded_tail` built the backwards seek offset for `-c -N` as `-(*count as i64)`. `count` is a `u64`, so `2^63` casts to `i64::MIN`, and negating `i64::MIN` overflows.

I now convert the count with `i64::try_from` before negating it. A count that doesn't fit in an `i64` reaches further back than any file can be long, so it falls into the branch the arm already had for an offset landing before the start of the file: seek to 0 and print the whole file. That matches what `-c -N` already does for any other N larger than the file.

Tested with a new test in `tests/by-util/test_tail.rs` that runs `-c -9223372036854775808` against an 8 KiB file (larger than `sane_blksize`, so the seek path is taken) and expects the whole file back. It fails with exit 101 before the change and passes after. I also ran the rest of `test_tail` and `cargo clippy -p uu_tail`. Everything was run on macOS only; `test_follow_detects_file_truncation` is flaky here under load, but it fails the same way on an unmodified checkout.