### PR TITLE
date: apply the ^ and # case flags per specifier

### DIFF
--- a/src/uu/date/src/format_modifiers.rs
+++ b/src/uu/date/src/format_modifiers.rs
@@ -19,7 +19,9 @@
 //! - `_`: Pad with spaces instead of zeros
 //! - `0`: Pad with zeros (default for numeric fields)
 //! - `^`: Convert to uppercase
-//! - `#`: Use opposite case (uppercase becomes lowercase and vice versa)
+//! - `#`: Use opposite case (uppercase becomes lowercase and vice versa).
+//!   Only the specifiers that emit a name (`%a %A %b %B %h %p %P %Z`) honor it,
+//!   and there it takes precedence over `^`
 //! - `+`: Force display of sign (+ for positive, - for negative)
 //!
 //! ### Width
@@ -265,6 +267,24 @@ fn is_text_specifier(specifier: &str) -> bool {
     )
 }
 
+/// Returns true if GNU's conversion for `specifier` honors the `#`
+/// (opposite case) flag.
+///
+/// Only the conversions that emit a locale name or abbreviation look at `#`.
+/// Composite specifiers such as `%c` and `%r` are expanded recursively without
+/// it, so `%#c` and `%#r` print like `%c` and `%r`, while `^` still reaches
+/// into that expansion.
+///
+/// This deliberately duplicates the list in `is_text_specifier` rather than
+/// calling it: that one classifies specifiers for padding, and the two sets
+/// only happen to coincide today.
+fn honors_opposite_case(specifier: &str) -> bool {
+    matches!(
+        specifier.chars().last(),
+        Some('A' | 'a' | 'B' | 'b' | 'h' | 'Z' | 'p' | 'P')
+    )
+}
+
 /// Returns true if the specifier defaults to space padding.
 /// This includes text specifiers and numeric specifiers like %e and %k
 /// that use blank-padding by default in GNU date.
@@ -391,10 +411,8 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
             }
             '^' => {
                 uppercase = true;
-                swap_case = false; // ^ overrides #
             }
-            '#' if !uppercase => {
-                // Only apply # if ^ hasn't been set
+            '#' => {
                 swap_case = true;
             }
             '+' => {
@@ -406,7 +424,15 @@ fn apply_modifiers(value: &str, parsed: &ParsedSpec<'_>) -> Result<String, Forma
         }
     }
 
-    // Apply case modifications (uppercase takes precedence over swap_case)
+    // GNU applies the case flags inside each conversion rather than to the
+    // whole rendered string, so `#` only reaches the specifiers that emit a
+    // name, and where it applies it wins over `^`: `%^#p` and `%#^p` both
+    // print `pm`.
+    let swap_case = swap_case && honors_opposite_case(specifier);
+    // `%P` is the lower-case form of `%p` and stays lower case whatever the
+    // flags ask for, so `%^P` prints `pm`.
+    let uppercase = uppercase && !swap_case && !specifier.ends_with('P');
+
     if uppercase {
         result = result.to_uppercase();
     } else if swap_case {

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2742,7 +2742,7 @@ fn test_date_format_modifier_combined_flags() {
 
 #[test]
 fn test_date_format_modifier_case_precedence() {
-    // Test that ^ (uppercase) takes precedence over # (swap case) regardless of order
+    // "June" is upper-cased by either flag, so %^#B and %#^B agree
     new_ucmd!()
         .env("TZ", "UTC")
         .env("LC_ALL", "C")
@@ -2756,6 +2756,56 @@ fn test_date_format_modifier_case_precedence() {
         .args(&["-d", "1999-06-01", "+%#^B"])
         .succeeds()
         .stdout_is("JUNE\n");
+}
+
+#[test]
+fn test_date_format_modifier_case_flags_per_specifier() {
+    // GNU applies `^` and `#` inside each conversion instead of to the whole
+    // rendered string. Only the specifiers that emit a name honor `#`, and
+    // there it wins over `^`; the composite `%c` and `%r` are expanded without
+    // it, and `%P` stays lower case whatever the flags ask for.
+    let cases = [
+        ("%c", "Sat Jun 15 13:05:03 2024"),
+        ("%^c", "SAT JUN 15 13:05:03 2024"),
+        ("%#c", "Sat Jun 15 13:05:03 2024"),
+        ("%r", "01:05:03 PM"),
+        ("%^r", "01:05:03 PM"),
+        ("%#r", "01:05:03 PM"),
+        ("%p", "PM"),
+        ("%^p", "PM"),
+        ("%#p", "pm"),
+        ("%^#p", "pm"),
+        ("%#^p", "pm"),
+        ("%P", "pm"),
+        ("%^P", "pm"),
+        ("%#P", "pm"),
+        ("%^#P", "pm"),
+        ("%Z", "UTC"),
+        ("%^Z", "UTC"),
+        ("%#Z", "utc"),
+        ("%^#Z", "utc"),
+    ];
+    for (format, expected) in cases {
+        new_ucmd!()
+            .env("LC_ALL", "C")
+            .env("TZ", "UTC")
+            .arg("-d")
+            .arg("2024-06-15 13:05:03")
+            .arg(format!("+{format}"))
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+}
+
+#[test]
+fn test_date_format_modifier_case_flags_on_named_zone() {
+    // `#` lower-cases a non-UTC abbreviation too, and `^` does not cancel it
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .env("TZ", "America/New_York")
+        .args(&["-d", "2024-06-15", "+%Z %^Z %#Z %^#Z"])
+        .succeeds()
+        .stdout_is("EDT EDT edt edt\n");
 }
 
 #[test]


### PR DESCRIPTION
GNU applies the `^` and `#` case flags inside each conversion rather than to the whole rendered string. `#` reaches only the specifiers that emit a name, it is not carried into the recursive expansion of `%c` and `%r`, and where it does apply it takes precedence over `^`.

uutils instead let `^` cancel `#` and applied both flags to every specifier, so with `TZ=UTC LC_ALL=C -d '2024-06-15 13:05:03'` it printed `SAT JUN 15 13:05:03 2024` for `%#c`, lower-cased the `PM` in `%#r`, and printed `PM`/`UTC` for `%^P`, `%^#p` and `%^#Z` where GNU prints `pm`/`utc`.

The fix stops `^` from clearing `#` and gates both flags on the specifier: `#` is honored for `%a %A %b %B %h %p %P %Z` and wins over `^`, and `%P` stays lower case whatever the flags ask for. The existing swap-case heuristic already matched GNU for those specifiers in the C locale, so only the gating changed. Single flags and `%^#B`/`%^#A` behave as before.

Tested with a table of the `%c %p %P %r %Z` flag combinations plus a named-zone case (`TZ=America/New_York`) in `tests/by-util/test_date.rs`; both new tests fail on main and pass with the change, and the rest of the date suite is unaffected. Every expected value was checked against GNU coreutils 9.11 under `TZ=UTC LC_ALL=C`. No GNU coreutils source was consulted.

One thing this PR does not address: in glibc, `#` sets upper-case for `%a %A %b %B %h` and lower-case for `%p %P %Z`, rather than swapping case. That is invisible in the C locale, where the names are already mixed or upper case, but it does show elsewhere: `LC_ALL=es_ES.UTF-8 date +%#B` gives `JUNIO` where a swap would leave `junio` alone. The swap heuristic predates this change and the gating here is correct either way, so I left the locale question for a separate PR.

Fixes #14351
