### PR TITLE
tsort stdout flushing fix and several error messages handling ameliorations  

### DIFF
--- a/src/uu/tsort/locales/en-US.ftl
+++ b/src/uu/tsort/locales/en-US.ftl
@@ -3,7 +3,6 @@ tsort-about = Topological sort the strings in FILE.
   Useful for scheduling and determining execution order.
   If FILE is not passed in, stdin is used instead.
 tsort-usage = tsort [OPTIONS] FILE
-tsort-error-is-dir = read error: Is a directory
 tsort-error-odd = input contains an odd number of tokens
 tsort-error-loop = input contains a loop:
 tsort-error-extra-operand = extra operand { $operand }

--- a/src/uu/tsort/locales/fr-FR.ftl
+++ b/src/uu/tsort/locales/fr-FR.ftl
@@ -3,7 +3,6 @@ tsort-about = Tri topologique des chaînes présentes dans FILE.
   Utile pour la planification et la détermination de l'ordre d'exécution.
   Si FILE n'est pas fourni, l'entrée standard (stdin) est utilisée.
 tsort-usage = tsort [OPTIONS] FILE
-tsort-error-is-dir = erreur de lecture : c'est un répertoire
 tsort-error-odd = l'entrée contient un nombre impair de jetons
 tsort-error-loop = l'entrée contient une boucle :
 tsort-error-extra-operand = opérande supplémentaire { $operand }

--- a/src/uu/tsort/src/error.rs
+++ b/src/uu/tsort/src/error.rs
@@ -1,0 +1,41 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use std::io;
+
+use uucore::{display::Quotable as _, translate};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    /// Error while reading input.
+    #[error(transparent)]
+    Read(#[from] ReadError),
+
+    /// Error while writing output.
+    #[error("{message}: {0}", message = translate!("common-write-error"))]
+    Write(io::Error),
+
+    /// The graph contains a cycle.
+    #[error("{input}: {message}", input = .0, message = translate!("tsort-error-loop"))]
+    Loop(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReadError {
+    /// The input file is actually a directory.
+    #[error("{input}: {read_error}: {message}", input = .0.maybe_quote(), read_error = translate!("common-read-error"), message = translate!("error-is-a-directory-text"))]
+    IsDir(String),
+
+    /// The number of tokens in the input data is odd.
+    ///
+    /// The length of the list of edges must be even because each edge has two
+    /// components: a source node and a target node.
+    #[error("{input}: {message}", input = .0.maybe_quote(), message = translate!("tsort-error-odd"))]
+    NumTokensOdd(String),
+
+    /// Wrapper for bubbling up input IO errors.
+    #[error("{message}: {0}", message = translate!("common-read-error"))]
+    Io(io::Error),
+}

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -6,6 +6,8 @@
 // spell-checker:ignore TAOCP indegree
 // spell-checker:ignore (libs) interner
 
+mod error;
+
 use clap::{Arg, ArgAction, Command};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
@@ -15,10 +17,11 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use string_interner::StringInterner;
 use string_interner::backend::BucketBackend;
-use thiserror::Error;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::{format_usage, show, translate};
+
+use crate::error::{Error, ReadError};
 
 // short types for switching interning behavior on the fly.
 type Sym = string_interner::symbol::SymbolUsize;
@@ -59,7 +62,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         {
             let input = std::path::Path::new(input);
             if input.is_dir() {
-                return Err(TsortError::IsDir(input.to_string_lossy().to_string()).into());
+                return Err(
+                    Error::Read(ReadError::IsDir(input.to_string_lossy().to_string())).into(),
+                );
             }
         }
         let file = File::open(input).map_err_context(|| input.maybe_quote().to_string())?;
@@ -71,7 +76,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         process_input(reader, &mut g)?;
     }
 
-    g.run_tsort()
+    g.run_tsort()?;
+    Ok(())
 }
 
 pub fn uu_app() -> Command {
@@ -99,37 +105,15 @@ pub fn uu_app() -> Command {
         )
 }
 
-#[derive(Debug, Error)]
-enum TsortError {
-    /// The input file is actually a directory.
-    #[error("{input}: {message}", input = .0.maybe_quote(), message = translate!("tsort-error-is-dir"))]
-    IsDir(String),
-
-    /// The number of tokens in the input data is odd.
-    ///
-    /// The length of the list of edges must be even because each edge has two
-    /// components: a source node and a target node.
-    #[error("{input}: {message}", input = .0.maybe_quote(), message = translate!("tsort-error-odd"))]
-    NumTokensOdd(String),
-
-    /// The graph contains a cycle.
-    #[error("{input}: {message}", input = .0, message = translate!("tsort-error-loop"))]
-    Loop(String),
-
-    /// Wrapper for bubbling up IO errors
-    #[error("{0}")]
-    IO(#[from] io::Error),
-}
-
 // Auxiliary struct, just for printing loop nodes via show! macro
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 struct LoopNode<'a>(&'a str);
 
-impl UError for TsortError {}
+impl UError for Error {}
 impl UError for LoopNode<'_> {}
 
-fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), TsortError> {
+fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), Error> {
     let mut pending: Option<Sym> = None;
 
     // Input is considered to be in the format
@@ -137,13 +121,13 @@ fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), TsortEr
     // with tokens separated by whitespaces
 
     for line in reader.lines() {
-        let line = line.map_err(|e| {
-            if e.kind() == io::ErrorKind::IsADirectory {
-                TsortError::IsDir(graph.name())
-            } else {
-                e.into()
+        let line = match line {
+            Err(e) if e.kind() == io::ErrorKind::IsADirectory => {
+                return Err(ReadError::IsDir(graph.name()).into());
             }
-        })?;
+            Err(e) => return Err(ReadError::Io(e).into()),
+            Ok(line) => line,
+        };
         for token in line.split_whitespace() {
             // Intern the token and get a Sym
             let token_sym = graph.interner.get_or_intern(token);
@@ -156,7 +140,7 @@ fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), TsortEr
         }
     }
     if pending.is_some() {
-        return Err(TsortError::NumTokensOdd(graph.name()));
+        return Err(ReadError::NumTokensOdd(graph.name()).into());
     }
 
     Ok(())
@@ -244,7 +228,7 @@ impl Graph {
     }
 
     /// Implementation of algorithm T from TAOCP (Don. Knuth), vol. 1.
-    fn run_tsort(&mut self) -> UResult<()> {
+    fn run_tsort(&mut self) -> Result<(), Error> {
         let mut independent_nodes_queue: VecDeque<Sym> = self
             .nodes
             .iter()
@@ -264,7 +248,7 @@ impl Graph {
         let mut out = BufWriter::new(io::stdout().lock());
         while !self.nodes.is_empty() {
             let v = self.find_next_node(&mut independent_nodes_queue);
-            writeln!(out, "{}", self.get_node_name(v))?;
+            writeln!(out, "{}", self.get_node_name(v)).map_err(Error::Write)?;
             if let Some(node_to_process) = self.nodes.remove(&v) {
                 for successor_name in node_to_process.successor_tokens.into_iter().rev() {
                     // we reverse to match GNU tsort order
@@ -279,6 +263,7 @@ impl Graph {
                 }
             }
         }
+        out.flush().map_err(Error::Write)?;
         Ok(())
     }
     pub fn indegree(&self, sym: Sym) -> Option<usize> {
@@ -309,7 +294,7 @@ impl Graph {
 
     fn find_and_break_cycle(&mut self, frontier: &mut VecDeque<Sym>) {
         let cycle = self.detect_cycle();
-        show!(TsortError::Loop(self.name()));
+        show!(Error::Loop(self.name()));
         for &sym in &cycle {
             show!(LoopNode(self.get_node_name(sym)));
         }

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -7,6 +7,7 @@ common-tip = tip
 common-usage = Usage
 common-help = help
 common-version = version
+common-read-error = read error
 common-write-error = write error
 
 # Common clap error messages
@@ -31,7 +32,8 @@ error-permission-denied = Permission denied
 error-file-not-found = No such file or directory
 error-no-such-process = No such process
 error-invalid-argument = Invalid argument
-error-is-a-directory = { $file }: Is a directory
+error-is-a-directory-text = Is a directory
+error-is-a-directory = { $file }: { error-is-a-directory-text }
 
 # Common actions
 action-copying = copying

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -8,7 +8,7 @@ common-usage = Utilisation
 common-help = aide
 common-version = version
 common-write-error = erreur d'écriture
-
+common-read-error = erreur de lecture
 # Messages d'erreur clap communs
 clap-error-unexpected-argument = { $error_word } : argument inattendu '{ $arg }' trouvé
 clap-error-unexpected-argument-simple = argument inattendu
@@ -31,7 +31,8 @@ error-permission-denied = Permission refusée
 error-file-not-found = Aucun fichier ou répertoire de ce type
 error-no-such-process = Aucun processus de ce type
 error-invalid-argument = Argument invalide
-error-is-a-directory = { $file }: Est un répertoire
+error-is-a-directory-text = Est un répertoire
+error-is-a-directory = { $file }: { error-is-a-directory-text }
 
 # Actions communes
 action-copying = copie

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -251,3 +251,21 @@ fn test_nonexistent_file_error_includes_filename() {
         .fails_with_code(1)
         .stderr_only("tsort: nosuchfile.txt: No such file or directory\n");
 }
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+fn test_write_error() {
+    use std::fs::OpenOptions;
+
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    at.write("input", "a d\n");
+
+    let dev_full = OpenOptions::new().write(true).open("/dev/full").unwrap();
+
+    ucmd.arg("input")
+        .set_stdout(dev_full)
+        .fails()
+        .stderr_contains("write error")
+        .stderr_contains("No space left on device");
+}


### PR DESCRIPTION
fixes #14383 
fixes #12006
closes #12065

The HEAD tsort added buffering but did not check whether writing was successful or not. I
I added the fix and modified the locale to make the names use generic constants. 