### PR TITLE
sort: 2x faster whole-line sorting

### DIFF
--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -132,6 +132,7 @@ fn reader(
             &mut iter::empty(),
             settings.line_ending.into(),
             settings,
+            false,
         )?;
         if !should_continue {
             break;

--- a/src/uu/sort/src/check.rs
+++ b/src/uu/sort/src/check.rs
@@ -27,6 +27,7 @@ use uucore::error::UResult;
 ///
 /// The code we should exit with.
 pub fn check(path: &OsStr, settings: &GlobalSettings) -> UResult<()> {
+    let settings = &settings.collating_on_demand();
     let max_allowed_cmp = if settings.unique {
         // If `unique` is enabled, the previous line must compare _less_ to the next one.
         Ordering::Less

--- a/src/uu/sort/src/chunks.rs
+++ b/src/uu/sort/src/chunks.rs
@@ -20,7 +20,9 @@ use self_cell::self_cell;
 use uucore::error::{UResult, USimpleError, strip_errno};
 use uucore::translate;
 
-use crate::{GeneralBigDecimalParseResult, GlobalSettings, Line, numeric_str_cmp::NumInfo};
+use crate::{
+    GeneralBigDecimalParseResult, GlobalSettings, Line, numeric_str_cmp::NumInfo, set_prefix_keys,
+};
 
 const ALLOC_CHUNK_SIZE: usize = 64 * 1024;
 const MAX_TOKEN_BUFFER_BYTES: usize = 4 * 1024 * 1024;
@@ -56,6 +58,8 @@ pub struct LineData<'a> {
     pub collation_key_buffer: Vec<u8>,
     /// End offsets into `collation_key_buffer` for each line's sort key.
     pub collation_key_ends: Vec<usize>,
+    /// Prefix shared by all lines, past which a whole-line sort takes its keys.
+    pub shared_prefix_len: usize,
 }
 
 impl LineData<'_> {
@@ -177,6 +181,8 @@ impl RecycledChunk {
 /// * `next_files`: What `file` should be updated to next.
 /// * `separator`: The line separator.
 /// * `settings`: The global settings.
+/// * `want_prefix_keys`: Whether the lines are going to be sorted in memory. Only that
+///   sorter reads the prefix keys; merging and checking never do, so they skip the scan.
 #[allow(clippy::too_many_arguments)]
 pub fn read<T: Read>(
     sender: &SyncSender<Chunk>,
@@ -187,6 +193,7 @@ pub fn read<T: Read>(
     next_files: &mut impl Iterator<Item = UResult<T>>,
     separator: u8,
     settings: &GlobalSettings,
+    want_prefix_keys: bool,
 ) -> UResult<bool> {
     let RecycledChunk {
         lines,
@@ -196,8 +203,8 @@ pub fn read<T: Read>(
         line_num_floats,
         collation_key_buffer,
         collation_key_ends,
-        mut token_buffer,
-        mut line_count_hint,
+        token_buffer,
+        line_count_hint,
         mut buffer,
     } = recycled_chunk;
     if buffer.len() < carry_over.len() {
@@ -223,35 +230,29 @@ pub fn read<T: Read>(
                 // It was only temporarily transmuted to a Vec<Line<'static>> to make recycling possible.
                 std::mem::transmute::<Vec<&'static [u8]>, Vec<&'_ [u8]>>(selections)
             };
-            let mut lines = unsafe {
+            let lines = unsafe {
                 // SAFETY: (same as above) It is safe to transmute to a vector of lines with shorter lifetime,
                 // because it was only temporarily transmuted to a Vec<Line<'static>> to make recycling possible.
                 std::mem::transmute::<Vec<Line<'static>>, Vec<Line<'_>>>(lines)
             };
             let read = &buffer[..read];
-            let mut line_data = LineData {
+            let line_data = LineData {
                 selections,
                 num_infos,
                 parsed_floats,
                 line_num_floats,
                 collation_key_buffer,
                 collation_key_ends,
+                shared_prefix_len: 0,
             };
-            parse_lines(
-                read,
-                &mut lines,
-                &mut line_data,
-                &mut token_buffer,
-                &mut line_count_hint,
-                separator,
-                settings,
-            );
-            Ok(ChunkContents {
+            let mut contents = ChunkContents {
                 lines,
                 line_data,
                 token_buffer,
                 line_count_hint,
-            })
+            };
+            parse_lines(read, &mut contents, separator, settings, want_prefix_keys);
+            Ok(contents)
         });
         sender.send(payload?).unwrap();
     }
@@ -261,14 +262,19 @@ pub fn read<T: Read>(
 /// Split `read` into `Line`s, and add them to `lines`.
 fn parse_lines<'a>(
     read: &'a [u8],
-    lines: &mut Vec<Line<'a>>,
-    line_data: &mut LineData<'a>,
-    token_buffer: &mut Vec<Range<usize>>,
-    line_count_hint: &mut usize,
+    contents: &mut ChunkContents<'a>,
     separator: u8,
     settings: &GlobalSettings,
+    want_prefix_keys: bool,
 ) {
     const SMALL_CHUNK_BYTES: usize = 64 * 1024;
+
+    let ChunkContents {
+        lines,
+        line_data,
+        token_buffer,
+        line_count_hint,
+    } = contents;
 
     let read = read.strip_suffix(&[separator]).unwrap_or(read);
 
@@ -324,6 +330,9 @@ fn parse_lines<'a>(
     let line = &read[start..];
     lines.push(Line::create(line, index, line_data, token_buffer, settings));
     *line_count_hint = exact_line_count.unwrap_or(index + 1);
+    if want_prefix_keys && settings.precomputed.fast_lexicographic {
+        line_data.shared_prefix_len = set_prefix_keys(lines);
+    }
 }
 
 /// Read from `file` into `buffer`.
@@ -441,23 +450,12 @@ pub fn parse_into_chunk<'a>(
     separator: u8,
     settings: &GlobalSettings,
 ) -> ChunkContents<'a> {
-    let mut lines = Vec::new();
-    let mut line_data = LineData::default();
-    let mut token_buffer = Vec::new();
-    let mut line_count_hint = 0;
-    parse_lines(
-        buffer,
-        &mut lines,
-        &mut line_data,
-        &mut token_buffer,
-        &mut line_count_hint,
-        separator,
-        settings,
-    );
-    ChunkContents {
-        lines,
-        line_data,
-        token_buffer,
-        line_count_hint,
-    }
+    let mut contents = ChunkContents {
+        lines: Vec::new(),
+        line_data: LineData::default(),
+        token_buffer: Vec::new(),
+        line_count_hint: 0,
+    };
+    parse_lines(buffer, &mut contents, separator, settings, true);
+    contents
 }

--- a/src/uu/sort/src/ext_sort/threaded.rs
+++ b/src/uu/sort/src/ext_sort/threaded.rs
@@ -230,6 +230,7 @@ fn read_write_loop<I: WriteableTmpFile>(
             &mut files,
             separator,
             settings,
+            true,
         )?;
 
         if !should_continue {
@@ -276,6 +277,7 @@ fn read_write_loop<I: WriteableTmpFile>(
                 &mut files,
                 separator,
                 settings,
+                true,
             )?;
             if !should_continue {
                 sender_option = None;

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -32,6 +32,7 @@ use crate::{
     chunks::{self, Chunk, RecycledChunk},
     compare_by, current_open_fd_count, fd_soft_limit, open,
     tmp_dir::TmpDirWrapper,
+    write_failed_context,
 };
 
 /// If the output file occurs in the input files as well, copy the contents of the output file
@@ -135,24 +136,22 @@ pub fn merge_with_file_limit<
             batch.push(file);
             if batch.len() >= batch_size {
                 assert_eq!(batch.len(), batch_size);
-                let merger = merge_without_limit(batch.into_iter(), settings)?;
+                temporary_files.push(merge_batch_to_tmp_file::<_, _, Tmp>(
+                    batch.into_iter(),
+                    settings,
+                    tmp_dir,
+                )?);
                 batch = Vec::with_capacity(batch_size);
-
-                let mut tmp_file =
-                    Tmp::create(tmp_dir.next_file()?, settings.compress_prog.as_deref())?;
-                merger.write_all_to(settings, tmp_file.as_write())?;
-                temporary_files.push(tmp_file.finished_writing()?);
             }
         }
         // Merge any remaining files that didn't get merged in a full batch above.
         if !batch.is_empty() {
             assert!(batch.len() < batch_size);
-            let merger = merge_without_limit(batch.into_iter(), settings)?;
-
-            let mut tmp_file =
-                Tmp::create(tmp_dir.next_file()?, settings.compress_prog.as_deref())?;
-            merger.write_all_to(settings, tmp_file.as_write())?;
-            temporary_files.push(tmp_file.finished_writing()?);
+            temporary_files.push(merge_batch_to_tmp_file::<_, _, Tmp>(
+                batch.into_iter(),
+                settings,
+                tmp_dir,
+            )?);
         }
         merge_with_file_limit::<_, _, Tmp>(
             temporary_files
@@ -166,6 +165,23 @@ pub fn merge_with_file_limit<
             tmp_dir,
         )
     }
+}
+
+/// Merge one batch of inputs into a fresh temporary file.
+fn merge_batch_to_tmp_file<
+    M: MergeInput + 'static,
+    F: ExactSizeIterator<Item = UResult<M>>,
+    Tmp: WriteableTmpFile,
+>(
+    files: F,
+    settings: &GlobalSettings,
+    tmp_dir: &mut TmpDirWrapper,
+) -> UResult<Tmp::Closed> {
+    let merger = merge_without_limit(files, settings)?;
+    let (file, path) = tmp_dir.next_file()?;
+    let mut tmp_file = Tmp::create((file, path.clone()), settings.compress_prog.as_deref())?;
+    merger.write_all_to(settings, tmp_file.as_write(), path.as_os_str())?;
+    tmp_file.finished_writing()
 }
 
 /// Merge files without limiting how many files are concurrently open.
@@ -336,15 +352,27 @@ struct FileMerger<'a> {
 impl FileMerger<'_> {
     /// Write the merged contents to the output file.
     fn write_all(self, settings: &GlobalSettings, output: Output) -> UResult<()> {
+        let output_name = output
+            .as_output_name()
+            .unwrap_or(OsStr::new("standard output"))
+            .to_owned();
         let mut out = output.into_write();
-        self.write_all_to(settings, &mut out)
+        self.write_all_to(settings, &mut out, &output_name)?;
+        out.flush()
+            .map_err_context(|| write_failed_context(&output_name))
     }
 
-    fn write_all_to(mut self, settings: &GlobalSettings, out: &mut impl Write) -> UResult<()> {
+    fn write_all_to(
+        mut self,
+        settings: &GlobalSettings,
+        out: &mut impl Write,
+        output_name: &OsStr,
+    ) -> UResult<()> {
+        let write_error_context = || write_failed_context(output_name);
         let write_result = loop {
             match self
                 .write_next(out, settings)
-                .map_err_context(|| "write failed".into())
+                .map_err_context(write_error_context)
             {
                 Ok(true) => (),
                 Ok(false) => break Ok(()),

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -123,6 +123,7 @@ pub fn merge_with_file_limit<
     output: Output,
     tmp_dir: &mut TmpDirWrapper,
 ) -> UResult<()> {
+    let settings = &settings.collating_on_demand();
     let batch_size = effective_merge_batch_size(settings);
     debug_assert!(batch_size >= 2);
 

--- a/src/uu/sort/src/merge.rs
+++ b/src/uu/sort/src/merge.rs
@@ -279,6 +279,7 @@ fn reader(
                 &mut iter::empty(),
                 separator,
                 settings,
+                false,
             )?;
             if !should_continue {
                 // Remove the file from the list by replacing it with `None`.

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -37,7 +37,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
-use std::io::{BufRead, BufReader, BufWriter, Read, Write, stdin, stdout};
+use std::io::{BufRead, BufReader, BufWriter, IsTerminal, Read, Write, stdin, stdout};
 use std::num::IntErrorKind;
 use std::ops::Range;
 use std::path::Path;
@@ -54,6 +54,7 @@ use uucore::extendedbigdecimal::ExtendedBigDecimal;
 use uucore::i18n::collator::{compute_sort_key_utf8, locale_cmp};
 use uucore::i18n::datetime::get_locale_months;
 use uucore::i18n::decimal::locale_decimal_separator;
+use uucore::io::OwnedFileDescriptorOrHandle;
 use uucore::line_ending::LineEnding;
 use uucore::parser::num_parser::{ExtendedParser, ExtendedParserError};
 use uucore::parser::parse_size::{ParseSizeError, Parser};
@@ -133,6 +134,8 @@ const POSITIVE: &u8 = &b'+';
 const MIN_AUTOMATIC_BUF_SIZE: usize = 512 * 1024; // 512 KiB
 const FALLBACK_AUTOMATIC_BUF_SIZE: usize = 32 * 1024 * 1024; // 32 MiB
 const MAX_AUTOMATIC_BUF_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
+/// Size of the buffer used to write the sorted output.
+const OUTPUT_BUF_SIZE: usize = 256 * 1024;
 
 #[derive(Debug, Error)]
 pub enum SortError {
@@ -256,14 +259,24 @@ impl Output {
     }
 
     fn into_write(self) -> BufWriter<Box<dyn Write>> {
-        BufWriter::new(match self.file {
+        let writer: Box<dyn Write> = match self.file {
             Some((_name, file)) => {
                 // truncate the file
                 let _ = file.set_len(0);
                 Box::new(file)
             }
-            None => Box::new(stdout()),
-        })
+            // `stdout()` is line buffered, so every byte we write is scanned for a
+            // line ending on top of the buffering we already do here. Write to a
+            // duplicate of the descriptor instead, which is not. A terminal keeps
+            // `stdout()`: on Windows that is what converts the output for the
+            // console, and no terminal is fast enough for the buffering to matter.
+            None if stdout().is_terminal() => Box::new(stdout()),
+            None => OwnedFileDescriptorOrHandle::from(stdout()).map_or_else(
+                |_| Box::new(stdout()) as Box<dyn Write>,
+                |fd| Box::new(fd.into_file()),
+            ),
+        };
+        BufWriter::with_capacity(OUTPUT_BUF_SIZE, writer)
     }
 
     fn as_output_name(&self) -> Option<&OsStr> {
@@ -3292,6 +3305,10 @@ fn month_compare(a: &[u8], b: &[u8]) -> Ordering {
     ma.cmp(&mb)
 }
 
+pub(crate) fn write_failed_context(output_name: &OsStr) -> String {
+    translate!("sort-error-write-failed", "output" => output_name.maybe_quote())
+}
+
 fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
     iter: T,
     settings: &GlobalSettings,
@@ -3301,7 +3318,7 @@ fn print_sorted<'a, T: Iterator<Item = &'a Line<'a>>>(
         .as_output_name()
         .unwrap_or(OsStr::new("standard output"))
         .to_owned();
-    let ctx = || translate!("sort-error-write-failed", "output" => output_name.maybe_quote());
+    let ctx = || write_failed_context(&output_name);
 
     let mut writer = output.into_write();
     for line in iter {

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -426,13 +426,14 @@ impl GlobalSettings {
     /// looking at any key. That is only the same comparison when the single
     /// key spans the entire line: `-n -k1.2` sorts on the line's second
     /// character onwards, and `-n -t. -k2` on its second field, neither of
-    /// which the line as a whole stands for. A key of its own `r` also has to
-    /// go the long way, since the shortcut only knows the global one.
+    /// which the line as a whole stands for. A key whose `r` disagrees with
+    /// the global one (`-k1r` without `-r`) also has to go the long way, since
+    /// the shortcut only knows the global one.
     fn can_use_whole_line_numeric(&self) -> bool {
         self.mode == SortMode::Numeric && self.selectors.len() == 1 && {
             let selector = &self.selectors[0];
             selector.settings.mode == SortMode::Numeric
-                && !selector.settings.reverse
+                && selector.settings.reverse == self.reverse
                 && selector.from.field == 1
                 && selector.from.char == 1
                 && selector.to.is_none()
@@ -443,6 +444,8 @@ impl GlobalSettings {
     /// Note: When i18n-collator is enabled, the caller must have already determined
     /// whether locale-aware collation is needed (via checking if we're in a UTF-8 locale).
     /// This check is performed in uumain() before init_precomputed() is called.
+    /// A key whose `r` disagrees with the global one (`-k1r` without `-r`) is
+    /// excluded as the fast path only knows the global one.
     fn can_use_fast_lexicographic(&self) -> bool {
         self.mode == SortMode::Default
             && !self.ignore_case
@@ -453,6 +456,7 @@ impl GlobalSettings {
             && {
                 let selector = &self.selectors[0];
                 !selector.needs_selection
+                    && selector.settings.reverse == self.reverse
                     && matches!(selector.settings.mode, SortMode::Default)
                     && !selector.settings.ignore_case
                     && !selector.settings.dictionary_order
@@ -461,7 +465,9 @@ impl GlobalSettings {
             }
     }
 
-    /// Returns true when the ASCII case-insensitive fast path is valid.
+    /// Returns true when the ASCII case-insensitive fast path is valid. Like
+    /// the lexicographic one it only knows the global `r`, so a key whose `r`
+    /// disagrees with it is excluded.
     fn can_use_fast_ascii_insensitive(&self) -> bool {
         self.mode == SortMode::Default
             && self.ignore_case
@@ -472,6 +478,7 @@ impl GlobalSettings {
             && {
                 let selector = &self.selectors[0];
                 !selector.needs_selection
+                    && selector.settings.reverse == self.reverse
                     && matches!(selector.settings.mode, SortMode::Default)
                     && selector.settings.ignore_case
                     && !selector.settings.dictionary_order
@@ -666,7 +673,44 @@ type Field = Range<usize>;
 #[derive(Clone, Debug)]
 pub struct Line<'a> {
     line: &'a [u8],
+    /// Position in the chunk, used to find the line's entries in `LineData`.
+    /// A whole-line sort has none and stores a [`prefix_key`] here instead.
     index: usize,
+}
+
+/// The first bytes of `bytes` as a big-endian `usize`, zero padded. Keys order
+/// like the bytes they came from; equal keys leave the order undecided.
+fn prefix_key(bytes: &[u8]) -> usize {
+    let mut key = [0; size_of::<usize>()];
+    let len = bytes.len().min(key.len());
+    key[..len].copy_from_slice(&bytes[..len]);
+    usize::from_be_bytes(key)
+}
+
+/// Store a prefix key in each line's `index`, taken past the prefix shared by
+/// all lines (paths, timestamped logs, ...), and return that prefix's length.
+fn set_prefix_keys(lines: &mut [Line<'_>]) -> usize {
+    let mut shared = lines.first().map_or(&[][..], |first| first.line);
+    for line in lines.iter().skip(1) {
+        if shared.is_empty() {
+            break;
+        }
+        // Most lines keep the prefix intact; `starts_with` checks that with a
+        // single memcmp, leaving the byte walk to the few lines that shorten it.
+        if !line.line.starts_with(shared) {
+            let common = shared
+                .iter()
+                .zip(line.line)
+                .take_while(|(a, b)| a == b)
+                .count();
+            shared = &shared[..common];
+        }
+    }
+    let shared_len = shared.len();
+    for line in lines {
+        line.index = prefix_key(&line.line[shared_len..]);
+    }
+    shared_len
 }
 
 impl<'a> Line<'a> {
@@ -2784,19 +2828,50 @@ fn exec(
 }
 
 fn sort_by<'a>(unsorted: &mut Vec<Line<'a>>, settings: &GlobalSettings, line_data: &LineData<'a>) {
-    let cmp = |a: &Line<'a>, b: &Line<'a>| compare_by(a, b, settings, line_data, line_data);
-    // WASI does not support threads, so use non-parallel sort to avoid
-    // rayon's thread pool which triggers an unreachable trap.
-    if settings.stable || settings.unique {
-        #[cfg(not(target_os = "wasi"))]
-        unsorted.par_sort_by(cmp);
-        #[cfg(target_os = "wasi")]
-        unsorted.sort_by(cmp);
+    // `compare_by` is far too large to be inlined into the sort, so the plain
+    // whole-line comparison would pay for a call into it on every one of the
+    // n log n comparisons. Hand the sort a comparator that only holds that
+    // case instead, which does inline.
+    if settings.precomputed.fast_lexicographic {
+        // The prefix keys decide most comparisons without reading the lines;
+        // equal keys leave only the bytes past the shared prefix to compare.
+        // Tied lines are identical, so the unstable sort is fine even for -s/-u.
+        let reverse = settings.reverse;
+        let shared_len = line_data.shared_prefix_len;
+        sort_lines(unsorted, false, |a, b| {
+            let cmp = a
+                .index
+                .cmp(&b.index)
+                .then_with(|| a.line[shared_len..].cmp(&b.line[shared_len..]));
+            if reverse { cmp.reverse() } else { cmp }
+        });
     } else {
-        #[cfg(not(target_os = "wasi"))]
-        unsorted.par_sort_unstable_by(cmp);
-        #[cfg(target_os = "wasi")]
-        unsorted.sort_unstable_by(cmp);
+        sort_lines(unsorted, settings.stable || settings.unique, |a, b| {
+            compare_by(a, b, settings, line_data, line_data)
+        });
+    }
+}
+
+/// Sort `unsorted` with `compare`, keeping equal lines in input order if `stable`.
+fn sort_lines<'a, F>(unsorted: &mut [Line<'a>], stable: bool, compare: F)
+where
+    F: Fn(&Line<'a>, &Line<'a>) -> Ordering + Sync,
+{
+    // WASI has no threads. Elsewhere, rayon's sorts are older ports of std's
+    // and only worth it with more than one thread.
+    #[cfg(not(target_os = "wasi"))]
+    if rayon::current_num_threads() > 1 {
+        if stable {
+            unsorted.par_sort_by(compare);
+        } else {
+            unsorted.par_sort_unstable_by(compare);
+        }
+        return;
+    }
+    if stable {
+        unsorted.sort_by(compare);
+    } else {
+        unsorted.sort_unstable_by(compare);
     }
 }
 
@@ -3456,6 +3531,24 @@ mod tests {
         let c = get_rand_string();
 
         assert_eq!(Ordering::Equal, random_shuffle(a, b, &c));
+    }
+
+    #[test]
+    fn test_prefix_keys() {
+        assert!(prefix_key(b"m") < prefix_key(b"m\x01"));
+        assert!(prefix_key(b"m\x01") < prefix_key(b"n"));
+        assert!(prefix_key(b"zebra") < prefix_key(b"zebras"));
+        // Only the first bytes count, and a NUL is indistinguishable from padding.
+        assert_eq!(prefix_key(b"wordsmith-A"), prefix_key(b"wordsmith-B"));
+        assert_eq!(prefix_key(b"hi"), prefix_key(b"hi\0"));
+
+        let raw: [&[u8]; 3] = [b"/srv/www/logs", b"/srv/www/", b"/srv/www/tmp"];
+        let mut lines: Vec<Line> = raw.iter().map(|line| Line { line, index: 0 }).collect();
+        assert_eq!(set_prefix_keys(&mut lines), b"/srv/www/".len());
+        assert_eq!(lines[1].index, 0);
+        assert_eq!(lines[2].index, prefix_key(b"tmp"));
+        assert!(lines[0].index < lines[2].index);
+        assert_eq!(set_prefix_keys(&mut []), 0);
     }
 
     #[test]

--- a/src/uu/sort/src/sort.rs
+++ b/src/uu/sort/src/sort.rs
@@ -348,7 +348,11 @@ struct Precomputed {
     floats_per_line: usize,
     selections_per_line: usize,
     fast_lexicographic: bool,
-    fast_locale_collation: bool,
+    /// The whole line is collated by the locale, with no key options in the way.
+    whole_line_collation: bool,
+    /// Store a collation key per line for [`whole_line_collation`] instead of
+    /// collating on demand.
+    precompute_collation_keys: bool,
     fast_ascii_insensitive: bool,
     whole_line_numeric: bool,
     tokenize_blank_thousands_sep: bool,
@@ -413,10 +417,21 @@ impl GlobalSettings {
 
         self.precomputed.fast_lexicographic =
             !disable_fast_lexicographic && self.can_use_fast_lexicographic();
-        self.precomputed.fast_locale_collation =
+        self.precomputed.whole_line_collation =
             disable_fast_lexicographic && self.can_use_fast_lexicographic();
+        self.precomputed.precompute_collation_keys = self.precomputed.whole_line_collation;
         self.precomputed.fast_ascii_insensitive = self.can_use_fast_ascii_insensitive();
         self.precomputed.whole_line_numeric = self.can_use_whole_line_numeric();
+    }
+
+    /// A copy of these settings that collates lines on demand rather than
+    /// storing a key per line. Precomputing the key only pays off when each
+    /// line takes part in many comparisons; merging and checking compare each
+    /// line about once.
+    pub(crate) fn collating_on_demand(&self) -> Self {
+        let mut settings = self.clone();
+        settings.precomputed.precompute_collation_keys = false;
+        settings
     }
 
     /// Returns true when a number parsed from the whole line can stand in for
@@ -726,7 +741,7 @@ impl<'a> Line<'a> {
         settings: &GlobalSettings,
     ) -> Self {
         #[cfg(feature = "i18n-collator")]
-        if settings.precomputed.fast_locale_collation {
+        if settings.precomputed.precompute_collation_keys {
             compute_sort_key_utf8(line, &mut line_data.collation_key_buffer);
             line_data
                 .collation_key_ends
@@ -2892,11 +2907,15 @@ fn compare_by<'a>(
     }
 
     #[cfg(feature = "i18n-collator")]
-    if global_settings.precomputed.fast_locale_collation {
-        let a_key = a_line_data.collation_key(a.index);
-        let b_key = b_line_data.collation_key(b.index);
-        let mut cmp = a_key.cmp(b_key);
-        // If collation keys are equal, fall back to lexicographic comparison
+    if global_settings.precomputed.whole_line_collation {
+        let mut cmp = if global_settings.precomputed.precompute_collation_keys {
+            let a_key = a_line_data.collation_key(a.index);
+            let b_key = b_line_data.collation_key(b.index);
+            a_key.cmp(b_key)
+        } else {
+            locale_cmp(a.line, b.line)
+        };
+        // If the lines collate equal, fall back to lexicographic comparison
         // This can be the case for inputs like `01` and `0_1`, which have equal keys
         if cmp == Ordering::Equal {
             // Reversing the order to match sort's sorting behaviour

--- a/src/uucore/src/lib/features/i18n/collator.rs
+++ b/src/uucore/src/lib/features/i18n/collator.rs
@@ -16,11 +16,14 @@ pub use icu_collator::options::{
 static COLLATOR: OnceLock<CollatorBorrowed> = OnceLock::new();
 
 /// Will initialize the collator if not already initialized.
-/// returns `true` if initialization happened
+/// Returns `true` once a collator is in place, whether this call set it up.
 pub fn try_init_collator(opts: CollatorOptions) -> bool {
-    COLLATOR
-        .set(CollatorBorrowed::try_new(get_collating_locale().0.clone().into(), opts).unwrap())
-        .is_ok()
+    // A second call in the same process (an embedded utility run twice) keeps
+    // the collator already set up and still reports that collation is active.
+    COLLATOR.get_or_init(|| {
+        CollatorBorrowed::try_new(get_collating_locale().0.clone().into(), opts).unwrap()
+    });
+    true
 }
 
 /// Will initialize the collator and panic if already initialized.

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -2079,6 +2079,29 @@ fn test_args_check_conflict() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn test_merge_reports_failed_write_of_buffered_output() {
+    // Output smaller than the write buffer is only written when merging
+    // finishes, so the failure must still be reported and not swallowed.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("small.txt", "kiwi\nlime\n");
+    ucmd.args(&["-m", "small.txt"])
+        .set_stdout(std::fs::File::create("/dev/full").unwrap())
+        .fails()
+        .stderr_is("sort: write failed: 'standard output': No space left on device\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_merge_names_output_file_on_failed_write() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("small.txt", "kiwi\nlime\n");
+    ucmd.args(&["-m", "-o", "/dev/full", "small.txt"])
+        .fails()
+        .stderr_is("sort: write failed: /dev/full: No space left on device\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn test_failed_write_is_reported() {
     new_ucmd!()
         .pipe_in("hello")
@@ -3686,3 +3709,33 @@ sort: invalid suffix in --buffer-size argument '8zz'
 }
 
 /* spell-checker: enable */
+
+#[test]
+fn test_stdout_larger_than_the_output_buffer() {
+    // The sorted result is written to stdout through a buffer; make sure nothing
+    // is lost or reordered when the output is several times that buffer's size.
+    let line_count = 60_000;
+    let mut input = String::new();
+    // Feed the keys in descending order so every line has to move.
+    for key in (0..line_count).rev() {
+        writeln!(input, "{key:07}:filler-padding-to-widen-the-line").unwrap();
+    }
+    let mut expected = String::new();
+    for key in 0..line_count {
+        writeln!(expected, "{key:07}:filler-padding-to-widen-the-line").unwrap();
+    }
+    assert!(expected.len() > 512 * 1024);
+
+    new_ucmd!().pipe_in(input).succeeds().stdout_is(expected);
+}
+
+#[test]
+fn test_single_line_without_any_line_ending() {
+    // A line far longer than the output buffer that contains no line ending at
+    // all: sort still has to emit it in full, terminated.
+    let line = "q".repeat(400_000);
+    new_ucmd!()
+        .pipe_in(line.clone())
+        .succeeds()
+        .stdout_is(format!("{line}\n"));
+}

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-// spell-checker:ignore (words) ints (linux) NOFILE dfgi abmon avril
+// spell-checker:ignore (words) ints (linux) NOFILE dfgi abmon avril abricot figue échalote zeste nfigue nzeste néchalote
 #![allow(clippy::cast_possible_wrap)]
 
 use std::env;
@@ -3835,6 +3835,84 @@ fn test_whole_line_ordering_with_long_shared_prefix() {
         }
     }
 }
+
+#[test]
+fn test_merge_and_check_collate_by_locale() {
+    // -m and -c collate on demand rather than through precomputed keys, so
+    // make sure they still order by the locale and not by bytes.
+    let (at, mut ucmd) = at_and_ucmd!();
+    at.write("left.txt", "abricot\nfigue\n");
+    at.write("right.txt", "échalote\nzeste\n");
+    ucmd.env("LC_ALL", "en_US.UTF-8")
+        .args(&["-m", "left.txt", "right.txt"])
+        .succeeds()
+        .stdout_only("abricot\néchalote\nfigue\nzeste\n");
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-c")
+        .pipe_in("abricot\néchalote\nfigue\n")
+        .succeeds()
+        .no_output();
+    new_ucmd!()
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-c")
+        .pipe_in("abricot\nfigue\néchalote\n")
+        .fails_with_code(1)
+        .stderr_only("sort: -:3: disorder: échalote\n");
+}
+
+#[test]
+fn test_locale_collation_agrees_between_sort_merge_and_check() {
+    // "café" spelled with a single é code point and with e + combining acute
+    // collates equal but differs in bytes. Every mode has to break that tie
+    // the same way: sorting, merging (which collates on demand), checking,
+    // and a sort that spills to temporary files.
+    let composed = "caf\u{e9}\n";
+    let combining = "cafe\u{301}\n";
+    let input = format!("{composed}{combining}");
+    let scene = TestScenario::new("sort");
+    let at = &scene.fixtures;
+    at.write("in.txt", &input);
+    let sorted = scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("in.txt")
+        .succeeds()
+        .stdout_move_str();
+    scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .arg("-c")
+        .pipe_in(sorted.clone())
+        .succeeds()
+        .no_output();
+    scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .args(&["-m", "in.txt"])
+        .succeeds()
+        .stdout_only(&sorted);
+    scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .args(&["-S", "1", "in.txt"])
+        .succeeds()
+        .stdout_only(&sorted);
+    // -u keeps both spellings, as the byte tie-break tells them apart.
+    scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .args(&["-u", "in.txt"])
+        .succeeds()
+        .stdout_only(&sorted);
+    scene
+        .ucmd()
+        .env("LC_ALL", "en_US.UTF-8")
+        .args(&["-mu", "in.txt"])
+        .succeeds()
+        .stdout_only(&sorted);
+}
+
 #[test]
 fn test_ignore_case_key_reverse_disagreeing_with_global() {
     // A key `r` that the global options lack has to be honored on the

--- a/tests/by-util/test_sort.rs
+++ b/tests/by-util/test_sort.rs
@@ -353,6 +353,13 @@ fn test_numeric_sort_uses_the_key_not_the_whole_line() {
         .pipe_in("19\n21\n3\n")
         .succeeds()
         .stdout_is("3\n21\n19\n");
+    // With the global `-r` agreeing, the key still keeps its own ordering:
+    // the `r` on it switches `-n` off for that key, so this is lexicographic.
+    new_ucmd!()
+        .args(&["-n", "-k1r", "-r"])
+        .pipe_in("19\n21\n3\n")
+        .succeeds()
+        .stdout_is("3\n21\n19\n");
 
     // Equal keys fall back to comparing the lines byte by byte, not
     // numerically.
@@ -3738,4 +3745,117 @@ fn test_single_line_without_any_line_ending() {
         .pipe_in(line.clone())
         .succeeds()
         .stdout_is(format!("{line}\n"));
+}
+
+#[test]
+fn test_whole_line_ordering_matches_across_sort_flavors() {
+    // Plain whole-line sorting takes a dedicated comparison path; the flag
+    // combinations below each pick a different sort, so check they agree.
+    let input = "pear\nfig\npear\nquince\nfig\napricot\n";
+
+    new_ucmd!()
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("apricot\nfig\nfig\npear\npear\nquince\n");
+    new_ucmd!()
+        .arg("-r")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\npear\nfig\nfig\napricot\n");
+    new_ucmd!()
+        .arg("-u")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("apricot\nfig\npear\nquince\n");
+    new_ucmd!()
+        .args(&["-u", "-r"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\nfig\napricot\n");
+    new_ucmd!()
+        .arg("-s")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("apricot\nfig\nfig\npear\npear\nquince\n");
+    // `r` on the key rather than global
+    new_ucmd!()
+        .arg("-k1r")
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\npear\nfig\nfig\napricot\n");
+    new_ucmd!()
+        .args(&["-k1r", "-u"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\nfig\napricot\n");
+    // A key `r` that agrees with the global one reverses once, not twice.
+    new_ucmd!()
+        .args(&["-k1r", "-r"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\npear\nfig\nfig\napricot\n");
+    new_ucmd!()
+        .args(&["-r", "-k1"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("quince\npear\npear\nfig\nfig\napricot\n");
+}
+
+#[test]
+fn test_whole_line_ordering_with_long_shared_prefix() {
+    // Lines share a long prefix and differ before, inside and past the eight
+    // bytes that follow it; one is the bare prefix and one holds a NUL.
+    let prefix = "/var/lib/backups/nightly/host-";
+    let input = format!(
+        "{prefix}beta/2026-08-31.tar\n{prefix}alpha/2026-09-01.tar\n\
+         {prefix}alpha/2026-09-01.tar.gz\n{prefix}alpha\0/x\n{prefix}\n\
+         {prefix}alpha/2026-08-30.tar\n{prefix}alpha\n{prefix}alpha/2026-09-01.tar\n"
+    );
+    let expected = format!(
+        "{prefix}\n{prefix}alpha\n{prefix}alpha\0/x\n{prefix}alpha/2026-08-30.tar\n\
+         {prefix}alpha/2026-09-01.tar\n{prefix}alpha/2026-09-01.tar\n\
+         {prefix}alpha/2026-09-01.tar.gz\n{prefix}beta/2026-08-31.tar\n"
+    );
+    let unique_reversed = format!(
+        "{prefix}beta/2026-08-31.tar\n{prefix}alpha/2026-09-01.tar.gz\n\
+         {prefix}alpha/2026-09-01.tar\n{prefix}alpha/2026-08-30.tar\n\
+         {prefix}alpha\0/x\n{prefix}alpha\n{prefix}\n"
+    );
+    for parallel in ["--parallel=1", "--parallel=4"] {
+        for (args, expected) in [
+            (vec![parallel], &expected),
+            (vec![parallel, "-s"], &expected),
+            (vec![parallel, "-u", "-r"], &unique_reversed),
+        ] {
+            new_ucmd!()
+                .args(&args)
+                .pipe_in(input.as_bytes())
+                .succeeds()
+                .stdout_is_bytes(expected.as_bytes());
+        }
+    }
+}
+#[test]
+fn test_ignore_case_key_reverse_disagreeing_with_global() {
+    // A key `r` that the global options lack has to be honored on the
+    // case-insensitive whole-line path too.
+    let input = "Kiwi\nplum\nDATE\n";
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-f", "-k1fr"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("plum\nKiwi\nDATE\n");
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-f", "-r", "-k1f"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("DATE\nKiwi\nplum\n");
+    new_ucmd!()
+        .env("LC_ALL", "C")
+        .args(&["-f", "-r", "-k1fr"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_is("plum\nKiwi\nDATE\n");
 }


### PR DESCRIPTION
Three perf changes to sort:
 - write output in full buffers and flush merged output
 - key whole-line comparisons on a prefix word, dispatching the comparator once up front
 - collate on demand for -m/-c instead of precomputing collation keys
