### PR TITLE
base32, base64, basenc: drop the "error: " from the invalid-input message

### DIFF
--- a/src/uu/base32/locales/en-US.ftl
+++ b/src/uu/base32/locales/en-US.ftl
@@ -52,6 +52,7 @@ base-common-extra-operand = extra operand {$operand}
 base-common-no-such-file = {$file}: No such file or directory
 base-common-invalid-wrap-size = invalid wrap size: {$size}
 base-common-read-error = read error: {$error}
+base-common-invalid-input = invalid input
 
 # Shared base_common help messages
 base-common-help-decode = decode data

--- a/src/uu/base32/locales/fr-FR.ftl
+++ b/src/uu/base32/locales/fr-FR.ftl
@@ -47,6 +47,7 @@ base-common-extra-operand = opérande supplémentaire {$operand}
 base-common-no-such-file = {$file} : Aucun fichier ou répertoire de ce type
 base-common-invalid-wrap-size = taille de retour à la ligne invalide : {$size}
 base-common-read-error = erreur de lecture : {$error}
+base-common-invalid-input = entrée invalide
 
 # Messages d'aide partagés de base_common
 base-common-help-decode = décoder les données

--- a/src/uu/base32/src/base_common.rs
+++ b/src/uu/base32/src/base_common.rs
@@ -627,6 +627,7 @@ pub mod fast_decode {
     use uucore::{
         encoding::SupportsFastDecodeAndEncode,
         error::{UResult, USimpleError},
+        translate,
     };
 
     // Start of helper functions
@@ -729,7 +730,10 @@ pub mod fast_decode {
             } else if ignore_garbage {
                 continue;
             } else {
-                return Err(USimpleError::new(1, "error: invalid input"));
+                return Err(USimpleError::new(
+                    1,
+                    translate!("base-common-invalid-input"),
+                ));
             }
 
             if supports_partial_decode {
@@ -778,7 +782,10 @@ pub mod fast_decode {
             write_to_output(&mut decoded_buffer, output)?;
 
             if had_invalid_tail {
-                return Err(USimpleError::new(1, "error: invalid input"));
+                return Err(USimpleError::new(
+                    1,
+                    translate!("base-common-invalid-input"),
+                ));
             }
         }
 
@@ -841,7 +848,10 @@ pub mod fast_decode {
                             buffer.drain(..decode_in_chunks_of_size);
                         }
                     }
-                    return Err(USimpleError::new(1, "error: invalid input"));
+                    return Err(USimpleError::new(
+                        1,
+                        translate!("base-common-invalid-input"),
+                    ));
                 }
 
                 if supports_partial_decode {
@@ -893,7 +903,10 @@ pub mod fast_decode {
             write_to_output(&mut decoded_buffer, output)?;
 
             if had_invalid_tail {
-                return Err(USimpleError::new(1, "error: invalid input"));
+                return Err(USimpleError::new(
+                    1,
+                    translate!("base-common-invalid-input"),
+                ));
             }
         }
 

--- a/src/uucore/locales/en-US.ftl
+++ b/src/uucore/locales/en-US.ftl
@@ -93,3 +93,7 @@ mode-error-invalid-operator = invalid operator (expected +, -, or =, but found {
 mode-diag-label-missing-operator = this clause says who, but not what to change
 mode-diag-label-invalid-number = not an octal mode
 mode-diag-help-syntax = a mode is either octal, as in 644, or clauses such as u+rwx,go-w
+
+# Encoding/decoding error messages (base32, base64, basenc)
+encoding-error-invalid-input = invalid input
+encoding-error-invalid-input-z85-length = invalid input (length must be multiple of 4 characters)

--- a/src/uucore/locales/fr-FR.ftl
+++ b/src/uucore/locales/fr-FR.ftl
@@ -87,3 +87,7 @@ mode-error-invalid-operator = opérateur invalide (+, - ou = attendu, mais { $op
 mode-diag-label-missing-operator = cette clause indique qui, mais pas quoi changer
 mode-diag-label-invalid-number = n'est pas un mode octal
 mode-diag-help-syntax = un mode est soit octal, comme 644, soit des clauses comme u+rwx,go-w
+
+# Messages d'erreur d'encodage/décodage (base32, base64, basenc)
+encoding-error-invalid-input = entrée invalide
+encoding-error-invalid-input-z85-length = entrée invalide (la longueur doit être un multiple de 4 caractères)

--- a/src/uucore/src/lib/features/encoding.rs
+++ b/src/uucore/src/lib/features/encoding.rs
@@ -8,6 +8,7 @@
 // spell-checker:ignore ABCDEFGHJKLMNPQRSTUVWXY Zabcdefghijkmnopqrstuvwxyz
 
 use crate::error::{UResult, USimpleError};
+use crate::translate;
 use base64_simd;
 use data_encoding::Encoding;
 use data_encoding_macro::new_encoding;
@@ -82,11 +83,15 @@ impl SupportsFastDecodeAndEncode for Base64SimdWrapper {
                     let segment_len = blocks * 4;
 
                     if segment_len > remaining.len() {
-                        return Err(USimpleError::new(1, "error: invalid input"));
+                        return Err(USimpleError::new(
+                            1,
+                            translate!("encoding-error-invalid-input"),
+                        ));
                     }
 
-                    Self::decode_with_standard(&remaining[..segment_len], output)
-                        .map_err(|_| USimpleError::new(1, "error: invalid input"))?;
+                    Self::decode_with_standard(&remaining[..segment_len], output).map_err(
+                        |_| USimpleError::new(1, translate!("encoding-error-invalid-input")),
+                    )?;
 
                     start += segment_len;
                 } else {
@@ -99,8 +104,9 @@ impl SupportsFastDecodeAndEncode for Base64SimdWrapper {
                         Self::decode_with_no_pad
                     };
 
-                    decoder(remaining, output)
-                        .map_err(|_| USimpleError::new(1, "error: invalid input"))?;
+                    decoder(remaining, output).map_err(|_| {
+                        USimpleError::new(1, translate!("encoding-error-invalid-input"))
+                    })?;
 
                     break;
                 }
@@ -109,7 +115,7 @@ impl SupportsFastDecodeAndEncode for Base64SimdWrapper {
             Ok(())
         } else {
             Self::decode_with_no_pad(input, output)
-                .map_err(|_| USimpleError::new(1, "error: invalid input"))
+                .map_err(|_| USimpleError::new(1, translate!("encoding-error-invalid-input")))
         };
 
         if let Err(err) = decode_result {
@@ -287,7 +293,7 @@ impl SupportsFastDecodeAndEncode for Base58Wrapper {
             let digit = alphabet
                 .iter()
                 .position(|&b| b == byte)
-                .ok_or_else(|| USimpleError::new(1, "error: invalid input"))?;
+                .ok_or_else(|| USimpleError::new(1, translate!("encoding-error-invalid-input")))?;
 
             // Multiply by 58 and add digit
             let mut carry = digit as u32;
@@ -418,11 +424,14 @@ impl SupportsFastDecodeAndEncode for Z85Wrapper {
 
     fn decode_into_vec(&self, input: &[u8], output: &mut Vec<u8>) -> UResult<()> {
         if input.first() == Some(&b'#') {
-            return Err(USimpleError::new(1, "error: invalid input"));
+            return Err(USimpleError::new(
+                1,
+                translate!("encoding-error-invalid-input"),
+            ));
         }
 
-        let decode_result =
-            z85::decode(input).map_err(|_de| USimpleError::new(1, "error: invalid input"))?;
+        let decode_result = z85::decode(input)
+            .map_err(|_de| USimpleError::new(1, translate!("encoding-error-invalid-input")))?;
         output.extend_from_slice(&decode_result);
 
         Ok(())
@@ -438,7 +447,7 @@ impl SupportsFastDecodeAndEncode for Z85Wrapper {
         if !input.len().is_multiple_of(4) {
             return Err(USimpleError::new(
                 1,
-                "error: invalid input (length must be multiple of 4 characters)",
+                translate!("encoding-error-invalid-input-z85-length"),
             ));
         }
 
@@ -464,7 +473,7 @@ impl SupportsFastDecodeAndEncode for EncodingWrapper {
         let decode_len_result = self
             .encoding
             .decode_len(input.len())
-            .map_err(|_de| USimpleError::new(1, "error: invalid input"))?;
+            .map_err(|_de| USimpleError::new(1, translate!("encoding-error-invalid-input")))?;
 
         let output_len = output.len();
 
@@ -473,7 +482,7 @@ impl SupportsFastDecodeAndEncode for EncodingWrapper {
         let us = self
             .encoding
             .decode_mut(input, &mut (output[output_len..]))
-            .map_err(|_de| USimpleError::new(1, "error: invalid input"))?;
+            .map_err(|_de| USimpleError::new(1, translate!("encoding-error-invalid-input")))?;
         // See:
         // https://docs.rs/data-encoding/latest/data_encoding/struct.Encoding.html#method.decode_mut
         // "Returns the length of the decoded output. This length may be smaller than the output length if the input contained padding or ignored characters. The output bytes after the returned length are not initialized and should not be read."

--- a/tests/by-util/test_base32.rs
+++ b/tests/by-util/test_base32.rs
@@ -89,7 +89,7 @@ fn test_garbage() {
         .arg("-d")
         .pipe_in(input)
         .fails()
-        .stderr_only("base32: error: invalid input\n");
+        .stderr_only("base32: invalid input\n");
 }
 
 #[test]

--- a/tests/by-util/test_base64.rs
+++ b/tests/by-util/test_base64.rs
@@ -155,7 +155,7 @@ fn test_garbage() {
         .arg("-d")
         .pipe_in(input)
         .fails()
-        .stderr_only("base64: error: invalid input\n");
+        .stderr_only("base64: invalid input\n");
 }
 
 #[test]

--- a/tests/by-util/test_basenc.rs
+++ b/tests/by-util/test_basenc.rs
@@ -24,7 +24,7 @@ fn test_z85_not_padded_decode() {
         .args(&["--z85", "-d"])
         .pipe_in("##########")
         .fails()
-        .stderr_only("basenc: error: invalid input\n");
+        .stderr_only("basenc: invalid input\n");
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_z85_not_padded_encode() {
         .args(&["--z85"])
         .pipe_in("123")
         .fails()
-        .stderr_only("basenc: error: invalid input (length must be multiple of 4 characters)\n");
+        .stderr_only("basenc: invalid input (length must be multiple of 4 characters)\n");
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn test_base32_baddecode_keeps_prefix() {
         .pipe_in("MFRGGZDF=")
         .fails()
         .stdout_is("abcde")
-        .stderr_is("basenc: error: invalid input\n");
+        .stderr_is("basenc: invalid input\n");
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn test_base32hex_rejects_trailing_garbage() {
         .pipe_in("VNC0FKD5W")
         .fails()
         .stdout_is_bytes(b"\xFD\xD8\x07\xD1\xA5")
-        .stderr_is("basenc: error: invalid input\n");
+        .stderr_is("basenc: invalid input\n");
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_base32hex_truncated_block_keeps_prefix() {
         .pipe_in("CPNMUO")
         .fails()
         .stdout_is_bytes(b"foo")
-        .stderr_is("basenc: error: invalid input\n");
+        .stderr_is("basenc: invalid input\n");
 }
 
 #[test]

--- a/util/build-gnu.sh
+++ b/util/build-gnu.sh
@@ -275,9 +275,6 @@ sed -i -e "s|invalid suffix in --pages argument|invalid --pages argument|" \
 sed -i "s/\(baddecode.*OUT=>\"\).*\"/\1\"/g" tests/basenc/base64.pl
 sed -i "s/\(\(b2[ml]_[69]\|z85_8\|z85_35\).*OUT=>\)[^}]*\(.*\)/\1\"\"\3/g" tests/basenc/basenc.pl
 
-# add "error: " to the expected error message
-sed -i "s/\$prog: invalid input/\$prog: error: invalid input/g" tests/basenc/basenc.pl
-
 # basenc: swap out error message for unexpected arg
 sed -i "s/  {ERR=>\"\$prog: foobar\\\\n\" \. \$try_help }/  {ERR=>\"error: unexpected argument '--foobar' found\n\n  tip: to pass '--foobar' as a value, use '-- --foobar'\n\nUsage: basenc [OPTION]... [FILE]\n\nFor more information, try '--help'.\n\"}]/" tests/basenc/basenc.pl
 sed -i "s/  {ERR_SUBST=>\"s\/(unrecognized|unknown) option \[-' \]\*foobar\[' \]\*\/foobar\/\"}],//" tests/basenc/basenc.pl


### PR DESCRIPTION
The invalid-input diagnostic carried a literal `error: ` on top of the
program name that `uucore` already prints:

```console
$ printf 'not base64!' | base64 -d            # GNU
base64: invalid input
$ printf 'not base64!' | base64 -d            # uutils, before
base64: error: invalid input

$ printf 'abc' | basenc --z85                 # GNU
basenc: invalid input (length must be multiple of 4 characters)
$ printf 'abc' | basenc --z85                 # uutils, before
basenc: error: invalid input (length must be multiple of 4 characters)
```

No other diagnostic in these utilities spells the word "error" — the
neighbouring messages are `basenc: missing encoding type`,
`base64: extra operand`, and so on — and none of the GNU ones do either.

## The fix

Dropping the prefix from the 13 message literals in
`src/uucore/src/lib/features/encoding.rs` and
`src/uu/base32/src/base_common.rs`, and from the seven test assertions
that pinned the old wording. Nothing else changes: same error kind, same
exit status 1, same trailing detail in the z85 length message.

Not addressed here: GNU also writes the successfully decoded prefix to
stdout before failing, which uutils does not — that is #6008 and is left
alone.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binaries (Homebrew, `gbase32`,
`gbase64`, `gbasenc`) as a black box on undecodable input across
`--base64`, `--base64url`, `--base32`, `--base32hex`, `--base16`, `--z85`
and the plain `base32 -d` / `base64 -d` forms, and diffing stderr against
uutils. I did not read GNU coreutils source.

## Testing

- The seven existing assertions in `tests/by-util/test_base32.rs`,
  `test_base64.rs` and `test_basenc.rs` now pin the GNU wording, so they
  are the mutation check: reverting the two source files alone makes all
  seven fail.
- `cargo test --features "base32 base64 basenc" --test tests test_base`:
  119 passed, 0 failed.
- `cargo clippy -p uu_base32 -p uu_base64 -p uu_basenc --all-targets -- -D warnings`:
  clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over 713 invocations across
  28 utilities: mismatches 79 -> 74 (base32 1 -> 0, basenc 6 -> 2), no
  other bucket moved. The four that remain in these utilities are the
  partial-output difference of #6008.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binaries, not from reading GPL source. All testing
was run locally.
