### PR TITLE
printf: treat a `--` past the format as an argument

### DIFF
--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -42,11 +42,35 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     result
 }
 
+/// Mark where the options end, so that only a `--` written before FORMAT acts
+/// as the terminator.
+///
+/// GNU accepts a leading `--` (`printf -- '%s\n' a`), but past FORMAT every
+/// operand is data: `printf '%s\n' --` prints `--`. clap would instead
+/// swallow the first `--` wherever it appears, so insert one in front of the
+/// format operand when the caller did not write it there.
+fn mark_end_of_options(mut args: Vec<OsString>) -> Vec<OsString> {
+    let mut i = 1;
+    while i < args.len() {
+        // Both exit before FORMAT is looked at, and GNU honors them only here.
+        if args[i] == "--help" || args[i] == "--version" {
+            i += 1;
+            continue;
+        }
+        if args[i] != "--" {
+            args.insert(i, OsString::from("--"));
+        }
+        break;
+    }
+    args
+}
+
 fn print_formatted(args: impl uucore::Args) -> UResult<()> {
     let args: Vec<OsString> = args.collect();
     // Kept for the caret in format diagnostics, which needs the format as typed.
     let diag_args = uucore::diagnostics::capture(&args);
-    let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
+    let matches =
+        uucore::clap_localization::handle_clap_result(uu_app(), mark_end_of_options(args))?;
 
     let format = matches
         .get_one::<OsString>(options::FORMAT)

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -1792,3 +1792,57 @@ printf: %z: invalid conversion specification
             .stderr_only("printf: %5.2c: invalid conversion specification\n");
     }
 }
+
+#[test]
+fn leading_double_dash_ends_the_options() {
+    new_ucmd!()
+        .args(&["--", "%s\n", "a"])
+        .succeeds()
+        .stdout_only("a\n");
+}
+
+#[test]
+fn double_dash_after_the_format_is_an_argument() {
+    new_ucmd!()
+        .args(&["%s\n", "--"])
+        .succeeds()
+        .stdout_only("--\n");
+
+    new_ucmd!()
+        .args(&["%s %s\n", "--", "--"])
+        .succeeds()
+        .stdout_only("-- --\n");
+
+    // Only the first `--` terminates the options; the second one is data.
+    new_ucmd!()
+        .args(&["--", "%s\n", "--"])
+        .succeeds()
+        .stdout_only("--\n");
+}
+
+#[test]
+fn double_dash_as_the_format_is_printed_literally() {
+    new_ucmd!()
+        .args(&["--", "--", "x"])
+        .succeeds()
+        .stdout_is("--")
+        .stderr_contains("warning: ignoring excess arguments, starting with 'x'");
+}
+
+#[test]
+fn help_and_version_past_the_format_are_arguments() {
+    new_ucmd!()
+        .args(&["%s", "--help"])
+        .succeeds()
+        .stdout_only("--help");
+
+    new_ucmd!()
+        .args(&["%s", "--version"])
+        .succeeds()
+        .stdout_only("--version");
+
+    new_ucmd!()
+        .args(&["--", "--help"])
+        .succeeds()
+        .stdout_only("--help");
+}


### PR DESCRIPTION
`printf` lost a `--` operand that came after the format string:

```console
$ printf '%s\n' --            # GNU
--
$ printf '%s\n' --            # uutils, before
                              # (empty line)

$ printf '%s %s\n' -- --      # GNU
-- --
$ printf '%s %s\n' -- --      # uutils, before
%s
----

$ printf '%s' --help          # GNU
--help
$ printf '%s' --help          # uutils, before
<the help text>
```

`--help` spells out the two mutually exclusive forms:

> Usage: printf FORMAT [ARGUMENT]...
>   or:  printf OPTION

Options are an alternative to FORMAT, not something that can follow it. So
GNU looks for `--`, `--help` and `--version` only in the very first
operand; from FORMAT onwards everything is data, including further `--`.

## The fix

`print_formatted` handed the arguments to clap unchanged, and clap ends the
options at the first `--` it sees anywhere, so a `--` in argument position
was consumed. A new `mark_end_of_options` inserts an explicit `--` in front
of the format operand when the caller did not already write one there,
which pins the terminator to the only place GNU accepts it. A leading
`--help`/`--version` is stepped over so both still work as the sole
operand; past that point they reach the formatter as ordinary arguments.

The change is confined to argument marshalling — the formatter, the
diagnostics capture (which still sees the arguments as typed) and the
excess-argument warning are untouched.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binary (Homebrew, `gprintf`) as
a black box: `printf -- '%s\n' a`, `printf '%s\n' --`,
`printf '%s %s\n' -- --`, `printf -- -- x`, `printf -- --help`,
`printf '%s' --help`, `printf -- --version`, `printf '%s' -- --version`,
`printf --help`, `printf --version`, `printf`, `printf -v`, and diffing
against uutils. I did not read GNU coreutils source.

## Testing

- New tests in `tests/by-util/test_printf.rs`:
  `leading_double_dash_ends_the_options`,
  `double_dash_after_the_format_is_an_argument`,
  `double_dash_as_the_format_is_printed_literally`,
  `help_and_version_past_the_format_are_arguments`. Mutation-checked:
  reverting `printf.rs` alone makes two of them fail.
- `cargo test --features printf --test tests test_printf`: 145 passed, 0
  failed (141 before, plus the four new ones).
- `cargo clippy -p uu_printf --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over 41 `printf`
  invocations: mismatches 4 -> 3, no case regressed. (The two remaining
  real mismatches are unrelated: `%a` formatting, and a harness quoting
  artifact.)

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binary, not from reading GPL source. All testing was
run locally.
