### PR TITLE
uucore: fix a fsext test

### DIFF
--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -1259,7 +1259,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(unix, not(target_os = "redox")))]
+    #[cfg(all(unix, not(any(target_os = "aix", target_os = "redox"))))]
     // spell-checker:ignore (word) binfmt
     fn test_binfmt_misc_is_dummy() {
         use super::is_dummy_filesystem;


### PR DESCRIPTION
Follow-up to https://github.com/uutils/coreutils/pull/14430.

Fix an unresolved import error.

```sh
cargo +nightly check -q -Zbuild-std -p uucore --all-targets --features fsext --target powerpc64-ibm-aix
```