### PR TITLE
truncate: remove unreachable code

### DIFF
--- a/src/uu/truncate/locales/en-US.ftl
+++ b/src/uu/truncate/locales/en-US.ftl
@@ -24,7 +24,6 @@ truncate-help-reference = base the size of each file on the size of RFILE
 truncate-help-size = set or adjust the size of each file according to SIZE, which is in bytes unless --io-blocks is specified
 
 # Error messages
-truncate-error-missing-file-operand = missing file operand
 truncate-error-cannot-open-no-device = cannot open { $filename } for writing: No such device or address
 truncate-error-cannot-open-for-writing = cannot open { $filename } for writing
 truncate-error-invalid-number = Invalid number: { $error }

--- a/src/uu/truncate/locales/fr-FR.ftl
+++ b/src/uu/truncate/locales/fr-FR.ftl
@@ -24,7 +24,6 @@ truncate-help-reference = baser la taille de chaque fichier sur la taille de RFI
 truncate-help-size = définir ou ajuster la taille de chaque fichier selon TAILLE, qui est en octets sauf si --io-blocks est spécifié
 
 # Messages d'erreur
-truncate-error-missing-file-operand = opérande de fichier manquant
 truncate-error-cannot-open-no-device = impossible d'ouvrir { $filename } en écriture : Aucun périphérique ou adresse de ce type
 truncate-error-cannot-open-for-writing = impossible d'ouvrir { $filename } en écriture
 truncate-error-invalid-number = Nombre invalide : { $error }

--- a/src/uu/truncate/src/truncate.rs
+++ b/src/uu/truncate/src/truncate.rs
@@ -14,7 +14,7 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use uucore::diagnostics::OptionValue;
 use uucore::display::Quotable;
-use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
+use uucore::error::{FromIo, UResult, USimpleError};
 use uucore::format_usage;
 use uucore::show_if_err;
 use uucore::translate;
@@ -159,14 +159,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let files: Vec<OsString> = matches
         .get_many::<OsString>(options::ARG_FILES)
         .map(|v| v.cloned().collect())
-        .unwrap_or_default();
-
-    if files.is_empty() {
-        return Err(UUsageError::new(
-            1,
-            translate!("truncate-error-missing-file-operand"),
-        ));
-    }
+        .expect("ARG_FILES should be required by clap");
 
     let io_blocks = matches.get_flag(options::IO_BLOCKS);
     let no_create = matches.get_flag(options::NO_CREATE);


### PR DESCRIPTION
This PR removes some code that's unreachable because the error case is handled by clap as `required(true)` is set.