### PR TITLE
csplit: a negative offset may not cross the split start

### DIFF
--- a/src/uu/csplit/src/csplit.rs
+++ b/src/uu/csplit/src/csplit.rs
@@ -482,6 +482,11 @@ impl SplitWriter<'_> {
             // The consequence is that the buffer may already be full with lines from a previous
             // split, which is taken care of when calling `shrink_buffer_to_size`.
             let offset_usize = offset.unsigned_abs() as usize;
+            // Number of lines belonging to the current split that were read before the
+            // matching line: the ones already held in the buffer (they are written to the
+            // current split by `shrink_buffer_to_size`) plus the ones read below. The target
+            // line of a negative offset may not go back past the start of the current split.
+            let mut lines_in_split = input_iter.buffer_len();
             input_iter.set_size_of_buffer(offset_usize);
             while let Some((ln, line)) = input_iter.next() {
                 let line = line?;
@@ -489,6 +494,10 @@ impl SplitWriter<'_> {
                     .strip_suffix("\r\n")
                     .unwrap_or_else(|| line.strip_suffix('\n').unwrap_or(&line));
                 if regex.is_match(l) {
+                    if offset_usize > lines_in_split {
+                        self.finish_split()?;
+                        return Err(CsplitError::LineOutOfRange(pattern_as_str.to_string()));
+                    }
                     for line in input_iter.shrink_buffer_to_size() {
                         self.writeln(&line)?;
                     }
@@ -507,11 +516,9 @@ impl SplitWriter<'_> {
                     }
 
                     self.finish_split()?;
-                    if input_iter.buffer_len() < offset_usize {
-                        return Err(CsplitError::LineOutOfRange(pattern_as_str.to_string()));
-                    }
                     return Ok(());
                 }
+                lines_in_split += 1;
                 if let Some(line) = input_iter.add_line_to_buffer(ln, line) {
                     self.writeln(&line)?;
                 }

--- a/tests/by-util/test_csplit.rs
+++ b/tests/by-util/test_csplit.rs
@@ -237,6 +237,92 @@ fn test_up_to_match_negative_offset() {
 }
 
 #[test]
+fn test_up_to_match_negative_offset_before_split_start() {
+    // The target line (match minus the offset) may not precede the start of the
+    // current split.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "/3$/-3"])
+        .fails()
+        .stdout_is("0\n")
+        .stderr_is("csplit: '/3$/-3': line number out of range\n");
+
+    assert_eq!(
+        glob(&at.plus_as_string("xx*"))
+            .expect("there should be no splits created")
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn test_up_to_match_negative_offset_at_split_start() {
+    // The target line is exactly the first line of the current split: an empty
+    // split, not an error.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "/3$/-2"])
+        .succeeds()
+        .stdout_only("0\n141\n");
+
+    assert_eq!(at.read("xx00"), "");
+    assert_eq!(at.read("xx01"), generate(1, 51));
+}
+
+#[test]
+fn test_up_to_match_negative_offset_before_second_split_start() {
+    // The bound is the start of the current split, not the start of the input.
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "/10$/", "/12$/-3"])
+        .fails()
+        .stdout_is("18\n0\n")
+        .stderr_is("csplit: '/12$/-3': line number out of range\n");
+
+    assert_eq!(
+        glob(&at.plus_as_string("xx*"))
+            .expect("there should be no splits created")
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn test_up_to_match_negative_offset_at_second_split_start() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "/10$/", "/12$/-2"])
+        .succeeds()
+        .stdout_only("18\n0\n123\n");
+
+    assert_eq!(at.read("xx00"), generate(1, 10));
+    assert_eq!(at.read("xx01"), "");
+    assert_eq!(at.read("xx02"), generate(10, 51));
+}
+
+#[test]
+fn test_up_to_match_negative_offset_before_split_start_keep_files() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["-k", "numbers50.txt", "/3$/-3"])
+        .fails()
+        .stdout_is("0\n")
+        .stderr_is("csplit: '/3$/-3': line number out of range\n");
+
+    assert_eq!(at.read("xx00"), "");
+}
+
+#[test]
+fn test_skip_to_match_negative_offset_before_split_start() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    ucmd.args(&["numbers50.txt", "%3$%-3"])
+        .fails()
+        .stderr_is("csplit: '%3$%-3': line number out of range\n");
+
+    assert_eq!(
+        glob(&at.plus_as_string("xx*"))
+            .expect("there should be no splits created")
+            .count(),
+        0
+    );
+}
+
+#[test]
 fn test_up_to_match_negative_offset_min_i32() {
     new_ucmd!()
         .args(&["numbers50.txt", "/45/-2147483648"])


### PR DESCRIPTION
For `/re/-N`, GNU requires the target line (the match minus `N`) to be at or
after the first line of the *current* split; otherwise it fails:

```console
$ seq 50 | csplit - '/3$/-3'      # GNU: 'line number out of range', status 1, no xx* files
$ seq 50 | csplit - '/3$/-3'      # uutils, before: splits at line 0, status 0
$ seq 50 | csplit - '/10$/' '/12$/-3'   # same, for a split that does not start at line 1
```

uutils only checked that the target does not precede the start of the *input*
(`buffer_len() < offset`), so a negative offset could silently reach back into a
previous split. `do_to_match` now counts the lines of the current split read
before the match (the ones carried over in the buffer plus the ones read in the
loop) and reports the existing `LineOutOfRange` error when the offset exceeds
them. The old buffer-length check is the same test in the special case of the
first split, so it is dropped. Target line exactly at the split start stays a
valid (empty) split. `%re%-N`, `{N}` repetitions, `-k`, `-z`, `-s` and
`--suppress-matched` all follow.

## Testing

- 6 new tests in `tests/by-util/test_csplit.rs` (exact stderr, status, and the
  absence/presence of the split files). Mutation-checked: reverting
  `csplit.rs` alone fails 4 of them.
- `cargo test --features csplit --test tests test_csplit`: 95 passed, 0 failed.
- `cargo clippy -p uu_csplit --all-targets -- -D warnings` and `cargo fmt --check`: clean.
- Differential run against GNU coreutils 9.11 over 27 `csplit` invocations
  (negative offsets shorter/equal/longer than the distance to the split start,
  in the first, second and third split, with the options above, plus `/re/+N`
  and `%re%-N` for contrast): 12 mismatches before, 0 after.
- The behavior was established by running the installed GNU 9.11 binary as a
  black box; I did not read GNU coreutils source.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI policy
in CONTRIBUTING.md. All testing was run locally.
