### PR TITLE
tsort: handle invalid utf8 in input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,6 +4365,7 @@ dependencies = [
  "codspeed-divan-compat",
  "fluent",
  "hashbrown 0.17.1",
+ "memchr",
  "rustc-hash",
  "rustix",
  "thiserror 2.0.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hex"
@@ -2899,16 +2904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string-interner"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15"
-dependencies = [
- "hashbrown 0.16.1",
- "serde",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,9 +4364,9 @@ dependencies = [
  "clap",
  "codspeed-divan-compat",
  "fluent",
+ "hashbrown 0.17.1",
  "rustc-hash",
  "rustix",
- "string-interner",
  "thiserror 2.0.20",
  "uucore",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # coreutils (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime foldhash serde gethostid kqueue libcrypto libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner getauxval
+# spell-checker:ignore (libs) bigdecimal datetime foldhash serde gethostid kqueue libcrypto libselinux mangen memmap uuhelp startswith constness expl unnested logind cfgs interner getauxval hashbrown
 
 [package]
 name = "coreutils"
@@ -430,6 +430,7 @@ foldhash = "0.2.0"
 gcd = "2.3"
 glob = "0.3.1"
 half = "2.4.1"
+hashbrown = '0.17.1'
 hostname = "0.4"
 icu_calendar = { version = "2.0.0", default-features = false }
 icu_collator = { version = "2.0.0", default-features = false }
@@ -477,7 +478,6 @@ rust-ini = "0.21.0"
 rustix = { version = "1.1.4", default-features = false }
 self_cell = "1.0.4"
 selinux = "0.6"
-string-interner = "0.20.0"
 tempfile = "3.15.0"
 terminal_size = "0.4.0"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }

--- a/deny.toml
+++ b/deny.toml
@@ -88,7 +88,7 @@ skip = [
   { name = "itertools", version = "0.14.0" },
   # ordered-multimap
   { name = "hashbrown", version = "0.14.5" },
-  # lru (via num-prime), string-interner
+  # lru (via num-prime)
   { name = "hashbrown", version = "0.16.1" },
   # cexpr (via bindgen)
   { name = "nom", version = "7.1.3" },

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 clap = { workspace = true }
 fluent = { workspace = true }
 hashbrown = { workspace = true }
+memchr = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
 rustc-hash = { workspace = true }

--- a/src/uu/tsort/Cargo.toml
+++ b/src/uu/tsort/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [dependencies]
 clap = { workspace = true }
 fluent = { workspace = true }
-string-interner = { workspace = true }
+hashbrown = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
 rustc-hash = { workspace = true }

--- a/src/uu/tsort/src/interner.rs
+++ b/src/uu/tsort/src/interner.rs
@@ -1,0 +1,56 @@
+use hashbrown::HashTable;
+use rustc_hash::FxHasher;
+use std::hash::Hasher;
+
+pub type Sym = usize;
+
+#[derive(Clone, Copy)]
+struct Entry {
+    hash: u64,
+    sym: Sym,
+}
+
+#[derive(Default)]
+pub struct ByteInterner {
+    table: HashTable<Entry>,
+    bytes: Vec<u8>,
+    spans: Vec<(usize, usize)>,
+}
+
+impl ByteInterner {
+    #[inline]
+    fn hash(value: &[u8]) -> u64 {
+        let mut hasher = FxHasher::default();
+        hasher.write(value);
+        hasher.finish()
+    }
+
+    #[inline]
+    pub fn get_or_intern(&mut self, value: &[u8]) -> Sym {
+        let hash = Self::hash(value);
+
+        if let Some(entry) = self.table.find(hash, |entry| {
+            let (start, len) = self.spans[entry.sym];
+            self.bytes[start..start + len] == *value
+        }) {
+            return entry.sym;
+        }
+
+        let sym = self.spans.len();
+        let start = self.bytes.len();
+
+        self.bytes.extend_from_slice(value);
+        self.spans.push((start, value.len()));
+
+        self.table
+            .insert_unique(hash, Entry { hash, sym }, |entry| entry.hash);
+
+        sym
+    }
+
+    #[inline]
+    pub fn resolve(&self, sym: Sym) -> Option<&[u8]> {
+        let &(start, len) = self.spans.get(sym)?;
+        Some(&self.bytes[start..start + len])
+    }
+}

--- a/src/uu/tsort/src/interner.rs
+++ b/src/uu/tsort/src/interner.rs
@@ -1,20 +1,50 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 use hashbrown::HashTable;
 use rustc_hash::FxHasher;
 use std::hash::Hasher;
 
 pub type Sym = usize;
 
-#[derive(Clone, Copy)]
-struct Entry {
-    hash: u64,
-    sym: Sym,
+/// Interns arbitrary byte strings.
+///
+/// During interning:
+///
+///     &[u8] -> Sym
+///     Sym    -> &[u8]
+///
+/// Once `finish_interning()` is called, the hash table used for
+/// `&[u8] -> Sym` lookups is dropped. `Sym -> &[u8]` resolution remains
+/// available for the lifetime of the interner.
+pub struct ByteInterner {
+    /// Needed only while new values are being interned.
+    table: Option<HashTable<Sym>>,
+
+    /// All interned byte strings packed contiguously.
+    bytes: Vec<u8>,
+
+    /// Boundaries into `bytes`.
+    ///
+    /// Symbol `n` corresponds to:
+    ///
+    ///     bytes[offsets[n]..offsets[n + 1]]
+    ///
+    /// The initial zero is a sentinel, so the number of symbols is
+    /// `offsets.len() - 1`.
+    offsets: Vec<usize>,
 }
 
-#[derive(Default)]
-pub struct ByteInterner {
-    table: HashTable<Entry>,
-    bytes: Vec<u8>,
-    spans: Vec<(usize, usize)>,
+impl Default for ByteInterner {
+    fn default() -> Self {
+        Self {
+            table: Some(HashTable::new()),
+            bytes: Vec::new(),
+            offsets: vec![0],
+        }
+    }
 }
 
 impl ByteInterner {
@@ -29,28 +59,57 @@ impl ByteInterner {
     pub fn get_or_intern(&mut self, value: &[u8]) -> Sym {
         let hash = Self::hash(value);
 
-        if let Some(entry) = self.table.find(hash, |entry| {
-            let (start, len) = self.spans[entry.sym];
-            self.bytes[start..start + len] == *value
+        let Self {
+            table,
+            bytes,
+            offsets,
+        } = self;
+
+        let table = table
+            .as_mut()
+            .expect("cannot intern values after finish_interning()");
+
+        // Check whether this byte sequence is already interned.
+        if let Some(&sym) = table.find(hash, |&sym| {
+            let start = offsets[sym];
+            let end = offsets[sym + 1];
+
+            &bytes[start..end] == value
         }) {
-            return entry.sym;
+            return sym;
         }
 
-        let sym = self.spans.len();
-        let start = self.bytes.len();
+        // Allocate a new symbol and append the bytes directly to the arena.
+        let sym = offsets.len() - 1;
 
-        self.bytes.extend_from_slice(value);
-        self.spans.push((start, value.len()));
+        bytes.extend_from_slice(value);
+        offsets.push(bytes.len());
 
-        self.table
-            .insert_unique(hash, Entry { hash, sym }, |entry| entry.hash);
+        // HashTable stores only the symbol. If it needs to resize, hashes
+        // for existing entries are reconstructed from the byte arena.
+        table.insert_unique(hash, sym, |&sym| {
+            let start = offsets[sym];
+            let end = offsets[sym + 1];
+
+            Self::hash(&bytes[start..end])
+        });
 
         sym
     }
 
     #[inline]
     pub fn resolve(&self, sym: Sym) -> Option<&[u8]> {
-        let &(start, len) = self.spans.get(sym)?;
-        Some(&self.bytes[start..start + len])
+        let start = *self.offsets.get(sym)?;
+        let end = *self.offsets.get(sym + 1)?;
+
+        Some(&self.bytes[start..end])
+    }
+
+    /// Drop the `bytes -> Sym` lookup structure.
+    ///
+    /// Call this after all input has been parsed and no more values will
+    /// be interned.
+    pub fn finish_interning(&mut self) {
+        drop(self.table.take());
     }
 }

--- a/src/uu/tsort/src/parser.rs
+++ b/src/uu/tsort/src/parser.rs
@@ -1,0 +1,68 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+use memchr::memchr3;
+use std::io::{self, BufRead};
+
+pub fn for_each_token<R, F>(mut reader: R, mut f: F) -> io::Result<()>
+where
+    R: BufRead,
+    F: FnMut(&[u8]),
+{
+    let mut pending = Vec::new();
+
+    loop {
+        let buf = reader.fill_buf()?;
+
+        if buf.is_empty() {
+            if !pending.is_empty() {
+                f(&pending);
+            }
+            return Ok(());
+        }
+
+        let mut pos = 0;
+
+        while pos < buf.len() {
+            if pending.is_empty() {
+                // Skip whitespace before the next token.
+                while pos < buf.len() && is_delimiter(buf[pos]) {
+                    pos += 1;
+                }
+
+                if pos == buf.len() {
+                    break;
+                }
+            }
+
+            if let Some(i) = memchr3(b' ', b'\t', b'\n', &buf[pos..]) {
+                let end = pos + i;
+
+                if pending.is_empty() {
+                    // Fast path: token is entirely inside this buffer.
+                    f(&buf[pos..end]);
+                } else {
+                    // Complete a token that started in an earlier buffer.
+                    pending.extend_from_slice(&buf[pos..end]);
+                    f(&pending);
+                    pending.clear();
+                }
+
+                pos = end + 1;
+            } else {
+                // Token continues into the next fill_buf() chunk.
+                pending.extend_from_slice(&buf[pos..]);
+                break;
+            }
+        }
+
+        let consumed = buf.len();
+        reader.consume(consumed);
+    }
+}
+
+#[inline]
+fn is_delimiter(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | b'\n')
+}

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -8,6 +8,7 @@
 
 mod error;
 mod interner;
+mod parser;
 
 use clap::{Arg, ArgAction, Command};
 use rustc_hash::FxHashMap;
@@ -123,41 +124,16 @@ impl std::error::Error for LoopNode<'_> {}
 impl UError for Error {}
 impl UError for LoopNode<'_> {}
 
-fn for_each_token<R, F>(mut reader: R, mut f: F) -> io::Result<()>
-where
-    R: BufRead,
-    F: FnMut(&[u8]),
-{
-    let mut buf = Vec::new();
-
-    loop {
-        buf.clear();
-
-        if reader.read_until(b'\n', &mut buf)? == 0 {
-            break;
-        }
-
-        for token in buf
-            .split(|b| matches!(b, b' ' | b'\t' | b'\n'))
-            .filter(|token| !token.is_empty())
-        {
-            f(token);
-        }
-    }
-
-    Ok(())
-}
-
 fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), Error> {
     let mut pending: Option<Sym> = None;
 
     // Input is considered to be in the format
     // From1 To1 From2 To2 ...
-    // with tokens separated by whitespaces.
+    // with tokens separated by whitespaces (<SPACE>, \t, or \n).
     //
     // Tokens are kept as raw bytes so invalid UTF-8 can be preserved.
 
-    let result = for_each_token(reader, |token| {
+    let result = parser::for_each_token(reader, |token| {
         let token_sym = graph.interner.get_or_intern(token);
 
         if let Some(from) = pending.take() {
@@ -177,7 +153,7 @@ fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), Error> 
     if pending.is_some() {
         return Err(ReadError::NumTokensOdd(graph.name()).into());
     }
-
+    graph.interner.finish_interning();
     Ok(())
 }
 

--- a/src/uu/tsort/src/tsort.rs
+++ b/src/uu/tsort/src/tsort.rs
@@ -7,25 +7,22 @@
 // spell-checker:ignore (libs) interner
 
 mod error;
+mod interner;
 
 use clap::{Arg, ArgAction, Command};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 use std::ffi::OsString;
+use std::fmt;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
-use string_interner::StringInterner;
-use string_interner::backend::BucketBackend;
 use uucore::display::Quotable;
 use uucore::error::{FromIo, UError, UResult, USimpleError};
 use uucore::{format_usage, show, translate};
 
 use crate::error::{Error, ReadError};
-
-// short types for switching interning behavior on the fly.
-type Sym = string_interner::symbol::SymbolUsize;
-type Interner = StringInterner<BucketBackend<Sym>, rustc_hash::FxBuildHasher>;
+use crate::interner::{ByteInterner, Sym};
 
 mod options {
     pub const FILE: &str = "file";
@@ -54,6 +51,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Create the directed graph from pairs of tokens in the input data.
     let mut g = Graph::new(input.to_string_lossy().to_string());
+
     if input == "-" {
         process_input(io::stdin().lock(), &mut g)?;
     } else {
@@ -67,7 +65,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 );
             }
         }
+
         let file = File::open(input).map_err_context(|| input.maybe_quote().to_string())?;
+
         // advise the OS we will access the data sequentially if possible
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         let _ = rustix::fs::fadvise(&file, 0, None, rustix::fs::Advice::Sequential);
@@ -105,40 +105,75 @@ pub fn uu_app() -> Command {
         )
 }
 
-// Auxiliary struct, just for printing loop nodes via show! macro
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-struct LoopNode<'a>(&'a str);
+// Auxiliary struct, just for printing loop nodes via show! macro.
+//
+// Diagnostics go through Display, so invalid UTF-8 bytes are represented
+// lossily here.
+#[derive(Debug)]
+struct LoopNode<'a>(&'a [u8]);
+
+impl fmt::Display for LoopNode<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(self.0))
+    }
+}
+
+impl std::error::Error for LoopNode<'_> {}
 
 impl UError for Error {}
 impl UError for LoopNode<'_> {}
+
+fn for_each_token<R, F>(mut reader: R, mut f: F) -> io::Result<()>
+where
+    R: BufRead,
+    F: FnMut(&[u8]),
+{
+    let mut buf = Vec::new();
+
+    loop {
+        buf.clear();
+
+        if reader.read_until(b'\n', &mut buf)? == 0 {
+            break;
+        }
+
+        for token in buf
+            .split(|b| matches!(b, b' ' | b'\t' | b'\n'))
+            .filter(|token| !token.is_empty())
+        {
+            f(token);
+        }
+    }
+
+    Ok(())
+}
 
 fn process_input<R: BufRead>(reader: R, graph: &mut Graph) -> Result<(), Error> {
     let mut pending: Option<Sym> = None;
 
     // Input is considered to be in the format
     // From1 To1 From2 To2 ...
-    // with tokens separated by whitespaces
+    // with tokens separated by whitespaces.
+    //
+    // Tokens are kept as raw bytes so invalid UTF-8 can be preserved.
 
-    for line in reader.lines() {
-        let line = match line {
-            Err(e) if e.kind() == io::ErrorKind::IsADirectory => {
-                return Err(ReadError::IsDir(graph.name()).into());
-            }
-            Err(e) => return Err(ReadError::Io(e).into()),
-            Ok(line) => line,
-        };
-        for token in line.split_whitespace() {
-            // Intern the token and get a Sym
-            let token_sym = graph.interner.get_or_intern(token);
+    let result = for_each_token(reader, |token| {
+        let token_sym = graph.interner.get_or_intern(token);
 
-            if let Some(from) = pending.take() {
-                graph.add_edge(from, token_sym);
-            } else {
-                pending = Some(token_sym);
-            }
+        if let Some(from) = pending.take() {
+            graph.add_edge(from, token_sym);
+        } else {
+            pending = Some(token_sym);
         }
+    });
+
+    if let Err(e) = result {
+        if e.kind() == io::ErrorKind::IsADirectory {
+            return Err(ReadError::IsDir(graph.name()).into());
+        }
+        return Err(ReadError::Io(e).into());
     }
+
     if pending.is_some() {
         return Err(ReadError::NumTokensOdd(graph.name()).into());
     }
@@ -175,29 +210,25 @@ impl Node {
 }
 
 struct Graph {
-    name_sym: Sym,
+    name: String,
     nodes: FxHashMap<Sym, Node>,
-    interner: Interner,
+    interner: ByteInterner,
 }
 
 impl Graph {
     fn new(name: String) -> Self {
-        let mut interner = Interner::with_hasher(rustc_hash::FxBuildHasher);
-        let name_sym = interner.get_or_intern(name);
         Self {
-            name_sym,
-            interner,
+            name,
             nodes: FxHashMap::default(),
+            interner: ByteInterner::default(),
         }
     }
 
     fn name(&self) -> String {
-        self.interner
-            .resolve(self.name_sym)
-            .expect("symbol should be interned")
-            .to_owned()
+        self.name.clone()
     }
-    fn get_node_name(&self, node_sym: Sym) -> &str {
+
+    fn get_node_name(&self, node_sym: Sym) -> &[u8] {
         self.interner
             .resolve(node_sym)
             .expect("symbol should be interned")
@@ -205,8 +236,10 @@ impl Graph {
 
     fn add_edge(&mut self, from: Sym, to: Sym) {
         let from_node = self.nodes.entry(from).or_default();
+
         if from != to {
             from_node.add_successor(to);
+
             let to_node = self.nodes.entry(to).or_default();
             to_node.predecessor_count += 1;
         }
@@ -221,6 +254,7 @@ impl Graph {
                 .successor_tokens,
             v,
         );
+
         self.nodes
             .get_mut(&v)
             .expect("node is part of the graph")
@@ -241,14 +275,20 @@ impl Graph {
             })
             .collect();
 
-        // Sort by resolved string for deterministic output
+        // Sort by name for deterministic output.
         independent_nodes_queue
             .make_contiguous()
             .sort_unstable_by(|a, b| self.get_node_name(*a).cmp(self.get_node_name(*b)));
+
         let mut out = BufWriter::new(io::stdout().lock());
+
         while !self.nodes.is_empty() {
             let v = self.find_next_node(&mut independent_nodes_queue);
-            writeln!(out, "{}", self.get_node_name(v)).map_err(Error::Write)?;
+
+            // Write the node exactly as it appeared in the input, followed by a newline
+            out.write_all(self.get_node_name(v)).map_err(Error::Write)?;
+            writeln!(out).map_err(Error::Write)?;
+
             if let Some(node_to_process) = self.nodes.remove(&v) {
                 for successor_name in node_to_process.successor_tokens.into_iter().rev() {
                     // we reverse to match GNU tsort order
@@ -256,16 +296,20 @@ impl Graph {
                         .nodes
                         .get_mut(&successor_name)
                         .expect("node is part of the graph");
+
                     successor_node.predecessor_count -= 1;
+
                     if successor_node.predecessor_count == 0 {
                         independent_nodes_queue.push_back(successor_name);
                     }
                 }
             }
         }
+
         out.flush().map_err(Error::Write)?;
         Ok(())
     }
+
     pub fn indegree(&self, sym: Sym) -> Option<usize> {
         self.nodes.get(&sym).map(|data| data.predecessor_count)
     }
@@ -294,25 +338,32 @@ impl Graph {
 
     fn find_and_break_cycle(&mut self, frontier: &mut VecDeque<Sym>) {
         let cycle = self.detect_cycle();
+
         show!(Error::Loop(self.name()));
+
         for &sym in &cycle {
             show!(LoopNode(self.get_node_name(sym)));
         }
+
         let u = *cycle.last().expect("cycle must be non-empty");
         let v = cycle[0];
+
         self.remove_edge(u, v);
+
         if self.indegree(v).expect("node is part of the graph") == 0 {
             frontier.push_back(v);
         }
     }
 
     fn detect_cycle(&self) -> Vec<Sym> {
-        // Sort by resolved string for deterministic output
+        // Sort by name for deterministic output.
         let mut nodes: Vec<_> = self.nodes.keys().copied().collect();
+
         nodes.sort_unstable_by(|a, b| self.get_node_name(*a).cmp(self.get_node_name(*b)));
 
         let mut visited = FxHashMap::default();
         let mut stack = Vec::with_capacity(self.nodes.len());
+
         for &node in &nodes {
             if self.dfs(node, &mut visited, &mut stack) {
                 let (loop_entry, _) = stack.pop().expect("loop is not empty");
@@ -324,6 +375,7 @@ impl Graph {
                     .collect();
             }
         }
+
         unreachable!("detect_cycle is expected to be called only on graphs with cycles");
     }
 
@@ -339,6 +391,7 @@ impl Graph {
                 .get(&node)
                 .map_or(&[], |n: &Node| &n.successor_tokens),
         ));
+
         let state = *visited.entry(node).or_insert(VisitedState::Opened);
 
         if state == VisitedState::Closed {
@@ -359,6 +412,7 @@ impl Graph {
                 Entry::Vacant(v) => {
                     // first visit of the node
                     v.insert(VisitedState::Opened);
+
                     stack.push((
                         next_node,
                         self.nodes
@@ -366,10 +420,12 @@ impl Graph {
                             .map_or(&[], |n| &n.successor_tokens),
                     ));
                 }
+
                 Entry::Occupied(o) => {
                     if *o.get() == VisitedState::Opened {
-                        // We have found a node that was already visited by another iteration => loop completed
-                        // the stack may contain unrelated nodes. This allows narrowing the loop down.
+                        // We have found a node that was already visited by another
+                        // iteration => loop completed. The stack may contain
+                        // unrelated nodes. This allows narrowing the loop down.
                         stack.push((next_node, &[]));
                         return true;
                     }

--- a/tests/by-util/test_tsort.rs
+++ b/tests/by-util/test_tsort.rs
@@ -269,3 +269,29 @@ fn test_write_error() {
         .stderr_contains("write error")
         .stderr_contains("No space left on device");
 }
+
+#[test]
+fn test_invalid_utf8_input() {
+    let (at, mut ucmd) = at_and_ucmd!();
+
+    // Equivalent to:
+    //
+    // hrllo
+    // awuyues
+    // apple
+    // iphone
+    // iphone
+    // a
+    // \xff
+    // \xff
+
+    std::fs::write(
+        at.plus("a"),
+        b"hrllo\nawuyues\napple\niphone\niphone\na\n\xff\n\xff\n",
+    )
+    .unwrap();
+
+    ucmd.arg("a")
+        .succeeds()
+        .stdout_only_bytes(b"apple\nhrllo\n\xff\niphone\nawuyues\na\n");
+}


### PR DESCRIPTION
fixes #12918

This PR is a big refactor of the input parsing to parse utf8 bytes properly. Because we can't use string interner anymore, I've replaced it with a handwritten small interner tuned for utf8 bytes. 
@sylvestre this withdraws the dependency to string-interner. 

@cakebaker @oech3 feel free to review this
