### PR TITLE
uucore: os_str_from_bytes does not need to alloc

### DIFF
--- a/src/uu/du/src/du.rs
+++ b/src/uu/du/src/du.rs
@@ -989,7 +989,7 @@ fn read_files_from(file_name: &OsStr) -> io::Result<Vec<PathBuf>> {
             // relies on inode-based deduplication during traversal (which is
             // disabled by --count-links). Deduplicating by name would, e.g.,
             // collapse repeated missing files into a single error.
-            paths.push(PathBuf::from(&*uucore::os_str_from_bytes(&path).unwrap()));
+            paths.push(PathBuf::from(uucore::os_str_from_bytes(&path).unwrap()));
         }
     }
 

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -685,7 +685,7 @@ fn compute_and_check_digest_from_file(
     let real_filename_to_check = os_str_from_bytes(&filename_to_check_unescaped)?;
 
     // Open the input file
-    let file_to_check = get_file_to_check(&real_filename_to_check, opts)?;
+    let file_to_check = get_file_to_check(real_filename_to_check, opts)?;
     let mut file_reader = BufReader::new(file_to_check);
 
     // Read the file and calculate the checksum
@@ -699,14 +699,14 @@ fn compute_and_check_digest_from_file(
             Ok(result) => result,
             Err(err) => {
                 show!(err.map_err_context(|| {
-                    locale_aware_escape_name(&real_filename_to_check, QuotingStyle::SHELL_ESCAPE)
+                    locale_aware_escape_name(real_filename_to_check, QuotingStyle::SHELL_ESCAPE)
                         .to_string_lossy()
                         .to_string()
                 }));
 
                 let _ = write_file_report(
                     io::stdout(),
-                    &real_filename_to_check,
+                    real_filename_to_check,
                     FileChecksumResult::CantOpen,
                     opts.verbose,
                 );
@@ -722,7 +722,7 @@ fn compute_and_check_digest_from_file(
     };
     let _ = write_file_report(
         io::stdout(),
-        &real_filename_to_check,
+        real_filename_to_check,
         FileChecksumResult::from_bool(checksum_correct),
         opts.verbose,
     );

--- a/src/uucore/src/lib/features/diagnostics.rs
+++ b/src/uucore/src/lib/features/diagnostics.rs
@@ -218,7 +218,7 @@ impl Snapshot {
         let mut snapshot = Self::with_capacity(args.len());
         for arg in args {
             snapshot.push(match crate::os_str_from_bytes(arg.as_ref()) {
-                Ok(arg) => arg.into_owned(),
+                Ok(arg) => arg.to_owned(),
                 // Only reachable on platforms where `OsStr` is not raw bytes;
                 // show the argument lossily rather than not at all.
                 Err(_) => String::from_utf8_lossy(arg.as_ref()).into_owned().into(),

--- a/src/uucore/src/lib/features/fsext.rs
+++ b/src/uucore/src/lib/features/fsext.rs
@@ -365,7 +365,7 @@ impl From<StatFs> for MountInfo {
             // spell-checker:disable-next-line
             CStr::from_ptr(statfs.f_mntonname.as_ptr()).to_bytes()
         };
-        let mount_dir = os_str_from_bytes(mount_dir_bytes).unwrap().into_owned();
+        let mount_dir = os_str_from_bytes(mount_dir_bytes).unwrap().to_owned();
 
         let dev_id = mount_dev_id(&mount_dir);
         let dummy = is_dummy_filesystem(&fs_type, "");

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -495,8 +495,7 @@ pub fn os_str_as_bytes_lossy(os_string: &OsStr) -> Cow<'_, [u8]> {
     }
 }
 
-/// Converts a `&[u8]` to an `&OsStr`,
-/// or parses it as UTF-8 into an [`OsString`] on non-unix platforms.
+/// Converts a `&[u8]` to an `&OsStr`.
 ///
 /// This always succeeds on unix platforms,
 /// and fails on other platforms if the bytes can't be parsed as UTF-8.
@@ -504,14 +503,14 @@ pub fn os_str_as_bytes_lossy(os_string: &OsStr) -> Cow<'_, [u8]> {
     any(unix, all(target_os = "wasi", target_env = "p1")),
     expect(clippy::unnecessary_wraps)
 )]
-pub fn os_str_from_bytes(bytes: &[u8]) -> error::UResult<Cow<'_, OsStr>> {
+pub fn os_str_from_bytes(bytes: &[u8]) -> error::UResult<&OsStr> {
     #[cfg(any(unix, all(target_os = "wasi", target_env = "p1")))]
-    return Ok(Cow::Borrowed(OsStr::from_bytes(bytes)));
+    return Ok(OsStr::from_bytes(bytes));
 
     #[cfg(not(any(unix, all(target_os = "wasi", target_env = "p1"))))]
-    Ok(Cow::Owned(OsString::from(str::from_utf8(bytes).map_err(
-        |_| error::UUsageError::new(1, "Unable to transform bytes into OsStr"),
-    )?)))
+    Ok(OsStr::new(str::from_utf8(bytes).map_err(|_| {
+        error::UUsageError::new(1, "Unable to transform bytes into OsStr")
+    })?))
 }
 
 /// Converts a `Vec<u8>` into an `OsString`, parsing as UTF-8 on non-unix platforms.

--- a/tests/by-util/test_basename.rs
+++ b/tests/by-util/test_basename.rs
@@ -169,7 +169,7 @@ fn test_invalid_utf8_args() {
         .expect("Only unix platforms can test non-unicode names");
 
     new_ucmd!()
-        .arg(&param)
+        .arg(param)
         .succeeds()
         .stdout_is_bytes(b"some-\xc0-file.k\xf3\n");
 
@@ -177,8 +177,8 @@ fn test_invalid_utf8_args() {
         .expect("Only unix platforms can test non-unicode names");
 
     new_ucmd!()
-        .arg(&param)
-        .arg(&suffix)
+        .arg(param)
+        .arg(suffix)
         .succeeds()
         .stdout_is_bytes(b"some-\xc0-file\n");
 }

--- a/tests/by-util/test_mkdir.rs
+++ b/tests/by-util/test_mkdir.rs
@@ -79,7 +79,7 @@ fn test_mkdir_non_unicode() {
 
     let target = uucore::os_str_from_bytes(b"some-\xc0-dir-\xf3")
         .expect("Only unix platforms can test non-unicode names");
-    ucmd.arg(&target).succeeds();
+    ucmd.arg(target).succeeds();
 
     assert!(at.dir_exists(target));
 }

--- a/tests/by-util/test_wc.rs
+++ b/tests/by-util/test_wc.rs
@@ -296,8 +296,8 @@ fn test_non_unicode_names() {
         .expect("Only unix platforms can test non-unicode names");
 
     at.mkdir("some-dir1");
-    at.touch(&target1);
-    at.touch(&target2);
+    at.touch(target1);
+    at.touch(target2);
 
     ucmd.args(&[target1, target2]).succeeds().stdout_is_bytes(
         [


### PR DESCRIPTION
The borrow checker agrees: 9 out of 10 doctors
recommend `os_str_from_bytes` to be alloc free.