### PR TITLE
sort: propagate temporary file write errors

### DIFF
--- a/src/uu/sort/src/ext_sort/threaded.rs
+++ b/src/uu/sort/src/ext_sort/threaded.rs
@@ -293,13 +293,45 @@ fn write<I: WriteableTmpFile>(
     separator: u8,
 ) -> UResult<I::Closed> {
     let mut tmp_file = I::create(file, compress_prog)?;
-    write_lines(chunk.lines(), tmp_file.as_write(), separator);
+    write_lines(chunk.lines(), tmp_file.as_write(), separator)?;
     tmp_file.finished_writing()
 }
 
-fn write_lines<T: Write>(lines: &[Line], writer: &mut T, separator: u8) {
+fn write_lines<T: Write>(lines: &[Line], writer: &mut T, separator: u8) -> std::io::Result<()> {
     for s in lines {
-        writer.write_all(s.line).unwrap();
-        writer.write_all(&[separator]).unwrap();
+        writer.write_all(s.line)?;
+        writer.write_all(&[separator])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+
+    use super::*;
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::StorageFull, "disk full"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_lines_propagates_write_errors() {
+        let lines = [Line {
+            line: b"line",
+            index: 0,
+        }];
+
+        let result = write_lines(&lines, &mut FailingWriter, b'\n');
+
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::StorageFull);
     }
 }

--- a/src/uu/sort/src/ext_sort/threaded.rs
+++ b/src/uu/sort/src/ext_sort/threaded.rs
@@ -330,7 +330,11 @@ mod tests {
             index: 0,
         }];
 
-        let result = write_lines(&lines, &mut FailingWriter, b'\n');
+        let result = write_lines(
+            &lines,
+            &mut FailingWriter(io::ErrorKind::StorageFull),
+            b'\n',
+        );
 
         assert_eq!(result.unwrap_err().kind(), io::ErrorKind::StorageFull);
     }

--- a/src/uu/sort/src/ext_sort/threaded.rs
+++ b/src/uu/sort/src/ext_sort/threaded.rs
@@ -311,11 +311,11 @@ mod tests {
 
     use super::*;
 
-    struct FailingWriter;
+    struct FailingWriter(io::ErrorKind);
 
     impl Write for FailingWriter {
         fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::StorageFull, "disk full"))
+            Err(io::Error::from(self.0))
         }
 
         fn flush(&mut self) -> io::Result<()> {

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1296,6 +1296,39 @@ fn test_merge_write_error_does_not_panic() {
     }
 }
 
+// Regression test: a full temporary filesystem must make external sort fail
+// cleanly instead of panicking while spilling a sorted chunk.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+fn test_spill_write_error_does_not_panic() {
+    let mut scene = TestScenario::new("sort");
+
+    // Mounting a filesystem requires privileges that are not available in all
+    // test environments, so leave this integration test skipped there.
+    let tmp_dir = "tmp_dir";
+    scene.fixtures.mkdir(tmp_dir);
+    if scene.mount_temp_fs(tmp_dir).is_err() {
+        return;
+    }
+
+    let lines = (0..200_000)
+        .map(|line| format!("{line:06}\n"))
+        .collect::<String>();
+    scene.fixtures.write("input.txt", &lines);
+
+    scene
+        .ucmd()
+        .args(&[
+            "--buffer-size=1",
+            "--temporary-directory",
+            tmp_dir,
+            "input.txt",
+        ])
+        .fails_with_code(1)
+        .stderr_contains("No space left on device")
+        .stderr_does_not_contain("panicked");
+}
+
 // A read error must be reported with context and without the raw io::Error suffix.
 // It used to print `sort: Input/output error (os error 5)`.
 #[test]

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1311,9 +1311,10 @@ fn test_spill_write_error_does_not_panic() {
         return;
     }
 
-    let lines = (0..200_000)
-        .map(|line| format!("{line:06}\n"))
-        .collect::<String>();
+    let lines = (0..200_000).fold(String::new(), |mut lines, line| {
+        writeln!(lines, "{line:06}").expect("writing to a String cannot fail");
+        lines
+    });
     scene.fixtures.write("input.txt", &lines);
 
     scene


### PR DESCRIPTION
## Summary

Fixes #14377.

## Reproduction

When external sort spills a chunk to a temporary file, a write failure (for example, `ENOSPC`/`EFBIG`) reached `write_lines`, whose `write_all` calls unconditionally used `unwrap()`. The process therefore panicked instead of reporting the I/O error and exiting non-zero.

## Cause

The temporary-file chunk writer discarded the `io::Result` from both line and separator writes.

## Fix

Propagate write errors from `write_lines` to the external-sort path with `?`, preserving the existing error handling and cleanup flow. Added a regression unit test using a writer that returns `StorageFull`.

## Validation

- `cargo fmt --check`
- `cargo test -p uu_sort`
- `cargo clippy -p uu_sort --all-targets -- -D warnings`
- `git diff --check`

The focused test and full `uu_sort` unit-test suite pass (29 tests).

## Not verified

A real full/size-limited filesystem was not mounted in this environment; the regression test deterministically exercises the same failing `Write` path.

AI assistance was used to help inspect the issue and prepare this patch; the submitted change was reviewed and verified against the repository's contributing and AI-policy requirements.
