### PR TITLE
numfmt: honor --round for an explicit --format precision of 0

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -544,6 +544,7 @@ fn consider_suffix(
     u: Unit,
     round_method: RoundMethod,
     precision: usize,
+    is_precision_specified: bool,
 ) -> Result<(f64, Option<Suffix>)> {
     use crate::units::RawSuffix::{E, G, K, M, P, Q, R, T, Y, Z};
 
@@ -582,7 +583,10 @@ fn consider_suffix(
     } else {
         precision
     };
-    let v = if precision > 0 {
+    let v = if is_precision_specified {
+        // An explicit `--format` precision, `%.0f` included, rounds the scaled
+        // value to exactly that many decimals. `div_round` is for the default
+        // presentation instead, which keeps one decimal below the next base.
         round_with_precision(n / bases[i], round_method, effective_precision)
     } else {
         div_round(n, bases[i], round_method)
@@ -699,7 +703,7 @@ fn transform_to(
 
     let s = s.to_f64();
     let i2 = s / (opts.to_unit as f64);
-    let (i2, s) = consider_suffix(i2, opts.to, round_method, precision)?;
+    let (i2, s) = consider_suffix(i2, opts.to, round_method, precision, is_precision_specified)?;
     let dec_sep = locale_decimal_separator();
     let localize = |s: String| -> String {
         if dec_sep == "." {
@@ -1247,7 +1251,7 @@ mod tests {
         use crate::options::RoundMethod;
         use crate::units::Unit;
 
-        let result = consider_suffix(1e27, Unit::Si, RoundMethod::FromZero, 0);
+        let result = consider_suffix(1e27, Unit::Si, RoundMethod::FromZero, 0, false);
         assert!(result.is_ok());
         let (value, suffix) = result.unwrap();
         assert!(suffix.is_some());
@@ -1255,7 +1259,7 @@ mod tests {
         assert_eq!(raw_suffix as i32, RawSuffix::R as i32);
         assert_eq!(value, 1.0);
 
-        let result = consider_suffix(1e30, Unit::Si, RoundMethod::FromZero, 0);
+        let result = consider_suffix(1e30, Unit::Si, RoundMethod::FromZero, 0, false);
         assert!(result.is_ok());
         let (value, suffix) = result.unwrap();
         assert!(suffix.is_some());
@@ -1263,7 +1267,7 @@ mod tests {
         assert_eq!(raw_suffix as i32, RawSuffix::Q as i32);
         assert_eq!(value, 1.0);
 
-        let result = consider_suffix(5e30, Unit::Si, RoundMethod::FromZero, 0);
+        let result = consider_suffix(5e30, Unit::Si, RoundMethod::FromZero, 0, false);
         assert!(result.is_ok());
         let (value, suffix) = result.unwrap();
         assert!(suffix.is_some());

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1648,6 +1648,46 @@ fn test_format_precision_zero_with_to_scale_issue_11667() {
         .stdout_is("5M\n");
 }
 
+// `--format=%.0f` with `--to=<scale>` must round the scaled value with the
+// selected `--round` method, instead of first keeping a fractional digit and
+// then rounding that to nearest.
+#[test]
+fn test_format_precision_zero_with_to_scale_honors_round_method() {
+    let cases = [
+        (vec!["--to=si", "--format=%.0f", "1234567"], "2M"),
+        (vec!["--to=si", "--format=%.0f", "--", "-1234567"], "-2M"),
+        (vec!["--to=iec", "--format=%.0f", "1234567"], "2M"),
+        (
+            vec!["--to=si", "--format=%.0f", "--round=up", "1234567"],
+            "2M",
+        ),
+        (
+            vec!["--to=si", "--format=%.0f", "--round=down", "1934567"],
+            "1M",
+        ),
+        (
+            vec!["--to=si", "--format=%.0f", "--round=nearest", "1234567"],
+            "1M",
+        ),
+        (
+            vec![
+                "--to=si",
+                "--format=%.0f",
+                "--round=towards-zero",
+                "1934567",
+            ],
+            "1M",
+        ),
+    ];
+
+    for (args, expected) in cases {
+        new_ucmd!()
+            .args(&args)
+            .succeeds()
+            .stdout_only(format!("{expected}\n"));
+    }
+}
+
 #[test]
 fn test_invalid_utf8_input() {
     // 0xFF is invalid UTF-8


### PR DESCRIPTION
`numfmt --to=<scale> --format='%.0f'` ignored `--round` and always rounded
the scaled value to nearest:

```console
$ numfmt --to=si --format=%.0f 1234567     # GNU
2M
$ numfmt --to=si --format=%.0f 1234567     # uutils, before
1M

$ numfmt --to=si --format=%.0f --round=down 1934567    # GNU
1M
$ numfmt --to=si --format=%.0f --round=down 1934567    # uutils, before
2M
```

`--help` documents both halves of the contract: "Optional precision (%.1f)
will override the input determined precision", and `--round=METHOD` with
`from-zero` as the default. With an explicit `.0`, `1234567 / 10^6 =
1.234567` must be rounded to zero decimals by the selected method, giving
`2M` by default and `1M` under `--round=down`.

## The fix

`consider_suffix` picked its rounding by `precision > 0`, so a precision
of `0` fell into the `div_round` branch. That branch is for the *default*
presentation, where a value below the next base keeps one fractional digit
(`1.3M`): it rounds `10 * v` and divides by ten. The result, `1.3`, then
reached `format_float(i2, 0)`, which rounds to nearest — hence `1M` from
`1.23`, and `2M` from `1.93` even with `--round=down`.

The function now takes `is_precision_specified` (already computed in
`format_string` and threaded to `transform_to`) and uses
`round_with_precision` whenever the precision was given, `.0` included.
The implicit-precision path is untouched: `consider_suffix` returns early
for `--to=none`, which is the only case where an implicit precision can be
non-zero, so the `div_round` branch still governs every unspecified-format
invocation.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binary (Homebrew, `gnumfmt`)
as a black box and diffing its output against uutils across a matrix of
`--to` x `--round` x `--format` precisions. I did not read GNU coreutils
source.

## Testing

- New test `test_format_precision_zero_with_to_scale_honors_round_method`
  in `tests/by-util/test_numfmt.rs`: 7 cases covering the default
  (from-zero) plus `up`, `down`, `nearest`, `towards-zero`, a negative
  value, and `--to=iec`. Mutation-checked: reverting the one-line
  condition in `format.rs` makes it fail.
- `cargo test --features numfmt --test tests test_numfmt`: 192 passed, 0
  failed (191 before, plus the new one).
- `cargo clippy -p uu_numfmt --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over 216 `numfmt`
  invocations (`--to`/`--from`/`--padding`/`--format`/`--round`/`--suffix`/
  `--invalid`/`--field`/`--grouping`): mismatches 37 -> 36. The one
  remaining `--format` mismatch is a separate defect (zero-padding width),
  and the rest are pre-existing diagnostics wording differences. No case
  regressed.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binary, not from reading GPL source. All testing was
run locally.
