### PR TITLE
env: trace the environment changes under -v

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -830,14 +830,14 @@ impl EnvAppData {
         // NOTE: we manually set and unset the env vars below rather than using Command::env() to more
         //       easily handle the case where no command is given
 
-        apply_removal_of_all_env_vars(&opts);
+        apply_removal_of_all_env_vars(&opts, self.do_debug_printing);
 
         // load .env-style config file prior to those given on the command-line
         load_config_file(&mut opts)?;
 
-        apply_unset_env_vars(&opts)?;
+        apply_unset_env_vars(&opts, self.do_debug_printing)?;
 
-        apply_specified_env_vars(&opts);
+        apply_specified_env_vars(&opts, self.do_debug_printing);
 
         #[cfg(all(unix, not(target_os = "fuchsia")))]
         {
@@ -990,9 +990,12 @@ impl EnvAppData {
     }
 }
 
-fn apply_removal_of_all_env_vars(opts: &Options<'_>) {
+fn apply_removal_of_all_env_vars(opts: &Options<'_>, do_debug_printing: bool) {
     // remove all env vars if told to ignore presets
     if opts.ignore_env {
+        if do_debug_printing {
+            let _ = writeln!(stderr(), "cleaning environ");
+        }
         for (ref name, _) in env::vars_os() {
             unsafe {
                 env::remove_var(name);
@@ -1075,7 +1078,13 @@ fn make_options<'a>(
     Ok(opts)
 }
 
-fn apply_unset_env_vars(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
+fn apply_unset_env_vars(
+    opts: &Options<'_>,
+    do_debug_printing: bool,
+) -> Result<(), Box<dyn UError>> {
+    // -i has already emptied the environment, and GNU does not log the
+    // individual unsets in that case.
+    let do_debug_printing = do_debug_printing && !opts.ignore_env;
     for name in &opts.unsets {
         let native_name = NativeStr::new(name);
         if name.is_empty()
@@ -1086,6 +1095,9 @@ fn apply_unset_env_vars(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
                 125,
                 translate!("env-error-cannot-unset-invalid", "name" => name.quote()),
             ));
+        }
+        if do_debug_printing {
+            let _ = writeln!(stderr(), "unset:    {}", name.to_string_lossy());
         }
         unsafe {
             env::remove_var(name);
@@ -1117,7 +1129,7 @@ fn apply_change_directory(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
     Ok(())
 }
 
-fn apply_specified_env_vars(opts: &Options<'_>) {
+fn apply_specified_env_vars(opts: &Options<'_>, do_debug_printing: bool) {
     // set specified env vars
     for (name, val) in &opts.sets {
         /*
@@ -1148,6 +1160,14 @@ fn apply_specified_env_vars(opts: &Options<'_>) {
                 translate!("env-warning-no-name-specified", "value" => val.quote())
             );
             continue;
+        }
+        if do_debug_printing {
+            let _ = writeln!(
+                stderr(),
+                "setenv:   {}={}",
+                name.to_string_lossy(),
+                val.to_string_lossy()
+            );
         }
         unsafe {
             env::set_var(name, val);

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -265,6 +265,7 @@ fn test_debug2_part_of_string_arg() {
             r"arg\[2\]: '[^\n]+(\/|\\)coreutils(.exe)?'\n",
             r"arg\[3\]: 'echo'\n",
             r"arg\[4\]: 'hello2'\n",
+            r"setenv:   FOO=BAR\n",
             r"executing: [^\n]+(\/|\\)coreutils(.exe)?\n",
             r"   arg\[0\]= '[^\n]+(\/|\\)coreutils(.exe)?'\n",
             r"   arg\[1\]= 'echo'\n",
@@ -2259,4 +2260,36 @@ env: no terminating quote in -S string at position 18 for quote '''
             .fails_with_code(125)
             .stderr_is("env: no terminating quote in -S string at position 18 for quote '''\n");
     }
+}
+
+/// -v traces what it does to the environment before exec, as GNU does:
+/// "cleaning environ" for -i, one "unset:" line per -u and one "setenv:"
+/// line per assignment.
+///
+/// Unix only: the trace is checked around `true`, and `-i` leaves no PATH for
+/// Windows to find a command with.
+#[test]
+#[cfg(unix)]
+fn test_debug_traces_environment_changes() {
+    new_ucmd!()
+        .args(&["-v", "-u", "A", "-u", "B", "FOO=1", "true"])
+        .succeeds()
+        .stderr_contains("unset:    A\nunset:    B\nsetenv:   FOO=1\nexecuting: true\n");
+
+    new_ucmd!()
+        .args(&["-v", "-i", "FOO=1", "true"])
+        .succeeds()
+        .stderr_contains("cleaning environ\nsetenv:   FOO=1\nexecuting: true\n");
+
+    // -i has already emptied the environment, so the unset is not logged.
+    new_ucmd!()
+        .args(&["-v", "-i", "-u", "PATH", "true"])
+        .succeeds()
+        .stderr_contains("cleaning environ\nexecuting: true\n");
+
+    // Without -v nothing is traced.
+    new_ucmd!()
+        .args(&["-i", "-u", "A", "FOO=1", "true"])
+        .succeeds()
+        .no_stderr();
 }


### PR DESCRIPTION
`-v` printed only the exec, not what it had just done to the environment:

```console
$ env -v -i true          # GNU
cleaning environ
executing: true
   arg[0]= 'true'
$ env -v -i true          # uutils, before
executing: true
   arg[0]= 'true'

$ env -v -u A -u B FOO=1 true     # GNU
unset:    A
unset:    B
setenv:   FOO=1
executing: true
   arg[0]= 'true'
$ env -v -u A -u B FOO=1 true     # uutils, before
executing: true
   arg[0]= 'true'
```

## The fix

`apply_removal_of_all_env_vars`, `apply_unset_env_vars` and
`apply_specified_env_vars` take the existing `do_debug_printing` flag and
emit their line, in the order they already run — which is the order GNU
prints them in. Column padding matches GNU (`unset:` and `setenv:` pad to
the width of `executing:`), and neither name nor value is quoted.

`-i` is a special case: it has already emptied the environment, so GNU
prints `cleaning environ` and no `unset:` lines at all. That is reproduced.

## How the GNU behavior was established

By running the installed GNU coreutils 9.11 binary (Homebrew, `genv`) as a
black box over 11 combinations of `-v`, `-i`, `-u` and `NAME=VALUE`,
including `-i` with `-u`, several `-u`, a value containing a space and a
quote, and `-v -i` with no command, diffing stderr byte for byte against
uutils. All 11 now match. I did not read GNU coreutils source.

## Testing

- New `test_debug_traces_environment_changes` in
  `tests/by-util/test_env.rs`: the `-u`/assignment trace, the `-i` trace,
  the `-i` plus `-u` case that must log no unset, and the no-`-v` case
  that must stay silent. Mutation-checked: reverting `env.rs` alone makes
  it fail.
  `test_debug2_part_of_string_arg` gains the `setenv:` line it now emits.
- `cargo test --features env --test tests test_env`: 103 passed, 0 failed.
- `cargo clippy -p uu_env --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Differential A/B against GNU coreutils 9.11 over the 16 `env`
  invocations in my harness: mismatches 3 -> 2.

## Not in scope

The two remaining mismatches are unrelated to `-v`: `env A=1 -- printenv A`
adds a `use -[v]S to pass options in shebang lines` line GNU does not
print, and `env -S '\techo x'` unescapes the `\t` in the program name it
reports as missing.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. Every GNU behavior quoted above came from
running the installed binary, not from reading GPL source. All testing was
run locally.
