### PR TITLE
uucore: update fsext to build on aix

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -384,7 +384,7 @@ impl From<StatFs> for MountInfo {
     }
 }
 
-#[cfg(all(unix, not(target_os = "redox")))]
+#[cfg(all(unix, not(any(target_os = "aix", target_os = "redox"))))]
 fn is_dummy_filesystem(fs_type: &str, mount_option: &str) -> bool {
     // spell-checker:disable
     match fs_type {


### PR DESCRIPTION
Fix a compile error on AIX where `MOUNT_OPT_BIND` is not defined:

```sh
cargo +nightly check -q -Zbuild-std -p uucore --features fsext --target powerpc64-ibm-aix
```
