### PR TITLE
ls: apply dir and vdir format defaults in Config::from

### DIFF
--- a/src/uu/dir/src/dir.rs
+++ b/src/uu/dir/src/dir.rs
@@ -6,7 +6,7 @@
 use clap::Command;
 use std::ffi::OsString;
 use std::path::Path;
-use uu_ls::{Config, Format, options};
+use uu_ls::{Config, options};
 use uucore::{error::UResult, format_usage, quoting_style::QuotingStyle, translate};
 
 #[uucore::main]
@@ -19,10 +19,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         uucore::clap_localization::handle_clap_result_with_diagnostics(command, args.collect(), 2)?;
 
     let mut default_quoting_style = false;
-    let mut default_format_style = false;
 
-    // We check if any options on formatting or quoting style have been given.
-    // If not, we will use dir default formatting and quoting style options
+    // If no quoting option was given, use dir's default quoting style.
 
     if !matches.contains_id(options::QUOTING_STYLE)
         && !matches.get_flag(options::quoting::C)
@@ -31,26 +29,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     {
         default_quoting_style = true;
     }
-    if !matches.contains_id(options::FORMAT)
-        && !matches.get_flag(options::format::ACROSS)
-        && !matches.get_flag(options::format::COLUMNS)
-        && !matches.get_flag(options::format::COMMAS)
-        && !matches.get_flag(options::format::LONG)
-        && !matches.get_flag(options::format::LONG_NO_GROUP)
-        && !matches.get_flag(options::format::LONG_NO_OWNER)
-        && !matches.get_flag(options::format::LONG_NUMERIC_UID_GID)
-        && !matches.get_flag(options::format::ONE_LINE)
-    {
-        default_format_style = true;
-    }
 
-    let mut config = Config::from(&matches, diag_args.as_deref())?;
+    let mut config = Config::from_dir(&matches, diag_args.as_deref())?;
 
     if default_quoting_style {
         config.quoting_style = QuotingStyle::C_NO_QUOTES;
-    }
-    if default_format_style {
-        config.format = Format::Columns;
     }
 
     let locs = matches

--- a/src/uu/ls/src/config.rs
+++ b/src/uu/ls/src/config.rs
@@ -192,6 +192,17 @@ pub(crate) enum Files {
     Normal,
 }
 
+/// Which listing program is constructing this [`Config`].
+///
+/// `ls` defaults depend on whether stdout is a terminal. `dir` and `vdir`
+/// use a fixed format when the user did not pass a format option.
+#[derive(Clone, Copy)]
+enum ProgramMode {
+    Ls,
+    Dir,
+    Vdir,
+}
+
 pub struct Config {
     // Dir and vdir needs access to this field
     pub format: Format,
@@ -233,11 +244,16 @@ pub struct Config {
 
 /// Extracts the format to display the information based on the options provided.
 ///
+/// When no format option is given, `mode` selects the program default: `ls`
+/// depends on whether stdout is a terminal; `dir` is columns; `vdir` is long.
+/// A `None` option id means that default, so `-1` and `--zero` can still
+/// override it.
+///
 /// # Returns
 ///
 /// A tuple containing the Format variant and an Option containing a &'static str
 /// which corresponds to the option used to define the format.
-fn extract_format(options: &clap::ArgMatches) -> (Format, Option<&'static str>) {
+fn extract_format(options: &clap::ArgMatches, mode: ProgramMode) -> (Format, Option<&'static str>) {
     if let Some(format_) = options.get_one::<String>(options::FORMAT) {
         (
             match format_.as_str() {
@@ -259,10 +275,18 @@ fn extract_format(options: &clap::ArgMatches) -> (Format, Option<&'static str>) 
         (Format::Commas, Some(options::format::COMMAS))
     } else if options.get_flag(options::format::COLUMNS) {
         (Format::Columns, Some(options::format::COLUMNS))
-    } else if stdout().is_terminal() {
-        (Format::Columns, None)
     } else {
-        (Format::OneLine, None)
+        match mode {
+            ProgramMode::Dir => (Format::Columns, None),
+            ProgramMode::Vdir => (Format::Long, None),
+            ProgramMode::Ls => {
+                if stdout().is_terminal() {
+                    (Format::Columns, None)
+                } else {
+                    (Format::OneLine, None)
+                }
+            }
+        }
     }
 }
 
@@ -682,10 +706,30 @@ fn parse_tab_size(size_str: &str) -> Result<usize, LsError> {
 }
 
 impl Config {
-    #[allow(clippy::cognitive_complexity)]
     pub fn from(options: &clap::ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
+        Self::from_with_program_mode(options, diag_args, ProgramMode::Ls)
+    }
+
+    /// Construct a configuration with dir's default column format.
+    pub fn from_dir(options: &clap::ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
+        Self::from_with_program_mode(options, diag_args, ProgramMode::Dir)
+    }
+
+    /// Construct a configuration with vdir's default long format.
+    pub fn from_vdir(options: &clap::ArgMatches, diag_args: Option<&[OsString]>) -> UResult<Self> {
+        Self::from_with_program_mode(options, diag_args, ProgramMode::Vdir)
+    }
+
+    #[allow(clippy::cognitive_complexity)]
+    fn from_with_program_mode(
+        options: &clap::ArgMatches,
+        diag_args: Option<&[OsString]>,
+        mode: ProgramMode,
+    ) -> UResult<Self> {
         let context = options.get_flag(options::CONTEXT);
-        let (mut format, opt) = extract_format(options);
+        let (mut format, opt) = extract_format(options, mode);
+        // -1 and --zero override a default long format, but not an explicit one.
+        let mut explicit_long = format == Format::Long && opt.is_some();
         let files = extract_files(options);
 
         // The -o, -n and -g options are tricky. They cannot override with each
@@ -696,14 +740,14 @@ impl Config {
         // when switching to a different format option in-between like this:
         // -ogCl or "-og --format=vertical --format=long".
         //
-        // -1 has a similar issue: it does nothing if the format is long. This
-        // actually makes it distinct from the --format=singe-column option,
+        // -1 has a similar issue: it does nothing if long format was explicitly
+        // requested. This makes it distinct from the --format=singe-column option,
         // which always applies.
         //
         // The idea here is to not let these options override with the other
         // options, but manually whether they have an index that's greater than
         // the other format options. If so, we set the appropriate format.
-        if format != Format::Long {
+        if !explicit_long {
             let idx = opt
                 .and_then(|opt| options.indices_of(opt).map(|x| x.max().unwrap()))
                 .unwrap_or(0);
@@ -725,6 +769,7 @@ impl Config {
             .any(|i| i >= idx)
             {
                 format = Format::Long;
+                explicit_long = true;
             } else if let Some(mut indices) = options.indices_of(options::format::ONE_LINE)
                 && options.value_source(options::format::ONE_LINE)
                     == Some(clap::parser::ValueSource::CommandLine)
@@ -811,13 +856,6 @@ impl Config {
 
         let (mut quoting_style, mut locale_quoting) = extract_quoting_style(options, show_control);
         let indicator_style = extract_indicator_style(options);
-        // Only parse the value to "--time-style" if it will become relevant.
-        let dired = options.get_flag(options::DIRED);
-        let (time_format_recent, time_format_older) = if format == Format::Long || dired {
-            parse_time_style(options)?
-        } else {
-            Default::default()
-        };
 
         let mut ignore_patterns: Vec<Pattern> = Vec::new();
 
@@ -898,7 +936,7 @@ impl Config {
                 .max()
                 .unwrap_or(0)
         {
-            format = if format == Format::Long {
+            format = if explicit_long {
                 format
             } else {
                 Format::OneLine
@@ -953,6 +991,7 @@ impl Config {
             None
         };
 
+        let dired = options.get_flag(options::DIRED);
         if dired || is_dired_arg_present() {
             // --dired implies --format=long
             // if we have --dired --hyperlink, we don't show dired but we still want to see the
@@ -962,6 +1001,13 @@ impl Config {
         if dired && options.get_flag(options::ZERO) {
             return Err(Box::new(LsError::DiredAndZeroAreIncompatible));
         }
+
+        // Only parse the time style after the final output format is known.
+        let (time_format_recent, time_format_older) = if format == Format::Long {
+            parse_time_style(options)?
+        } else {
+            Default::default()
+        };
 
         let dereference = if options.get_flag(options::dereference::ALL) {
             Dereference::All

--- a/src/uu/vdir/src/vdir.rs
+++ b/src/uu/vdir/src/vdir.rs
@@ -6,7 +6,7 @@
 use clap::Command;
 use std::ffi::OsString;
 use std::path::Path;
-use uu_ls::{Config, Format, options};
+use uu_ls::{Config, options};
 use uucore::error::UResult;
 use uucore::quoting_style::QuotingStyle;
 use uucore::{format_usage, translate};
@@ -20,10 +20,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         uucore::clap_localization::handle_clap_result_with_diagnostics(command, args.collect(), 2)?;
 
     let mut default_quoting_style = false;
-    let mut default_format_style = false;
 
-    // We check if any options on formatting or quoting style have been given.
-    // If not, we will use dir default formatting and quoting style options
+    // If no quoting option was given, use vdir's default quoting style.
 
     if !matches.contains_id(options::QUOTING_STYLE)
         && !matches.get_flag(options::quoting::C)
@@ -32,26 +30,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     {
         default_quoting_style = true;
     }
-    if !matches.contains_id(options::FORMAT)
-        && !matches.get_flag(options::format::ACROSS)
-        && !matches.get_flag(options::format::COLUMNS)
-        && !matches.get_flag(options::format::COMMAS)
-        && !matches.get_flag(options::format::LONG)
-        && !matches.get_flag(options::format::LONG_NO_GROUP)
-        && !matches.get_flag(options::format::LONG_NO_OWNER)
-        && !matches.get_flag(options::format::LONG_NUMERIC_UID_GID)
-        && !matches.get_flag(options::format::ONE_LINE)
-    {
-        default_format_style = true;
-    }
 
-    let mut config = Config::from(&matches, diag_args.as_deref())?;
+    let mut config = Config::from_vdir(&matches, diag_args.as_deref())?;
 
     if default_quoting_style {
         config.quoting_style = QuotingStyle::C_NO_QUOTES;
-    }
-    if default_format_style {
-        config.format = Format::Long;
     }
 
     let locs = matches

--- a/tests/by-util/test_dir.rs
+++ b/tests/by-util/test_dir.rs
@@ -33,6 +33,18 @@ fn test_default_output() {
 }
 
 #[test]
+fn test_default_format_overrides() {
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.touch("file");
+    for (flag, expected) in [("-1", "file\n"), ("--zero", "file\0")] {
+        scene.ucmd().arg(flag).succeeds().stdout_only(expected);
+    }
+    for flag in ["--full-time", "--dired"] {
+        scene.ucmd().arg(flag).succeeds().stdout_contains("total 0");
+    }
+}
+
+#[test]
 fn test_long_output() {
     let scene = TestScenario::new(util_name!());
     let at = &scene.fixtures;

--- a/tests/by-util/test_vdir.rs
+++ b/tests/by-util/test_vdir.rs
@@ -23,13 +23,57 @@ fn test_default_output() {
     let at = &scene.fixtures;
     at.mkdir("some-dir1");
     at.touch("some-file1");
+    filetime::set_file_mtime(
+        at.plus("some-file1"),
+        filetime::FileTime::from_unix_time(978_307_200, 0),
+    )
+    .unwrap();
 
     scene.ucmd().succeeds().stdout_contains("some-file1");
 
     scene
         .ucmd()
         .succeeds()
-        .stdout_matches(&Regex::new("[rwx-]{10}.*some-file1\n$").unwrap());
+        .stdout_contains("Jan  1  2001 some-file1\n");
+    scene
+        .ucmd()
+        .arg("--time-style=long-iso")
+        .succeeds()
+        .stdout_contains("2001-01-01 00:00 some-file1\n");
+    scene
+        .ucmd()
+        .env("TIME_STYLE", "long-iso")
+        .succeeds()
+        .stdout_contains("2001-01-01 00:00 some-file1\n");
+}
+
+#[test]
+fn test_default_format_overrides() {
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.touch("file");
+    for (args, expected) in [
+        (vec!["-1"], "file\n"),
+        (vec!["-C"], "file\n"),
+        (vec!["-x"], "file\n"),
+        (vec!["-m"], "file\n"),
+        (vec!["--format=single-column"], "file\n"),
+        (vec!["--zero"], "file\0"),
+        (vec!["-g", "-C"], "file\n"),
+    ] {
+        scene
+            .ucmd()
+            .env("TIME_STYLE", "invalid")
+            .args(&args)
+            .succeeds()
+            .stdout_only(expected);
+    }
+    for args in [["-l", "-1"], ["-g", "--zero"], ["-C", "-g"]] {
+        scene
+            .ucmd()
+            .args(&args)
+            .succeeds()
+            .stdout_contains("total 0");
+    }
 }
 
 #[test]


### PR DESCRIPTION
`dir` and `vdir` used to overwrite the listing format after `Config::from()`. Construction still used `ls` defaults, some behaviors don't match GNU's. For example, uutils' `vdir` can't output date because with `ls` defaults, it's not a long format ; thus, the date format is left empty.

https://github.com/uutils/coreutils/blob/c29429c13b79b3ab7928c7723eeaf95905a2e35e/src/uu/ls/src/config.rs#L816

Apply those defaults inside `Config` instead, and treat only an explicit long option from cli argument as immune to `-1` / `--zero`.

Sorry I ran out of Copilot budget this month... but I did use another AI review bot locally and it found no bug or security issue.