### PR TITLE
tests: don't pipe input into commands that exit before reading it

### DIFF
--- a/tests/by-util/test_numfmt.rs
+++ b/tests/by-util/test_numfmt.rs
@@ -184,7 +184,7 @@ fn test_unit_size_hyphen_leading_as_separate_arg() {
     for opt in ["--from-unit", "--to-unit"] {
         new_ucmd!()
             .args(&[opt, "-1"])
-            .pipe_in("5\n")
+            .pipe_in("")
             .fails()
             .stderr_contains("invalid unit size: '-1'");
     }
@@ -196,7 +196,7 @@ fn test_unit_hyphen_leading_as_separate_arg() {
     for opt in ["--from", "--to"] {
         new_ucmd!()
             .args(&[opt, "-x"])
-            .pipe_in("5\n")
+            .pipe_in("")
             .fails()
             .stderr_contains("invalid argument '-x' for '--");
     }

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -1894,7 +1894,7 @@ fn test_separator_attached_equals_double() {
     // `-t==` selects the two-character separator `==`, which GNU rejects.
     new_ucmd!()
         .args(&["-t==", "-k", "2"])
-        .pipe_in("a=b=c\n")
+        .pipe_in("")
         .fails()
         .stderr_contains("separator must be exactly one character long: '=='");
 }
@@ -1904,7 +1904,7 @@ fn test_separator_attached_equals_multi_char() {
     // `-t=a` selects the two-character separator `=a`, which GNU rejects.
     new_ucmd!()
         .args(&["-t=a", "-k", "2"])
-        .pipe_in("a=b=c\n")
+        .pipe_in("")
         .fails()
         .stderr_contains("separator must be exactly one character long: '=a'");
 }


### PR DESCRIPTION
`sort -t==`, `sort -t=a` and `numfmt --from-unit -1` / `--from -x` fail while parsing their arguments, so they never read stdin. The `pipe_in` thread writes into a pipe whose read end is already closed, and the test fails with `failed to write to stdin of child: Broken pipe (os error 32)` — intermittently, depending on which side wins.

I hit this on my own test in #14400, then saw the same failure on `test_sort::test_separator_attached_equals_multi_char` in an unrelated PR, so it is a class rather than one test.

None of these four tests need input, so they now pipe nothing.

To find the rest of the class I temporarily added a sleep before the write in `pipe_in`, which turns the race into a deterministic failure, and ran the whole suite: these four are the only ones. That probe is not part of this PR.