### PR TITLE
od: say the skip ran past the end of the combined input

### DIFF
--- a/src/uu/od/locales/en-US.ftl
+++ b/src/uu/od/locales/en-US.ftl
@@ -59,7 +59,7 @@ od-error-overflow = Numerical result out of range
 od-error-invalid-suffix = invalid suffix in {$option} argument {$value}
 od-error-invalid-argument = invalid {$option} argument {$value}
 od-error-argument-too-large = {$option} argument {$value} too large
-od-error-skip-past-end = tried to skip past end of input
+od-error-skip-past-end = cannot skip past end of combined input
 
 # Help messages
 od-help-help = Print help information.

--- a/src/uu/od/locales/fr-FR.ftl
+++ b/src/uu/od/locales/fr-FR.ftl
@@ -59,7 +59,7 @@ od-error-parse-failed = échec de l'analyse
 od-error-invalid-suffix = suffixe invalide dans l'argument {$option} {$value}
 od-error-invalid-argument = argument {$option} invalide {$value}
 od-error-argument-too-large = argument {$option} {$value} trop grand
-od-error-skip-past-end = tentative d'ignorer au-delà de la fin de l'entrée
+od-error-skip-past-end = impossible d'ignorer au-delà de la fin de l'entrée combinée
 
 # Messages d'aide
 od-help-help = Afficher les informations d'aide.

--- a/tests/by-util/test_od.rs
+++ b/tests/by-util/test_od.rs
@@ -948,6 +948,21 @@ fn test_skip_bytes_error() {
         .failure();
 }
 
+// The skip is measured over all the inputs joined together, and the message
+// says so, matching GNU od.
+#[test]
+fn test_skip_bytes_past_end_message() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("a", "abc");
+    at.write("b", "de");
+    ucmd.arg("-j6")
+        .arg("a")
+        .arg("b")
+        .fails_with_code(1)
+        .no_stdout()
+        .stderr_only("od: cannot skip past end of combined input\n");
+}
+
 // A seekable special file such as /dev/null can be skipped past its (empty)
 // end without error, matching GNU od.
 #[cfg(unix)]


### PR DESCRIPTION
`-j`/`--skip-bytes` is measured over all the inputs joined together, so the
message naming a single "input" is misleading once more than one file is
given:

```console
$ printf abc > a; printf de > b

$ od -j6 a b          # GNU
od: cannot skip past end of combined input
$ od -j6 a b          # uutils, before
od: tried to skip past end of input
```

GNU prints that one wording for every shape of the failure — one file,
several files, stdin, with or without `-N` — so this is a straight string
change in `src/uu/od/locales/en-US.ftl`, with the French translation
updated to match.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binary (Homebrew, `god`) as a
black box: `-j` past the end of one file, of two files, of piped stdin,
combined with `-N`, and the boundary case `-j5 a b` that must still
succeed. Exit status and stderr diffed against uutils. I did not read GNU
coreutils source.

## Testing

- New `test_skip_bytes_past_end_message` in `tests/by-util/test_od.rs`
  pins the exact stderr and exit status 1 for the two-file case.
  Mutation-checked: reverting the `.ftl` line alone makes it fail.
- `cargo test --features od --test tests test_od`: 78 passed, 0 failed.
- `cargo clippy -p uu_od --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over the 72 `od` invocations
  in my harness: mismatches 2 -> 0.

## Not in scope

Two neighbouring differences left alone: `od -j 1x f` reports
`invalid -j argument '1x'` where GNU reports
`invalid suffix in -j argument '1x'`, and when a named file is missing
uutils prints this skip error after the `No such file or directory` line
while GNU stops at the first.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binary, not from reading GPL source. All testing was
run locally.
