### PR TITLE
sort: echo the disorder line verbatim, not reformatted as a number

### DIFF
--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -61,6 +61,7 @@ use uucore::parser::shortcut_value_parser::ShortcutValueParser;
 use uucore::posix::{MODERN, TRADITIONAL};
 use uucore::show_error;
 use uucore::translate;
+use uucore::translate_text;
 use uucore::version_cmp::version_cmp;
 use uucore::{format_usage, i18n};
 
@@ -204,7 +205,11 @@ fn format_disorder(file: &OsString, line_number: &usize, line: &String, silent: 
     if *silent {
         String::new()
     } else {
-        translate!("sort-error-disorder", "file" => file.maybe_quote(), "line_number" => line_number, "line" => line.to_owned())
+        // `line` is the offending input line echoed back verbatim (GNU sort does the
+        // same): it must not be reinterpreted as a number by `translate!`, which would
+        // reformat it via Fluent's numeric formatting (e.g. "1.10" -> "1.1", "1e5" ->
+        // "100000", "nan" -> "NaN").
+        translate_text!("sort-error-disorder", "file" => file.maybe_quote(), "line_number" => line_number, "line" => line.to_owned())
     }
 }
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1391,6 +1391,30 @@ fn test_check() {
 }
 
 #[test]
+fn test_check_disorder_echoes_line_verbatim() {
+    // The line reported in a "disorder" diagnostic is the raw offending input line.
+    // It must never be reinterpreted/reformatted as a number, even though it looks
+    // like one (GNU sort echoes it verbatim too).
+    new_ucmd!()
+        .args(&["-n", "-c"])
+        .pipe_in("2\n1.10\n")
+        .fails()
+        .stderr_only("sort: -:2: disorder: 1.10\n");
+
+    new_ucmd!()
+        .args(&["-n", "-c"])
+        .pipe_in("5\nnan\n")
+        .fails()
+        .stderr_only("sort: -:2: disorder: nan\n");
+
+    new_ucmd!()
+        .args(&["-g", "-c"])
+        .pipe_in("1e10\n1e5\n")
+        .fails()
+        .stderr_only("sort: -:2: disorder: 1e5\n");
+}
+
+#[test]
 fn test_check_silent() {
     for silent_arg in [
         "-C",


### PR DESCRIPTION
## Bug

\`sort -c\` (and \`--check\`) reports the first out-of-order line via a
"disorder" diagnostic. In uutils that diagnostic ran the offending line
through the \`translate!\` macro, which — per its own doc comment — hands
any argument that parses as a number to Fluent as a number, and Fluent
then formats it for the locale. Since the offending line is arbitrary
input text that happens to look numeric in these failure cases, that
silently rewrote what gets echoed:

| input line | uutils printed | GNU prints |
|---|---|---|
| `1.10` | `1.1` | `1.10` |
| `1e5` | `100000` | `1e5` |
| `nan` | `NaN` | `nan` |

Reproduced against GNU coreutils 9.11 (`gsort`, built from the official
tarball):

```
$ printf '2\n1.10\n' | sort -n -c
sort: -:2: disorder: 1.1        # uutils (before this patch)
gsort: -:2: disorder: 1.10      # GNU

$ printf '1e10\n1e5\n' | sort -g -c
sort: -:2: disorder: 100000     # uutils (before this patch)
gsort: -:2: disorder: 1e5       # GNU

$ printf '5\nnan\n' | sort -n -c
sort: -:2: disorder: NaN        # uutils (before this patch)
gsort: -:2: disorder: nan       # GNU
```

## Fix

Swap `translate!` for `translate_text!` in `format_disorder`
(`src/uu/sort/src/sort.rs`). `translate_text!` is the macro uucore
already documents for exactly this case — text that must be echoed back
unchanged rather than reinterpreted as a locale-formatted number. The
`file` and `line_number` arguments are unaffected in practice (a file
name isn't numeric, and no test exercises locale-grouped line numbers),
so no other behavior changes.

## Testing

- New `test_check_disorder_echoes_line_verbatim` in
  `tests/by-util/test_sort.rs` covers all three cases above.
- Mutation check: reverting the one-line fix in `sort.rs` (test file
  untouched) makes the new test fail with the exact "1.1" vs "1.10"
  diff shown above.
- `cargo test --features sort --test tests test_sort`: **203 passed, 0
  failed** (202 pre-existing + 1 new), against upstream `main` at
  `d1dd5f94c`.
- `cargo fmt --all --check` and `cargo clippy -p uu_sort --all-targets
  -- -D warnings`: clean.
- Differential check against GNU coreutils 9.11 (built from the
  official release tarball) across the three inputs above, plus
  existing non-numeric-looking disorder cases (unaffected): 0
  regressions after the fix.

## Disclosure

Prepared with AI assistance (Claude Sonnet 5, via Claude Code), per the
AI policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed `gsort` 9.11 binary, not from reading GPL source.
All testing was run locally.