### PR TITLE
ci: fix `style_empty_assertions` job

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -197,6 +197,10 @@ jobs:
     name: Style/Empty assertions check
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Fail if empty stdout/stderr assertions are found
         shell: bash
         run: |


### PR DESCRIPTION
This PR fixes the `style_empty_assertions` job as it always fails with `grep: tests/: No such file or directory` (see, for example, https://github.com/uutils/coreutils/actions/runs/34179452330/job/101915358463?pr=14445#step:2:11) due to a missing checkout step.