### PR TITLE
fmt: honor -x and -X instead of always matching prefixes exactly

### DIFF
--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -108,9 +108,6 @@ impl FmtOptions {
             tagged = false;
         }
 
-        // `contains_id` is true whenever the argument has a value, and `SetTrue`
-        // gives these flags a default of `false`, so it was always true and both
-        // prefixes were matched exactly whether or not `-x`/`-X` was passed.
         let xprefix = matches.get_flag(options::EXACT_PREFIX);
         let xanti_prefix = matches.get_flag(options::EXACT_SKIP_PREFIX);
 

--- a/src/uu/fmt/src/fmt.rs
+++ b/src/uu/fmt/src/fmt.rs
@@ -108,8 +108,11 @@ impl FmtOptions {
             tagged = false;
         }
 
-        let xprefix = matches.contains_id(options::EXACT_PREFIX);
-        let xanti_prefix = matches.contains_id(options::SKIP_PREFIX);
+        // `contains_id` is true whenever the argument has a value, and `SetTrue`
+        // gives these flags a default of `false`, so it was always true and both
+        // prefixes were matched exactly whether or not `-x`/`-X` was passed.
+        let xprefix = matches.get_flag(options::EXACT_PREFIX);
+        let xanti_prefix = matches.get_flag(options::EXACT_SKIP_PREFIX);
 
         let prefix = matches.get_one::<String>(options::PREFIX).map(String::from);
         let anti_prefix = matches

--- a/tests/by-util/test_fmt.rs
+++ b/tests/by-util/test_fmt.rs
@@ -341,6 +341,56 @@ fn prefix_equal_skip_prefix_equal_two() {
 }
 
 #[test]
+fn prefix_ignores_leading_whitespace_without_exact_prefix() {
+    for prefix_args in [vec!["-p", "> "], vec!["--prefix", "> "]] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .pipe_in("  > alpha\n  > beta\n")
+            .succeeds()
+            .stdout_only("  > alpha beta\n");
+    }
+}
+
+#[test]
+fn exact_prefix_requires_the_prefix_to_start_the_line() {
+    for prefix_args in [
+        vec!["-x", "-p", "> "],
+        vec!["--exact-prefix", "--prefix", "> "],
+    ] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .pipe_in("  > alpha\n  > beta\n")
+            .succeeds()
+            .stdout_only("  > alpha\n  > beta\n");
+    }
+}
+
+#[test]
+fn skip_prefix_ignores_leading_whitespace_without_exact_skip_prefix() {
+    for prefix_args in [vec!["-P", "#"], vec!["--skip-prefix", "#"]] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .pipe_in("  # note\n  # more\n")
+            .succeeds()
+            .stdout_only("  # note\n  # more\n");
+    }
+}
+
+#[test]
+fn exact_skip_prefix_requires_the_prefix_to_start_the_line() {
+    for prefix_args in [
+        vec!["-X", "-P", "#"],
+        vec!["--exact-skip-prefix", "--skip-prefix", "#"],
+    ] {
+        new_ucmd!()
+            .args(&prefix_args)
+            .pipe_in("  # note\n  # more\n")
+            .succeeds()
+            .stdout_only("  # note # more\n");
+    }
+}
+
+#[test]
 fn test_fmt_unicode_whitespace_handling() {
     // Character classification fix: Test that Unicode whitespace characters like non-breaking space
     // are NOT treated as whitespace by fmt, maintaining GNU fmt compatibility.


### PR DESCRIPTION
`fmt`'s `-x`/`--exact-prefix` and `-X`/`--exact-skip-prefix` never did anything, and both prefixes were always matched exactly, so `fmt -p '> '` left `  > alpha` alone instead of reformatting it and `fmt -P '#'` reformatted `  # note` instead of skipping it. The help text says leading whitespace is ignored when matching PREFIX and PSKIP unless `-x`/`-X` is given.

In `FmtOptions::from_matches` (src/uu/fmt/src/fmt.rs:111) both flags were read with `matches.contains_id()`. `ArgAction::SetTrue` gives an argument a default value of `"false"`, and `contains_id()` is true whenever a value is present including a default, so `xprefix` was true on every run. The second line also read `options::SKIP_PREFIX` instead of `options::EXACT_SKIP_PREFIX`, so `xanti_prefix` was true whenever `-P` was passed, which is the only time it is consulted. Both are now read with `get_flag()`, and the second from `EXACT_SKIP_PREFIX`.

Four tests in tests/by-util/test_fmt.rs cover the short and long form of each flag. The two that assert whitespace is ignored fail on main and pass with the change; the two that assert `-x`/`-X` still match exactly pass either way and pin that behaviour.

```
cargo test --no-default-features --features fmt --test tests test_fmt   # 35 passed, 0 failed, 2 ignored
cargo clippy --features fmt --no-default-features --all-targets -- -D warnings   # clean
cargo fmt --all -- --check   # clean
```

The existing prefix fixtures have no leading whitespace, so `prefix_minus`, `prefix_equal` and `prefix_equal_skip_prefix_equal_two` produce byte-identical output before and after.
