### PR TITLE
printf: honor POSIXLY_CORRECT for the character-constant warning

### DIFF
--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -222,9 +222,14 @@ fn extract_value<T: Default>(
                 ExtendedParserError::PartialMatch(v, rest) => {
                     if quote_start {
                         set_exit_code(0);
-                        show_warning!(
-                            "{rest}: character(s) following character constant have been ignored"
-                        );
+                        // GNU stays silent about the ignored trailing bytes when
+                        // POSIXLY_CORRECT is set. Only the presence of the variable
+                        // matters, its value is irrelevant.
+                        if std::env::var_os("POSIXLY_CORRECT").is_none() {
+                            show_warning!(
+                                "{rest}: character(s) following character constant have been ignored"
+                            );
+                        }
                     } else {
                         show_error!("{}: value not completely converted", input.quote());
                     }

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -865,6 +865,40 @@ fn partial_char() {
 }
 
 #[test]
+fn partial_char_posixly_correct() {
+    // GNU suppresses the "character(s) following character constant" warning
+    // when POSIXLY_CORRECT is set. Only the presence of the variable matters,
+    // its value is irrelevant.
+    for value in ["1", "", "0"] {
+        for arg in ["'AB", "'ABC", "\"AB", "'-1"] {
+            new_ucmd!()
+                .args(&["%d", arg])
+                .env("POSIXLY_CORRECT", value)
+                .succeeds()
+                .no_stderr();
+        }
+    }
+
+    // Without POSIXLY_CORRECT the warning is still emitted.
+    for (arg, rest) in [("'AB", "B"), ("'ABC", "BC"), ("\"AB", "B"), ("'-1", "1")] {
+        new_ucmd!().args(&["%d", arg]).succeeds().stderr_is(format!(
+            "printf: warning: {rest}: character(s) following character constant have been ignored\n"
+        ));
+    }
+}
+
+#[test]
+fn value_not_completely_converted_ignores_posixly_correct() {
+    // POSIXLY_CORRECT only silences the character-constant warning; the
+    // unrelated "value not completely converted" error is unaffected.
+    new_ucmd!()
+        .args(&["%d", "42abc"])
+        .env("POSIXLY_CORRECT", "1")
+        .fails_with_code(1)
+        .stderr_contains("value not completely converted");
+}
+
+#[test]
 fn sub_alternative_lower_hex_0() {
     new_ucmd!().args(&["%#x", "0"]).succeeds().stdout_only("0");
 }


### PR DESCRIPTION
`printf '%d' "'AB"` warns that the trailing `B` was ignored. GNU stays silent when
`POSIXLY_CORRECT` is set, and our `--help` already says so:

> If there are additional bytes, they will throw an error (unless the environment
> variable POSIXLY_CORRECT is set)

Measured against GNU coreutils 9.11, `LC_ALL=C` (9.7 and 9.10 identical):

    argument "'AB"                  GNU       before    after
    POSIXLY_CORRECT unset           warns     warns     warns
    POSIXLY_CORRECT=1               silent    warns     silent
    POSIXLY_CORRECT=""              silent    warns     silent
    POSIXLY_CORRECT=0               silent    warns     silent
    POSIXLY_CORRECT=<non-UTF-8>     silent    warns     silent

Only the presence of the variable matters, not its value, so this uses
`env::var_os(...).is_none()` rather than `env::var(...)`, which reports a set but
non-UTF-8 value as absent.

The unrelated "value not completely converted" error is left alone; GNU keeps that
one under `POSIXLY_CORRECT` too.
