### PR TITLE
hostid: remove unuseful lock()

### DIFF
--- a/src/uu/hostid/src/hostid.rs
+++ b/src/uu/hostid/src/hostid.rs
@@ -28,7 +28,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mask = 0xffff_ffff;
 
     result &= mask;
-    writeln!(stdout().lock(), "{result:0>8x}")?;
+    writeln!(stdout(), "{result:0>8x}")?;
     Ok(())
 }
 


### PR DESCRIPTION
No reason to lock stdout just for writing 1 content.