### PR TITLE
ls: fix panic on a color style with no attributes

### DIFF
--- a/src/uu/ls/src/colors.rs
+++ b/src/uu/ls/src/colors.rs
@@ -205,10 +205,9 @@ impl<'a> StyleManager<'a> {
         self.current_style = Some(*new_style);
         let mut nu_a_style = new_style.to_nu_ansi_term_style();
         nu_a_style.prefix_with_reset = false;
-        let mut ret = nu_a_style.paint("").to_string();
-        // remove the suffix reset
-        ret.truncate(ret.len() - 4);
-        ret
+        // `prefix()` yields the escape sequence on its own, and an empty string
+        // for a style without any attribute, so there is no trailing reset to strip
+        nu_a_style.prefix().to_string()
     }
 
     pub(crate) fn is_current_style(&self, new_style: &Style) -> bool {

--- a/tests/by-util/test_ls.rs
+++ b/tests/by-util/test_ls.rs
@@ -6806,6 +6806,24 @@ fn test_ls_color_norm() {
         .stdout_contains(expected);
 }
 
+// A style that renders to an empty ANSI sequence, such as the default
+// foreground color, used to make `ls --color` panic while stripping the
+// trailing reset from the style code.
+#[test]
+fn test_ls_color_empty_style() {
+    let scene = TestScenario::new(util_name!());
+    let at = &scene.fixtures;
+    at.touch("f");
+
+    scene
+        .ucmd()
+        .env("LS_COLORS", "no=39")
+        .arg("--color=always")
+        .arg("f")
+        .succeeds()
+        .stdout_only("\u{1b}[0mf\u{1b}[0m\n");
+}
+
 #[test]
 fn test_ls_color_clear_to_eol() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Fixes #14360

`ls --color=always` panics with "attempt to subtract with overflow" in debug builds when an `LS_COLORS` entry yields a style that has no attributes, for example:

```console
$ mkdir d && touch d/f
$ LS_COLORS='no=39' ./target/debug/ls --color=always d >/dev/null
thread 'main' panicked at src/uu/ls/src/colors.rs:210:22:
attempt to subtract with overflow
```

`get_style_code` painted an empty string with nu-ansi-term and then stripped the trailing `\x1b[0m` with `ret.truncate(ret.len() - 4)`. A style with no attributes paints to an empty string, so there is no trailing reset to strip and the subtraction underflows on `usize`.

Rather than painting and then stripping, this asks nu-ansi-term for the prefix directly with `nu_a_style.prefix().to_string()`. That returns the escape sequence on its own, and an empty string for a style with no attributes, so there is nothing to strip and the underflow cannot happen. `Style::write_prefix` and `write_suffix` are gated on the same `is_plain()` check, so the result is byte-identical to the old code for every style that previously worked: `\x1b[07m\x1b[0m` still becomes `\x1b[07m`.

Tested with the new `test_ls_color_empty_style` in `tests/by-util/test_ls.rs`, which pins the exact output. Without the fix it fails with the panic and exit code 101; with the fix it passes. The other `--color` tests still pass (`cargo test --test tests --features ls test_ls_color`, 7 passed), `cargo clippy -p uu_ls --all-targets` is clean, and `rustfmt --check` passes on both touched files.

One thing I did not change and want to flag: with `no=39` the style is normalized away entirely, so we emit no `\x1b[39m` for it. That is a separate compatibility question from the panic, so I left it out of this PR. The test pins current behavior, which makes that gap easy to spot if someone fixes it later. I built and tested only the `ls` crate and the `tests` target locally, not the full workspace.
