### PR TITLE
numfmt: zero-pad the number, not the unit suffix

### DIFF
--- a/src/uu/numfmt/src/format.rs
+++ b/src/uu/numfmt/src/format.rs
@@ -762,6 +762,18 @@ fn pad_string(s: &str, width: usize, fill: char, right_align: bool) -> String {
     result
 }
 
+/// Split a scaled value into its numeric part and the unit suffix that trails
+/// it (`k`, `Mi`, ...).
+///
+/// A value with no digits at all, such as `inf`, has no numeric part to pad, so
+/// it is returned whole and is padded as before.
+fn split_number_and_units(s: &str) -> (&str, &str) {
+    match s.rfind(|c: char| c.is_ascii_digit()) {
+        Some(last_digit) => s.split_at(last_digit + 1),
+        None => (s, ""),
+    }
+}
+
 fn format_string(
     source: &str,
     options: &NumfmtOptions,
@@ -816,11 +828,30 @@ fn format_string(
     let padded_number = match padding {
         0 => number_with_suffix,
         p if p > 0 && options.format.zero_padding => {
-            let zero_padded = if let Some(unsigned) = number_with_suffix.strip_prefix(['-', '+']) {
-                let sign = &number_with_suffix[..1];
-                format!("{sign}{}", pad_string(unsigned, p as usize - 1, '0', true))
+            // GNU zero-pads the number itself: "Optional zero (%010f) width
+            // will zero pad the number". A unit suffix from --to and the
+            // --suffix text sit outside the width, unlike space padding,
+            // which applies to the whole output.
+            // The --suffix text is user-supplied and may itself contain
+            // digits, so peel it off before locating the number.
+            let (scaled, user_suffix) = match &options.suffix {
+                Some(suffix) => number_with_suffix
+                    .strip_suffix(suffix.as_str())
+                    .map_or((number_with_suffix.as_str(), ""), |rest| {
+                        (rest, suffix.as_str())
+                    }),
+                None => (number_with_suffix.as_str(), ""),
+            };
+            let (number, unit) = split_number_and_units(scaled);
+            let trailing = format!("{unit}{user_suffix}");
+            let zero_padded = if let Some(unsigned) = number.strip_prefix(['-', '+']) {
+                let sign = &number[..1];
+                format!(
+                    "{sign}{}{trailing}",
+                    pad_string(unsigned, (p as usize).saturating_sub(1), '0', true)
+                )
             } else {
-                pad_string(&number_with_suffix, p as usize, '0', true)
+                format!("{}{trailing}", pad_string(number, p as usize, '0', true))
             };
 
             match implicit_padding.unwrap_or(options.padding) {

--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -1114,6 +1114,41 @@ fn test_format_with_zero_padding_and_suffix() {
         .stdout_is("001234 ?\n");
 }
 
+// GNU zero-pads the number only: "Optional zero (%010f) width will zero pad
+// the number". The unit from --to and the --suffix text stay outside the width.
+#[test]
+fn test_format_with_zero_padding_excludes_unit_suffix() {
+    let cases = [
+        (vec!["--format=%05.1f", "--to=si", "1234567"], "001.3M"),
+        (vec!["--format=%06.1f", "--to=si", "1234"], "0001.3k"),
+        (
+            vec!["--format=%08.1f", "--to=iec-i", "1234567"],
+            "000001.2Mi",
+        ),
+        (
+            vec!["--format=%08.1f", "--to=si", "--", "-1234567"],
+            "-00001.3M",
+        ),
+        (vec!["--format=%03.1f", "--to=si", "1234567"], "1.3M"),
+        (
+            vec!["--format=%05.1f", "--to=si", "--suffix=B", "1234567"],
+            "001.3MB",
+        ),
+        (vec!["--format=%05.1f", "--suffix=B", "1.5"], "001.5B"),
+        (
+            vec!["--format=%08.1f", "--to=si", "--padding=12", "1234567"],
+            "   000001.3M",
+        ),
+    ];
+
+    for (args, expected) in cases {
+        new_ucmd!()
+            .args(&args)
+            .succeeds()
+            .stdout_only(format!("{expected}\n"));
+    }
+}
+
 #[test]
 fn test_format_with_precision() {
     let values = vec![("0.99", "1.0"), ("1", "1.0"), ("1.01", "1.1")];


### PR DESCRIPTION
`numfmt` counted the unit suffix inside a zero-padded `--format` width:

```console
$ numfmt --format=%05.1f --to=si 1234567     # GNU
001.3M
$ numfmt --format=%05.1f --to=si 1234567     # uutils, before
01.3M

$ numfmt --format=%05.1f --suffix=B 1.5      # GNU
001.5B
$ numfmt --format=%05.1f --suffix=B 1.5      # uutils, before
01.5B
```

`--help` draws the distinction explicitly:

> Optional width value (%10f) will pad **output**. Optional zero (%010f)
> width will zero pad **the number**.

So space padding covers the whole output — which uutils already gets right,
`--format=%8.1f` and `--padding` both match GNU — while zero padding covers
only the numeric part. The `--to` unit (`k`, `M`, `Mi`, ...) and the
`--suffix` text stay outside the width.

## The fix

The zero-padding arm of `format_string` padded `number_with_suffix`, which
is the number with everything already appended. It now peels off the
`--suffix` text (user-supplied, so it may itself contain digits) and splits
the remainder at its last digit, pads the numeric part alone, and puts the
unit back. The sign handling and the subsequent space-padding pass are
unchanged, so `--format=%08.1f --to=si -- -1234567` gives `-00001.3M` and
`--padding` still applies to the finished string.

A value with no digits at all (`inf`, `nan`) has no numeric part to pad, so
`split_number_and_units` returns it whole and it is padded as before.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binary (Homebrew, `gnumfmt`) as
a black box and diffing its output against uutils across `--format` widths,
precisions, `-` and `0` flags, `--to` scales, `--suffix`,
`--unit-separator`, and `--padding` combinations. I did not read GNU
coreutils source.

## Testing

- New test `test_format_with_zero_padding_excludes_unit_suffix` in
  `tests/by-util/test_numfmt.rs`: 8 cases covering si/iec-i units, a
  negative value, a width smaller than the number, `--suffix`, and
  `--padding` layered on top. Mutation-checked: dropping the split makes it
  fail.
- `cargo test --features numfmt --test tests test_numfmt`: 192 passed, 0
  failed (191 before, plus the new one) — the existing zero-padding tests
  (`test_format_with_zero_padding`, `..._and_padding_option`,
  `..._and_negative_padding_option`, `..._and_implicit_padding`,
  `..._and_suffix`) are unchanged and still green.
- `cargo clippy -p uu_numfmt --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over 216 `numfmt`
  invocations: mismatches 37 -> 36, no case regressed.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binary, not from reading GPL source. All testing was
run locally.
