### PR TITLE
fix: redundant_homepage cargo lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 license.workspace = true
-homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 


### PR DESCRIPTION
Fix the redundant_homepage cargo lint in nightly toolchain.
