### PR TITLE
date: align Thai locale formatting with GNU

### DIFF
--- a/src/uucore/src/lib/features/i18n/datetime.rs
+++ b/src/uucore/src/lib/features/i18n/datetime.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore fieldsets prefs febr abmon langinfo uppercased
+// spell-checker:ignore fieldsets prefs febr abmon langinfo uppercased พ.ศ.
 
 //! Locale-aware datetime formatting utilities using ICU and jiff-icu
 
@@ -67,6 +67,59 @@ pub enum CalendarType {
     Ethiopian,
 }
 
+/// Thai solar month names used by GNU coreutils for th_TH (post-1941 layout).
+fn thai_month_name(date: &Date<Iso>, long: bool) -> Option<String> {
+    // spell-checker:ignore มกราคม กุมภาพันธ์ มีนาคม เมษายน พฤษภาคม มิถุนายน กรกฎาคม สิงหาคม กันยายน ตุลาคม พฤศจิกายน ธันวาคม
+    // spell-checker:ignore ม.ค. ก.พ. มี.ค. เม.ย. พ.ค. มิ.ย. ก.ค. ส.ค. ก.ย. ต.ค. พ.ย. ธ.ค.
+    const FULL: [&str; 12] = [
+        "มกราคม",
+        "กุมภาพันธ์",
+        "มีนาคม",
+        "เมษายน",
+        "พฤษภาคม",
+        "มิถุนายน",
+        "กรกฎาคม",
+        "สิงหาคม",
+        "กันยายน",
+        "ตุลาคม",
+        "พฤศจิกายน",
+        "ธันวาคม",
+    ];
+    const ABBREV: [&str; 12] = [
+        "ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.",
+        "ธ.ค.",
+    ];
+    let ordinal = usize::from(date.month().ordinal).checked_sub(1)?;
+    Some(if long {
+        FULL[ordinal].to_string()
+    } else {
+        ABBREV[ordinal].to_string()
+    })
+}
+
+/// Thai weekday names matching glibc `th_TH` / GNU date output.
+fn thai_weekday_name(date: &Date<Iso>, long: bool) -> Option<String> {
+    // spell-checker:ignore อาทิตย์ จันทร์ อังคาร พุธ พฤหัสบดี ศุกร์ เสาร์
+    // spell-checker:ignore อา. จ. อ. พ. พฤ. ศ. ส.
+    // Index 0 = Sunday, matching libc DAY_1 / ICU weekday % 7.
+    const FULL: [&str; 7] = [
+        "อาทิตย์",
+        "จันทร์",
+        "อังคาร",
+        "พุธ",
+        "พฤหัสบดี",
+        "ศุกร์",
+        "เสาร์",
+    ];
+    const ABBREV: [&str; 7] = ["อา.", "จ.", "อ.", "พ.", "พฤ.", "ศ.", "ส."];
+    let weekday = usize::from((date.weekday() as u8) % 7);
+    Some(if long {
+        FULL[weekday].to_string()
+    } else {
+        ABBREV[weekday].to_string()
+    })
+}
+
 /// Transform a strftime format string to use locale-specific calendar values
 pub fn localize_format_string(format: &str, date: JiffDate) -> String {
     const PERCENT_PLACEHOLDER: &str = "\x00\x00";
@@ -76,74 +129,104 @@ pub fn localize_format_string(format: &str, date: JiffDate) -> String {
 
     let mut fmt = format.replace("%%", PERCENT_PLACEHOLDER);
 
-    // For non-Gregorian calendars, replace date components with converted values
+    // Match GNU coreutils' non-Gregorian calendar support in strftime: for
+    // th_TH, %Y/%m/%d use the Thai solar (Buddhist) calendar, while era
+    // conversions (%EY/%EC/%Ey) follow the locale's พ.ศ. era.
     let calendar_type = get_locale_calendar_type(locale);
-    if calendar_type != CalendarType::Gregorian {
-        let (cal_year, cal_month, cal_day) = match calendar_type {
-            CalendarType::Buddhist => {
-                let d = iso_date.to_calendar(Buddhist);
-                (
-                    d.year().extended_year(),
-                    d.month().ordinal,
-                    d.day_of_month().0,
-                )
-            }
-            CalendarType::Persian => {
-                let d = iso_date.to_calendar(Persian);
-                (
-                    d.year().extended_year(),
-                    d.month().ordinal,
-                    d.day_of_month().0,
-                )
-            }
-            CalendarType::Ethiopian => {
-                let d = iso_date.to_calendar(Ethiopian::new());
-                (
-                    d.year().extended_year(),
-                    d.month().ordinal,
-                    d.day_of_month().0,
-                )
-            }
-            CalendarType::Gregorian => unreachable!(),
-        };
-        fmt = fmt
-            .replace("%Y", &cal_year.to_string())
-            .replace("%m", &format!("{cal_month:02}"))
-            .replace("%d", &format!("{cal_day:02}"))
-            .replace("%e", &format!("{cal_day:2}"));
+    match calendar_type {
+        CalendarType::Buddhist => {
+            let d = iso_date.to_calendar(Buddhist);
+            let buddhist_year = d.year().extended_year();
+            let cal_month = d.month().ordinal;
+            let cal_day = d.day_of_month().0;
+            fmt = fmt
+                .replace("%EY", &format!("พ.ศ. {buddhist_year}"))
+                .replace("%EC", "พ.ศ.")
+                .replace("%Ey", &buddhist_year.to_string())
+                .replace("%Y", &buddhist_year.to_string())
+                .replace("%m", &format!("{cal_month:02}"))
+                .replace("%d", &format!("{cal_day:02}"))
+                .replace("%e", &format!("{cal_day:2}"));
+        }
+        CalendarType::Persian => {
+            let d = iso_date.to_calendar(Persian);
+            let cal_year = d.year().extended_year();
+            let cal_month = d.month().ordinal;
+            let cal_day = d.day_of_month().0;
+            fmt = fmt
+                .replace("%Y", &cal_year.to_string())
+                .replace("%m", &format!("{cal_month:02}"))
+                .replace("%d", &format!("{cal_day:02}"))
+                .replace("%e", &format!("{cal_day:2}"));
+        }
+        CalendarType::Ethiopian => {
+            let d = iso_date.to_calendar(Ethiopian::new());
+            let cal_year = d.year().extended_year();
+            let cal_month = d.month().ordinal;
+            let cal_day = d.day_of_month().0;
+            fmt = fmt
+                .replace("%Y", &cal_year.to_string())
+                .replace("%m", &format!("{cal_month:02}"))
+                .replace("%d", &format!("{cal_day:02}"))
+                .replace("%e", &format!("{cal_day:2}"));
+        }
+        CalendarType::Gregorian => {}
     }
 
-    // Format localized names using ICU DateTimeFormatter
-    let locale_prefs = locale.clone().into();
-
-    if fmt.contains("%B")
-        && let Ok(f) = DateTimeFormatter::try_new(locale_prefs, fieldsets::M::long())
-    {
-        fmt = fmt.replace("%B", &f.format(&iso_date).to_string());
+    // Prefer GNU Thai names for th_* locales; otherwise use ICU.
+    let is_thai = locale.to_string().starts_with("th");
+    if fmt.contains("%B") {
+        if is_thai {
+            if let Some(name) = thai_month_name(&iso_date, true) {
+                fmt = fmt.replace("%B", &name);
+            }
+        } else if let Ok(f) =
+            DateTimeFormatter::try_new(locale.clone().into(), fieldsets::M::long())
+        {
+            fmt = fmt.replace("%B", &f.format(&iso_date).to_string());
+        }
     }
-    if (fmt.contains("%b") || fmt.contains("%h"))
-        && let Ok(f) = DateTimeFormatter::try_new(locale_prefs, fieldsets::M::medium())
-    {
-        // ICU's medium format may include trailing periods (e.g., "febr." for Hungarian),
-        // which when combined with locale format strings that also add periods after
-        // %b (e.g., "%Y. %b. %d") results in double periods ("febr..").
-        // The standard C/POSIX locale via nl_langinfo returns abbreviations
-        // WITHOUT trailing periods, so we strip them here for consistency.
-        let month_abbrev = f.format(&iso_date).to_string();
-        let month_abbrev = month_abbrev.trim_end_matches('.').to_string();
-        fmt = fmt
-            .replace("%b", &month_abbrev)
-            .replace("%h", &month_abbrev);
+    if fmt.contains("%b") || fmt.contains("%h") {
+        if is_thai {
+            if let Some(name) = thai_month_name(&iso_date, false) {
+                fmt = fmt.replace("%b", &name).replace("%h", &name);
+            }
+        } else if let Ok(f) =
+            DateTimeFormatter::try_new(locale.clone().into(), fieldsets::M::medium())
+        {
+            // ICU's medium format may include trailing periods (e.g., "febr." for Hungarian),
+            // which when combined with locale format strings that also add periods after
+            // %b (e.g., "%Y. %b. %d") results in double periods ("febr..").
+            // The standard C/POSIX locale via nl_langinfo returns abbreviations
+            // WITHOUT trailing periods, so we strip them here for consistency.
+            let month_abbrev = f.format(&iso_date).to_string();
+            let month_abbrev = month_abbrev.trim_end_matches('.').to_string();
+            fmt = fmt
+                .replace("%b", &month_abbrev)
+                .replace("%h", &month_abbrev);
+        }
     }
-    if fmt.contains("%A")
-        && let Ok(f) = DateTimeFormatter::try_new(locale_prefs, fieldsets::E::long())
-    {
-        fmt = fmt.replace("%A", &f.format(&iso_date).to_string());
+    if fmt.contains("%A") {
+        if is_thai {
+            if let Some(name) = thai_weekday_name(&iso_date, true) {
+                fmt = fmt.replace("%A", &name);
+            }
+        } else if let Ok(f) =
+            DateTimeFormatter::try_new(locale.clone().into(), fieldsets::E::long())
+        {
+            fmt = fmt.replace("%A", &f.format(&iso_date).to_string());
+        }
     }
-    if fmt.contains("%a")
-        && let Ok(f) = DateTimeFormatter::try_new(locale_prefs, fieldsets::E::short())
-    {
-        fmt = fmt.replace("%a", &f.format(&iso_date).to_string());
+    if fmt.contains("%a") {
+        if is_thai {
+            if let Some(name) = thai_weekday_name(&iso_date, false) {
+                fmt = fmt.replace("%a", &name);
+            }
+        } else if let Ok(f) =
+            DateTimeFormatter::try_new(locale.clone().into(), fieldsets::E::short())
+        {
+            fmt = fmt.replace("%a", &f.format(&iso_date).to_string());
+        }
     }
 
     fmt.replace(PERCENT_PLACEHOLDER, "%%")

--- a/tests/by-util/test_date.rs
+++ b/tests/by-util/test_date.rs
@@ -2365,8 +2365,8 @@ fn test_date_ethiopian_locale_calendar() {
 #[test]
 #[cfg(unix)]
 fn test_date_thai_locale_solar_calendar() {
-    // Test Thai locale uses Thai solar calendar
-    // Verify the Thai solar calendar is used with the Thai locale
+    // Match GNU tests/date/date-thailand.sh: Thai solar calendar for %Y,
+    // Thai month names, Gregorian for --iso-8601 / --rfc-3339.
     if !is_locale_available("th_TH.UTF-8") {
         println!("Skipping Thai locale test - th_TH.UTF-8 locale not available");
         return;
@@ -2394,6 +2394,36 @@ fn test_date_thai_locale_solar_calendar() {
 
     assert_eq!(thai_year, current_year + 543);
 
+    let buddhist_year = current_year + 543;
+
+    // GNU date also formats the locale era via %EY / %EC / %Ey.
+    let thai_ey_year = new_ucmd!()
+        .env("LC_ALL", "th_TH.UTF-8")
+        .arg("+%EY")
+        .succeeds()
+        .stdout_str()
+        .trim()
+        .to_string();
+    assert_eq!(thai_ey_year, format!("พ.ศ. {buddhist_year}"));
+
+    let thai_ec = new_ucmd!()
+        .env("LC_ALL", "th_TH.UTF-8")
+        .arg("+%EC")
+        .succeeds()
+        .stdout_str()
+        .trim()
+        .to_string();
+    assert_eq!(thai_ec, "พ.ศ.");
+
+    let thai_ey = new_ucmd!()
+        .env("LC_ALL", "th_TH.UTF-8")
+        .arg("+%Ey")
+        .succeeds()
+        .stdout_str()
+        .trim()
+        .to_string();
+    assert_eq!(thai_ey, buddhist_year.to_string());
+
     // All months that have 31 days have names that end with "คม" (Thai characters)
     let days_31_suffix = "\u{0E04}\u{0E21}"; // "คม" in Unicode
 
@@ -2411,6 +2441,14 @@ fn test_date_thai_locale_solar_calendar() {
             "Month {month} should end with 'คม', got: {month_name}"
         );
     }
+
+    // GNU date keeps Thai month/day names with solar-calendar %Y.
+    check_date(
+        "th_TH.UTF-8",
+        "2026-06-14",
+        "+%Y %EY %B %A",
+        "2569 พ.ศ. 2569 มิถุนายน อาทิตย์",
+    );
 
     // Check that --iso-8601 and --rfc-3339 use the Gregorian calendar
     let iso_result = new_ucmd!()
@@ -2463,7 +2501,7 @@ fn test_locale_calendar_conversions() {
         check_date("fa_IR.UTF-8", d, "+%Y-%m-%d", e);
     }
 
-    // Thai Buddhist (year + 543, same month/day)
+    // Thai Buddhist / solar calendar (year + 543, same month/day since 1941)
     for (d, e) in [
         ("2026-01-01", "2569-01-01"),
         ("2026-01-26", "2569-01-26"),
@@ -2475,6 +2513,7 @@ fn test_locale_calendar_conversions() {
         ("1970-01-01", "2513-01-01"),
     ] {
         check_date("th_TH.UTF-8", d, "+%Y-%m-%d", e);
+        check_date("th_TH.UTF-8", d, "+%EY-%m-%d", &format!("พ.ศ. {e}"));
     }
 
     // Ethiopian (13 months, New Year on Sept 11)


### PR DESCRIPTION
Match GNU Thai solar calendar behavior for `th_TH`:

- `%Y` / `%m` / `%d` use Buddhist-era values
- `%EY` / `%EC` / `%Ey` use พ.ศ. era forms
- Thai month/weekday names match GNU

Fixes the empty/closed state of #12921 after a bad rebase.