### PR TITLE
split: fix overflow on a huge -n l/K/N chunk count

### DIFF
--- a/src/uu/split/src/split.rs
+++ b/src/uu/split/src/split.rs
@@ -1148,22 +1148,28 @@ fn n_chunks_by_line(
         // empty files in place(s) of skipped chunk(s)
         let num_line_bytes = bytes.len() as u64;
         num_bytes_written += num_line_bytes;
-        let mut skipped = -1;
+        let first_chunk_number = chunk_number;
         // Cap at the last chunk to avoid an infinite loop when trailing chunks are
         // zero-sized, and keep excess input from indexing past out_files.
         while chunk_number < num_chunks && num_bytes_should_be_written <= num_bytes_written {
-            num_bytes_should_be_written +=
-                chunk_size_base + (chunk_size_reminder > chunk_number) as u64;
+            let chunk_size = chunk_size_base + (chunk_size_reminder > chunk_number) as u64;
+            if chunk_size == 0 {
+                // Every remaining chunk is zero-sized as well, so all of them
+                // would be skipped one at a time, which takes prohibitively
+                // long for a huge number of chunks. Jump to the last one.
+                chunk_number = num_chunks;
+                break;
+            }
+            num_bytes_should_be_written += chunk_size;
             chunk_number += 1;
-            skipped += 1;
         }
 
         // If a chunk was skipped and `elide_empty_files` flag is set,
         // roll chunk_number back to preserve sequential continuity
         // of file names for files written to,
         // except for Kth chunk of N mode
-        if settings.elide_empty_files && skipped > 0 && kth_chunk.is_none() {
-            chunk_number -= skipped as u64;
+        if settings.elide_empty_files && kth_chunk.is_none() {
+            chunk_number = chunk_number.min(first_chunk_number + 1);
         }
         if kth_chunk.is_some_and(|k| chunk_number > k) {
             break;

--- a/tests/by-util/test_split.rs
+++ b/tests/by-util/test_split.rs
@@ -1290,6 +1290,20 @@ fn test_number_by_lines_fewer_bytes_than_chunks_elide() {
     assert!(!at.plus("xac").exists());
 }
 
+/// A huge chunk count must not overflow the skipped-chunk counter.
+///
+/// With far more chunks than input bytes, all of the trailing chunks are
+/// zero-sized and get skipped in one go. Counting them used to overflow and
+/// panic in a build with overflow checks enabled.
+#[test]
+fn test_number_by_lines_kth_huge_number_of_chunks() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("in", "a");
+    ucmd.args(&["-n", "l/1/9999999999", "in"])
+        .succeeds()
+        .stdout_only("a");
+}
+
 #[test]
 #[cfg(unix)]
 fn test_number_by_lines_kth_dev_null() {


### PR DESCRIPTION
## What was wrong

`split -n l/K/N FILE` panicked with `attempt to add with overflow` (exit 101) under overflow checks when `N` was very large:

```console
$ head -c 100000 /dev/zero | tr '\0' a > big
$ split -n l/1/9999999999 big > /dev/null
thread 'main' panicked at src/uu/split/src/split.rs:1158:13:
attempt to add with overflow
```

A release build wrapped the counter silently instead, but still spent minutes spinning before it finished.

## Root cause

`n_chunks_by_line` advances to the next chunk one chunk at a time. When the input is shorter than the requested number of chunks, every trailing chunk is zero-sized, so `num_bytes_should_be_written` stops growing and the loop condition stays true until `chunk_number` reaches `num_chunks` — up to `N` iterations. The count of chunks stepped over was `let mut skipped = -1;`, which is inferred as `i32`, so it overflowed once `N` passed `i32::MAX`.

Just widening the counter is not enough: `N` is parsed as a `u64`, so it can exceed `i64::MAX`, and the loop would still step through all `N` chunks — effectively forever for `N` near `u64::MAX`.

## The fix

- As soon as the loop reaches a zero-sized chunk, jump to the last chunk and stop. Every chunk after a zero-sized one is zero-sized too, so this reaches exactly the same chunk number that stepping one at a time would, without the iterations.
- Drop the `skipped` counter and take the `--elide-empty-files` rollback from the chunk number captured before the loop (`chunk_number.min(first_chunk_number + 1)`). This is equivalent to the previous `chunk_number -= skipped` and leaves no counter that can overflow.

Output is unchanged: `-n l/1/9999999999` on a short input now produces what `-n l/1/3`, `-n l/1/100` and `-n l/1/1000000` already produced, and the existing elide-empty-files behaviour is untouched.

## How it was tested

- Added `test_number_by_lines_kth_huge_number_of_chunks` in `tests/by-util/test_split.rs`. On `main` it fails (the run is killed by the 30s test timeout; run by hand the binary panics and exits 101), and it passes with this change.
- The full split suite passes: `cargo test --no-default-features --features split --test tests test_split` → 119 passed, 0 failed.
- Manually: `split -n l/1/9999999999 big` now exits 0 immediately with the full 100000 bytes, and `split -n l/1/18446744073709551615 big` works as well.
- `cargo clippy -p uu_split --all-targets` is clean, `cargo fmt` reports no changes.

Fixes #14328