### PR TITLE
realpath: fix exit status in quiet mode

### DIFF
--- a/src/uu/realpath/src/realpath.rs
+++ b/src/uu/realpath/src/realpath.rs
@@ -14,7 +14,6 @@ use std::{
     io::{Write, stdout},
     path::{Path, PathBuf},
 };
-use uucore::fs::make_path_relative_to;
 use uucore::translate;
 use uucore::{
     display::{Quotable, print_verbatim},
@@ -22,8 +21,8 @@ use uucore::{
     format_usage,
     fs::{MissingHandling, ResolveMode, canonicalize},
     line_ending::LineEnding,
-    show_if_err,
 };
+use uucore::{error::set_exit_code, fs::make_path_relative_to, show};
 
 const OPT_QUIET: &str = "quiet";
 const OPT_STRIP: &str = "strip";
@@ -115,13 +114,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             relative_to.as_deref(),
             relative_base.as_deref(),
         );
-        if !quiet {
-            show_if_err!(result.map_err_context(|| path.maybe_quote().to_string()));
+        if let Err(e) = result.map_err_context(|| path.maybe_quote().to_string()) {
+            if quiet {
+                set_exit_code(e.code());
+            } else {
+                show!(e);
+            }
         }
     }
     // Although we return `Ok`, it is possible that a call to
-    // `show!()` above has set the exit code for the program to a
-    // non-zero integer.
+    // `show!()` or `set_exit_code` above has set the exit code
+    // for the program to a non-zero integer.
     Ok(())
 }
 

--- a/tests/by-util/test_realpath.rs
+++ b/tests/by-util/test_realpath.rs
@@ -215,6 +215,14 @@ fn test_realpath_existing_error() {
 }
 
 #[test]
+fn test_realpath_existing_error_quiet() {
+    new_ucmd!()
+        .args(&["-q", "-e", GIBBERISH])
+        .fails_with_code(1)
+        .no_output();
+}
+
+#[test]
 fn test_realpath_missing() {
     let p = Path::new("").join(GIBBERISH).join(GIBBERISH);
     let (at, mut ucmd) = at_and_ucmd!();


### PR DESCRIPTION
According to the GNU's behavior, `1` should be returned when `-q` and `-e` flags are set and the path is invalid.

```bash
realpath -q -e /some/nonexistent/path; echo $?
```

uutils' `realpath` in `main` returns `0`.

Fix it in this PR.