### PR TITLE
mv: replace fs_extra with std directory sizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,12 +1146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,7 +3831,6 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "fluent",
- "fs_extra",
  "indicatif",
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,7 +433,6 @@ dns-lookup = { version = "4.0.0" }
 dunce = "1.0.4"
 filetime = "0.2.29"
 foldhash = "0.2.0"
-fs_extra = "1.3.0"
 gcd = "2.3"
 glob = "0.3.1"
 half = "2.4.1"

--- a/src/uu/mv/Cargo.toml
+++ b/src/uu/mv/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-fs_extra = { workspace = true }
 indicatif = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["fs"] }

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -57,8 +57,6 @@ use uucore::update_control;
 pub use uucore::{backup_control::BackupMode, update_control::UpdateMode};
 use uucore::{format_usage, prompt_yes, show};
 
-use fs_extra::dir::get_size as dir_get_size;
-
 use crate::error::MvError;
 
 /// Options contains all the possible behaviors and flags for mv.
@@ -1144,8 +1142,7 @@ fn rename_dir_fallback(
     #[cfg(unix)] hardlink_scanner: Option<&HardlinkGroupScanner>,
 ) -> io::Result<()> {
     // We remove the destination directory if it exists to match the
-    // behavior of `fs::rename`. As far as I can tell, `fs_extra`'s
-    // `move_dir` would otherwise behave differently.
+    // behavior of `fs::rename`.
     if to.exists() {
         fs::remove_dir_all(to)?;
     }
@@ -1155,7 +1152,7 @@ fn rename_dir_fallback(
     //    If finding the total size fails for whatever reason,
     //    the progress bar wont be shown for this file / dir.
     //    (Move will probably fail due to permission error later?)
-    let total_size = dir_get_size(from).ok();
+    let total_size = display_manager.and_then(|_| get_dir_size(from).ok());
 
     let progress_bar = match (display_manager, total_size) {
         (Some(display_manager), Some(total_size)) => {
@@ -1227,6 +1224,24 @@ fn create_dir_fail_closed(path: &Path) -> io::Result<()> {
             e
         }
     })
+}
+
+fn get_dir_size(path: &Path) -> io::Result<u64> {
+    let metadata = path.symlink_metadata()?;
+
+    if !metadata.is_dir() {
+        return Ok(metadata.len());
+    }
+
+    let mut size = 0;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        size += entry.metadata()?.len();
+        if entry.file_type()?.is_dir() {
+            size += get_dir_size(&entry.path())?;
+        }
+    }
+    Ok(size)
 }
 
 fn copy_dir_contents(


### PR DESCRIPTION
mv used `fs_extra` only to estimate a directory's size for the progress bar, but it also scanned the tree even when progress was disabled.

This replaces it with a small std-based helper and runs the estimate only when a progress bar exists.
