### PR TITLE
mv, sync, hostname, touch, rm: use safe std APIs on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,7 +3665,6 @@ dependencies = [
  "hostname",
  "tempfile",
  "uucore",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4032,7 +4031,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "uucore",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/uu/hostname/Cargo.toml
+++ b/src/uu/hostname/Cargo.toml
@@ -25,12 +25,6 @@ hostname = { workspace = true, features = ["set"] }
 uucore = { workspace = true, features = ["wide"] }
 fluent = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = [
-  "Win32_Networking_WinSock",
-  "Win32_Foundation",
-] }
-
 [[bin]]
 name = "hostname"
 path = "src/main.rs"

--- a/src/uu/hostname/locales/en-US.ftl
+++ b/src/uu/hostname/locales/en-US.ftl
@@ -7,7 +7,6 @@ hostname-help-short = Display the short hostname (the portion before the first d
 hostname-error-permission = hostname: you must be root to change the host name
 hostname-error-invalid-name = hostname: invalid hostname '{ $name }'
 hostname-error-resolve-failed = hostname: unable to resolve host name '{ $name }'
-hostname-error-winsock = failed to start Winsock
 hostname-error-set-hostname = failed to set hostname
 hostname-error-get-hostname = failed to get hostname
 hostname-error-resolve-socket = failed to resolve socket addresses

--- a/src/uu/hostname/locales/fr-FR.ftl
+++ b/src/uu/hostname/locales/fr-FR.ftl
@@ -7,7 +7,6 @@ hostname-help-short = Afficher le nom d'hôte court (la partie avant le premier 
 hostname-error-permission = hostname : vous devez être root pour changer le nom d'hôte
 hostname-error-invalid-name = hostname : nom d'hôte invalide '{ $name }'
 hostname-error-resolve-failed = hostname : impossible de résoudre le nom d'hôte '{ $name }'
-hostname-error-winsock = échec du démarrage de Winsock
 hostname-error-set-hostname = échec de la définition du nom d'hôte
 hostname-error-get-hostname = échec de l'obtention du nom d'hôte
 hostname-error-resolve-socket = échec de la résolution des adresses de socket

--- a/src/uu/hostname/src/hostname.rs
+++ b/src/uu/hostname/src/hostname.rs
@@ -26,38 +26,9 @@ static OPT_FQDN: &str = "fqdn";
 static OPT_SHORT: &str = "short";
 static OPT_HOST: &str = "host";
 
-#[cfg(windows)]
-mod wsa {
-    use std::io;
-
-    use windows_sys::Win32::Networking::WinSock::{WSACleanup, WSADATA, WSAStartup};
-
-    pub(super) struct WsaHandle(());
-
-    pub(super) fn start() -> io::Result<WsaHandle> {
-        let mut data = std::mem::MaybeUninit::<WSADATA>::uninit();
-        let err = unsafe { WSAStartup(0x0202, data.as_mut_ptr()) };
-        if err == 0 {
-            Ok(WsaHandle(()))
-        } else {
-            Err(io::Error::from_raw_os_error(err))
-        }
-    }
-
-    impl Drop for WsaHandle {
-        fn drop(&mut self) {
-            // This possibly returns an error but we can't handle it
-            let _ = unsafe { WSACleanup() };
-        }
-    }
-}
-
 #[uucore::main(no_signals)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let matches = uucore::clap_localization::handle_clap_result(uu_app(), args)?;
-
-    #[cfg(windows)]
-    let _handle = wsa::start().map_err_context(|| translate!("hostname-error-winsock"))?;
 
     match matches.get_one::<OsString>(OPT_HOST) {
         None => display_hostname(&matches),

--- a/src/uu/mv/src/mv.rs
+++ b/src/uu/mv/src/mv.rs
@@ -1604,44 +1604,11 @@ fn prompt_overwrite(to: &Path, cached_mode: Option<u32>) -> io::Result<()> {
 /// Checks if a file can be deleted by attempting to open it with delete permissions.
 #[cfg(windows)]
 fn can_delete_file(path: &Path) -> bool {
-    use std::{
-        os::windows::ffi::OsStrExt as _,
-        ptr::{null, null_mut},
-    };
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::DELETE;
 
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
-        Storage::FileSystem::{
-            CreateFileW, DELETE, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ,
-            FILE_SHARE_WRITE, OPEN_EXISTING,
-        },
-    };
-
-    let wide_path = path
-        .as_os_str()
-        .encode_wide()
-        .chain([0])
-        .collect::<Vec<u16>>();
-
-    let handle = unsafe {
-        CreateFileW(
-            wide_path.as_ptr(),
-            DELETE,
-            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-            null(),
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
-            null_mut(),
-        )
-    };
-
-    if handle == INVALID_HANDLE_VALUE {
-        return false;
-    }
-
-    unsafe { CloseHandle(handle) };
-
-    true
+    OpenOptions::new().access_mode(DELETE).open(path).is_ok()
 }
 
 #[cfg(not(windows))]

--- a/src/uu/rm/Cargo.toml
+++ b/src/uu/rm/Cargo.toml
@@ -28,9 +28,6 @@ uucore = { workspace = true, features = ["safe-traversal"] }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
-
 [[bin]]
 name = "rm"
 path = "src/main.rs"

--- a/src/uu/rm/src/rm.rs
+++ b/src/uu/rm/src/rm.rs
@@ -1050,12 +1050,10 @@ fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata
     }
 }
 
-// For windows we can use windows metadata trait and file attributes to see if a directory is readonly
+// For Windows, metadata.permissions().readonly() checks FILE_ATTRIBUTE_READONLY
 #[cfg(windows)]
 fn handle_writable_directory(path: &Path, options: &Options, metadata: &Metadata) -> bool {
-    use std::os::windows::prelude::MetadataExt;
-    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_READONLY;
-    let not_user_writable = (metadata.file_attributes() & FILE_ATTRIBUTE_READONLY) != 0;
+    let not_user_writable = metadata.permissions().readonly();
     let stdin_ok = options.__presume_input_tty.unwrap_or(false) || stdin().is_terminal();
     match (stdin_ok, not_user_writable, options.interactive) {
         (false, _, InteractiveMode::PromptProtected) => true,
@@ -1121,11 +1119,9 @@ fn is_symlink_dir(_metadata: &Metadata) -> bool {
 
 #[cfg(windows)]
 fn is_symlink_dir(metadata: &Metadata) -> bool {
-    use std::os::windows::prelude::MetadataExt;
-    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+    use std::os::windows::fs::FileTypeExt;
 
-    metadata.file_type().is_symlink()
-        && ((metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY) != 0)
+    metadata.file_type().is_symlink_dir()
 }
 
 mod tests {

--- a/src/uu/sync/src/sync.rs
+++ b/src/uu/sync/src/sync.rs
@@ -91,22 +91,20 @@ mod platform {
 #[cfg(windows)]
 mod platform {
     use std::fs::OpenOptions;
-    use std::os::windows::prelude::*;
     use std::path::Path;
     use uucore::error::{UResult, USimpleError};
     use uucore::translate;
     use uucore::wide::{FromWide, ToWide};
     use windows_sys::Win32::Foundation::{
-        ERROR_NO_MORE_FILES, GetLastError, HANDLE, INVALID_HANDLE_VALUE, MAX_PATH,
+        ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE, MAX_PATH,
     };
     use windows_sys::Win32::Storage::FileSystem::{
-        FindFirstVolumeW, FindNextVolumeW, FindVolumeClose, FlushFileBuffers, GetDriveTypeW,
+        FindFirstVolumeW, FindNextVolumeW, FindVolumeClose, GetDriveTypeW,
     };
     use windows_sys::Win32::System::WindowsProgramming::DRIVE_FIXED;
 
     fn get_last_error() -> u32 {
-        // SAFETY: `GetLastError` has no safety preconditions
-        unsafe { GetLastError() as u32 }
+        std::io::Error::last_os_error().raw_os_error().unwrap_or(1) as u32
     }
 
     fn flush_volume(name: &str) -> UResult<()> {
@@ -125,13 +123,12 @@ mod platform {
                     translate!("sync-error-create-volume-handle"),
                 )
             })?;
-        // SAFETY: `file` is a valid `File`
-        if unsafe { FlushFileBuffers(file.as_raw_handle() as HANDLE) } == 0 {
-            return Err(USimpleError::new(
-                get_last_error() as i32,
+        file.sync_all().map_err(|e| {
+            USimpleError::new(
+                e.raw_os_error().unwrap_or(1),
                 translate!("sync-error-flush-file-buffer"),
-            ));
-        }
+            )
+        })?;
         Ok(())
     }
 

--- a/src/uu/touch/src/platform/windows.rs
+++ b/src/uu/touch/src/platform/windows.rs
@@ -10,8 +10,7 @@ use std::os::windows::prelude::AsRawHandle;
 use std::path::PathBuf;
 
 use windows_sys::Win32::Foundation::{
-    ERROR_INVALID_PARAMETER, ERROR_NOT_ENOUGH_MEMORY, ERROR_PATH_NOT_FOUND, GetLastError, HANDLE,
-    MAX_PATH,
+    ERROR_INVALID_PARAMETER, ERROR_NOT_ENOUGH_MEMORY, ERROR_PATH_NOT_FOUND, HANDLE, MAX_PATH,
 };
 use windows_sys::Win32::Storage::FileSystem::{FILE_NAME_OPENED, GetFinalPathNameByHandleW};
 
@@ -50,13 +49,9 @@ pub fn pathbuf_from_stdout() -> Result<PathBuf, TouchError> {
         }
         0 => {
             return Err(TouchError::WindowsStdoutPathError(translate!(
-            "touch-error-windows-stdout-path-failed",
+                "touch-error-windows-stdout-path-failed",
                 "code".to_string() =>
-                format!(
-                    "{}",
-                    // SAFETY: GetLastError is thread-safe and has no documented memory unsafety.
-                    unsafe { GetLastError() }
-                ),
+                    format!("{}", std::io::Error::last_os_error().raw_os_error().unwrap_or(0)),
             )));
         }
         e => e as usize,


### PR DESCRIPTION
Replace unsafe Win32 calls and raw bitmasks with safe Rust standard library APIs on Windows:
- `mv`: use `OpenOptionsExt::access_mode(DELETE)` for delete permission check
- `sync`: use `File::sync_all()` instead of `FlushFileBuffers`
- `hostname`: remove redundant manual Winsock initialization (`WSAStartup`/`WSACleanup`) and drop `windows-sys` dependency
- `touch`: use `io::Error::last_os_error()` instead of `GetLastError`
- `rm`: use `Metadata::permissions().readonly()` and `FileTypeExt::is_symlink_dir()`, and drop `windows-sys` dependency
