### PR TITLE
fix: missing_lints_inheritance cargo lint

### DIFF
--- a/src/uucore_procs/Cargo.toml
+++ b/src/uucore_procs/Cargo.toml
@@ -18,3 +18,6 @@ doctest = false
 [dependencies]
 proc-macro2 = "1.0.81"
 quote = "1.0.36"
+
+[lints]
+workspace = true


### PR DESCRIPTION
Fix the missing_lints_inheritance cargo lint in nightly toolchain.