### PR TITLE
dircolors: honor TERM/COLORTERM for the built-in database

### DIFF
--- a/src/uu/dircolors/src/dircolors.rs
+++ b/src/uu/dircolors/src/dircolors.rs
@@ -86,7 +86,22 @@ fn generate_type_output(fmt: &OutputFmt) -> String {
     }
 }
 
+/// The built-in database is guarded by `COLORTERM ?*` followed by one `TERM`
+/// entry per known terminal. Those entries only take effect when one of them
+/// matches the environment, so reproduce that check before emitting anything.
+fn builtin_database_applies() -> bool {
+    if !env::var("COLORTERM").unwrap_or_default().is_empty() {
+        return true;
+    }
+    let term = env::var("TERM").unwrap_or_else(|_| "none".to_owned());
+    TERMS.iter().any(|pattern| term.fnmatch(pattern))
+}
+
 fn generate_ls_colors(fmt: &OutputFmt, sep: &str) -> String {
+    if !builtin_database_applies() {
+        let (prefix, suffix) = get_colors_format_strings(fmt);
+        return format!("{prefix}{suffix}");
+    }
     if let OutputFmt::Display = fmt {
         let mut display_parts = vec![];
         let type_output = generate_type_output(fmt);

--- a/tests/by-util/test_dircolors.rs
+++ b/tests/by-util/test_dircolors.rs
@@ -51,6 +51,7 @@ fn test_internal_db() {
 #[test]
 fn test_ls_colors() {
     new_ucmd!()
+        .env("TERM", "screen")
         .arg("--print-ls-colors")
         .succeeds()
         .stdout_is_fixture("ls_colors.expected");
@@ -248,4 +249,67 @@ fn test_invalid_term_glob() {
         .args(&["-b", "-"])
         .succeeds()
         .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
+}
+
+#[test]
+fn test_builtin_database_unknown_term() {
+    for (arg, expected) in [
+        ("-b", "LS_COLORS='';\nexport LS_COLORS\n"),
+        ("-c", "setenv LS_COLORS ''\n"),
+    ] {
+        new_ucmd!()
+            .env("TERM", "no-such-terminal")
+            .arg(arg)
+            .succeeds()
+            .stdout_only(expected);
+    }
+}
+
+#[test]
+fn test_builtin_database_no_term() {
+    new_ucmd!()
+        .arg("-b")
+        .succeeds()
+        .stdout_only("LS_COLORS='';\nexport LS_COLORS\n");
+}
+
+#[test]
+fn test_builtin_database_print_ls_colors_unknown_term() {
+    new_ucmd!()
+        .env("TERM", "no-such-terminal")
+        .arg("--print-ls-colors")
+        .succeeds()
+        .stdout_only("\n");
+}
+
+#[test]
+fn test_builtin_database_known_term() {
+    let stdout = new_ucmd!()
+        .env("TERM", "xterm")
+        .arg("-b")
+        .succeeds()
+        .stdout_move_str();
+    assert!(stdout.contains("di=01;34"), "{stdout}");
+}
+
+#[test]
+fn test_builtin_database_colorterm_without_term() {
+    let stdout = new_ucmd!()
+        .env("TERM", "no-such-terminal")
+        .env("COLORTERM", "truecolor")
+        .arg("-b")
+        .succeeds()
+        .stdout_move_str();
+    assert!(stdout.contains("di=01;34"), "{stdout}");
+}
+
+#[test]
+fn test_print_database_ignores_term() {
+    // -p dumps the database itself, so it is not filtered by TERM.
+    let stdout = new_ucmd!()
+        .env("TERM", "no-such-terminal")
+        .arg("-p")
+        .succeeds()
+        .stdout_move_str();
+    assert!(stdout.contains("DIR 01;34"), "{stdout}");
 }


### PR DESCRIPTION
Without a config file, `dircolors` emitted the whole built-in database no
matter what terminal it was running under:

```console
$ env -u TERM dircolors -b        # GNU
LS_COLORS='';
export LS_COLORS
$ env -u TERM dircolors -b        # uutils, before
LS_COLORS='rs=0:di=01;34:ln=01;36:...'   # the full database
```

Same for `TERM=dumb`, `TERM=some-unknown-term`, `-c` and `--print-ls-colors`.
The config-file path already honors `TERM`/`COLORTERM` lines; only the
built-in path did not.

## The fix

The built-in database is guarded by `COLORTERM ?*` plus one `TERM` entry per
known terminal — the entries `--print-database` prints. `generate_ls_colors`
now applies that same guard before emitting anything, using the `TERMS` list
and the existing `fnmatch` helper, and returns an empty `LS_COLORS` when
nothing matches. `-p` still dumps the database unfiltered, as before.

## Testing

- New tests in `tests/by-util/test_dircolors.rs` covering unknown `TERM`,
  unset `TERM`, `--print-ls-colors`, a known `TERM`, `COLORTERM` with an
  unknown `TERM`, and `-p` staying unfiltered. Mutation-checked: neutering
  the guard fails three of them.
- `test_ls_colors` gained `.env("TERM", "screen")`, matching its `-b`/`-c`
  siblings; it previously relied on the unfiltered output.
- `cargo test --features dircolors --test tests test_dircolors`: 24 passed,
  0 failed. `cargo clippy -p uu_dircolors --all-targets -- -D warnings` and
  `cargo fmt --check`: clean.
- Differential run against GNU coreutils 9.11 (Homebrew), 4 option sets x 8
  `TERM`/`COLORTERM` combinations plus 5 config-file cases: 8 filtering
  mismatches before, 0 after, no case regressed.

## Disclosure

Prepared with AI assistance (Claude Opus 5, via Claude Code), per the AI
policy in CONTRIBUTING.md. GNU behavior above came from running the
installed binary, not from reading GPL source. All testing was run locally.
