### PR TITLE
uucore: support signals feature for hurd

### DIFF
--- a/src/uucore/src/lib/features.rs
+++ b/src/uucore/src/lib/features.rs
@@ -109,6 +109,7 @@ pub mod selinux;
         target_os = "android",
         target_os = "cygwin",
         target_os = "freebsd",
+        target_os = "hurd",
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",

--- a/src/uucore/src/lib/features/signals.rs
+++ b/src/uucore/src/lib/features/signals.rs
@@ -94,6 +94,53 @@ pub static ALL_SIGNALS: [&str; 32] = [
 
 /*
 
+     The following signals are defined in GNU/Hurd:
+     // https://github.com/sailfishos-mirror/glibc/blob/glibc-2.35/bits/signum-generic.h
+     // https://github.com/sailfishos-mirror/glibc/blob/glibc-2.35/sysdeps/mach/hurd/bits/signum-arch.h
+
+     SIGHUP           1     Hangup.
+     SIGINT           2     Interactive attention signal.
+     SIGQUIT          3     Quit.
+     SIGILL           4     Illegal instruction.
+     SIGTRAP          5     Trace/breakpoint trap.
+     SIGABRT          6     Abnormal termination.
+     SIGEMT           7     Emulator trap (4.2 BSD).
+     SIGFPE           8     Erroneous arithmetic operation.
+     SIGKILL          9     Killed.
+     SIGBUS           10    Bus error.
+     SIGSEGV          11    Invalid access to storage.
+     SIGSYS           12    Bad system call.
+     SIGPIPE          13    Broken pipe.
+     SIGALRM          14    Alarm clock.
+     SIGTERM          15    Termination request.
+     SIGURG           16    Urgent data is available at a socket.
+     SIGSTOP          17    Stop, unblockable.
+     SIGTSTP          18    Keyboard stop.
+     SIGCONT          19    Continue.
+     SIGCHLD          20    Child terminated or stopped.
+     SIGTTIN          21    Background read from control terminal.
+     SIGTTOU          22    Background write to control terminal.
+     SIGPOLL          23    Pollable event occurred (System V).
+     SIGXCPU          24    CPU time limit exceeded.
+     SIGXFSZ          25    File size limit exceeded.
+     SIGVTALRM        26    Virtual timer expired.
+     SIGPROF          27    Profiling timer expired.
+     SIGWINCH         28    Window size change (4.3 BSD, Sun).
+     SIGINFO          29    Information request (4.4 BSD).
+     SIGUSR1          30    User-defined signal 1.
+     SIGUSR2          31    User-defined signal 2.
+     SIGLOST          32    Resource lost (Sun); server died (GNU).
+*/
+
+#[cfg(target_os = "hurd")]
+pub static ALL_SIGNALS: [&str; 33] = [
+    "EXIT", "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "EMT", "FPE", "KILL", "BUS", "SEGV",
+    "SYS", "PIPE", "ALRM", "TERM", "URG", "STOP", "TSTP", "CONT", "CHLD", "TTIN", "TTOU", "POLL",
+    "XCPU", "XFSZ", "VTALRM", "PROF", "WINCH", "INFO", "USR1", "USR2", "LOST",
+];
+
+/*
+
      The following signals are defined in NetBSD:
 
      SIGHUP           1     Hangup

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -118,6 +118,7 @@ pub use crate::features::safe_traversal;
         target_os = "android",
         target_os = "cygwin",
         target_os = "freebsd",
+        target_os = "hurd",
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",

--- a/src/uucore_procs/src/lib.rs
+++ b/src/uucore_procs/src/lib.rs
@@ -32,7 +32,7 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
         // Initialize SIGPIPE state capture at process startup (Unix only).
         // This must be at module level to set up the .init_array static that runs
         // before main() to capture whether SIGPIPE was ignored by the parent process.
-        #[cfg(all(#signals, unix, not(any(target_os = "fuchsia", target_os = "haiku", target_os = "hurd"))))]
+        #[cfg(all(#signals, unix, not(any(target_os = "fuchsia", target_os = "haiku"))))]
         uucore::init_startup_state_capture!();
 
         pub fn uumain(args: impl uucore::Args) -> i32 {
@@ -42,7 +42,7 @@ pub fn main(args: TokenStream, stream: TokenStream) -> TokenStream {
             // The Rust runtime ignores SIGPIPE, but we need to respect the parent's
             // signal disposition for proper pipeline behavior (GNU compatibility).
             // needed even for true --version
-            #[cfg(all(unix, not(any(target_os = "fuchsia", target_os = "haiku", target_os = "hurd"))))]
+            #[cfg(all(unix, not(any(target_os = "fuchsia", target_os = "haiku"))))]
             if !uucore::signals::sigpipe_was_ignored() {
                 let _ = uucore::signals::enable_pipe_errors();
             }


### PR DESCRIPTION
Add GNU/Hurd to the platforms supporting the `signals` feature and define its signal set.

The `signals` feature now builds successfully with Clippy:

```console
$ RUSTC_BOOTSTRAP=1 cargo clippy -q -Zbuild-std -p uucore --features signals --all-targets --target i686-unknown-hurd-gnu >/dev/null 2>&1; echo $?
0
```