### PR TITLE
sort: do not hold all inputs open while sorting

### DIFF
--- a/src/uu/sort/Cargo.toml
+++ b/src/uu/sort/Cargo.toml
@@ -44,7 +44,7 @@ fluent = { workspace = true }
 foldhash = { workspace = true }
 
 [target.'cfg(all(unix, not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku", target_os = "solaris", target_os = "illumos"))))'.dependencies]
-rustix = { workspace = true, features = ["system", "process"] }
+rustix = { workspace = true, features = ["fs", "system", "process"] }
 
 [target.'cfg(not(any(target_os = "redox", target_os = "wasi")))'.dependencies]
 ctrlc = { workspace = true }

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -2475,11 +2475,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         });
     }
 
-    let opened_inputs = if settings.merge || settings.check {
-        Vec::new()
-    } else {
-        files.iter().map(open).collect::<UResult<Vec<_>>>()?
-    };
+    if !(settings.merge || settings.check) {
+        check_inputs(&files)?;
+    }
 
     let output = Output::new(matches.get_one::<OsString>(options::OUTPUT))?;
 
@@ -2498,7 +2496,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     settings.init_precomputed(needs_locale_collation);
 
-    let result = exec(&mut files, opened_inputs, &settings, output, &mut tmp_dir);
+    let result = exec(&mut files, &settings, output, &mut tmp_dir);
     // Wait here if `SIGINT` was received,
     // for signal handler to do its work and terminate the program.
     tmp_dir.wait_if_signal();
@@ -2749,7 +2747,6 @@ pub fn uu_app() -> Command {
 
 fn exec(
     files: &mut [OsString],
-    opened_inputs: Vec<Box<dyn Read + Send>>,
     settings: &GlobalSettings,
     output: Output,
     tmp_dir: &mut TmpDirWrapper,
@@ -2766,7 +2763,9 @@ fn exec(
             check::check(files.first().unwrap(), settings)
         }
     } else {
-        let mut lines = opened_inputs.into_iter().map(Ok);
+        // Open each input once, when it is reached, so that only one input is open
+        // at a time and FIFOs are never reopened.
+        let mut lines = files.iter().map(open);
         ext_sort(&mut lines, settings, output, tmp_dir)
     }
 }
@@ -3309,6 +3308,38 @@ fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
         line.write(&mut writer, settings).map_err_context(ctx)?;
     }
     writer.flush().map_err_context(ctx)?;
+    Ok(())
+}
+
+/// Check that all inputs are readable before sorting starts, like GNU sort's
+/// `check_inputs`. The inputs are probed with `access(2)` rather than opened:
+/// opening a FIFO here would block until a writer appears and lose data on the
+/// reopen, and keeping every input open would be bounded by `RLIMIT_NOFILE`.
+fn check_inputs(files: &[OsString]) -> UResult<()> {
+    for file in files {
+        if file == STDIN_FILE {
+            continue;
+        }
+        let path = Path::new(file);
+        check_readable(path).map_err(|error| SortError::ReadFailed {
+            path: path.to_owned(),
+            error,
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn check_readable(path: &Path) -> std::io::Result<()> {
+    use rustix::fs::{Access, access};
+
+    access(path, Access::READ_OK).map_err(|e| std::io::Error::from_raw_os_error(e.raw_os_error()))
+}
+
+#[cfg(any(not(unix), target_os = "redox"))]
+fn check_readable(path: &Path) -> std::io::Result<()> {
+    // No `rustix::fs::access` here, so open the file and close it right away.
+    File::open(path)?;
     Ok(())
 }
 

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1766,6 +1766,31 @@ fn test_merge_more_files_than_fd_limit() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_more_files_than_fd_limit() {
+    use rlimit::Resource;
+    let (at, mut ucmd) = at_and_ucmd!();
+    // The inputs are read one after another, so sorting must not need more open
+    // file descriptors than the soft limit allows, no matter how many inputs there are.
+    let count = 40;
+    let mut names = Vec::new();
+    for i in 0..count {
+        let name = format!("fdlimit_{i:02}.txt");
+        at.write(&name, &format!("{:02}\n", count - 1 - i));
+        names.push(name);
+    }
+    let mut expected = String::new();
+    for i in 0..count {
+        writeln!(expected, "{i:02}").unwrap();
+    }
+    let limit_fd = 24;
+    ucmd.limit(Resource::NOFILE, limit_fd, limit_fd)
+        .args(&names)
+        .succeeds()
+        .stdout_only(expected);
+}
+
+#[test]
 fn test_sigpipe_panic() {
     let mut cmd = new_ucmd!();
     let mut child = cmd.args(&["ext_sort.txt"]).run_no_wait();
@@ -1867,6 +1892,18 @@ fn test_verifies_input_files() {
         .args(&["/dev/random", "nonexistent_file"])
         .fails_with_code(2)
         .stderr_is("sort: cannot read: nonexistent_file: No such file or directory\n");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_verifies_input_files_without_opening_them() {
+    // Opening a FIFO blocks until a writer shows up, so if the input check opened
+    // the inputs, the missing second file would never be reported.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.mkfifo("FIFO");
+    ucmd.args(&["FIFO", "nonexistent_file"])
+        .fails_with_code(2)
+        .stderr_only("sort: cannot read: nonexistent_file: No such file or directory\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #14419.

Since #13494 `sort` opens every input file up front and keeps all of them open until they are read, so sorting more than about 1020 files fails with `Too many open files` under the usual soft limit of 1024. Before #13494 the inputs were opened and closed once to verify them and then reopened for reading, which broke FIFOs: the second open either blocks or misses what the writer already sent.

This goes back to opening the inputs one at a time, but verifies them the way GNU sort's `check_inputs()` does, with `access(2)`. That holds no descriptor and does not block on a FIFO, so an unreadable input is still reported before anything is read or the output file is touched. Each input is then opened exactly once, when it is reached, and dropped when the next one is opened. The `cannot read` diagnostic is unchanged. On Windows, WASI and Redox the check opens and closes the file, as it did before #13494.

Merge and check mode are not touched. Merge already batches its inputs against the descriptor limit.

Tests added:

- `test_more_files_than_fd_limit`: 40 inputs with a soft limit of 24 descriptors. Fails on main with `Too many open files`.
- `test_verifies_input_files_without_opening_them`: a FIFO with no writer followed by a missing file has to fail right away. On main this blocks on the FIFO, and so did the pre-#13494 code.

The FIFO test from #13494 still passes, as does the rest of the sort suite. I also re-ran the original scenario from the issue: 1100 `uevent` files under `ulimit -n 1024`, and mkinitcpio's `find /sys/devices -name uevent -exec sort -u {} +`.
