### PR TITLE
more: get rid of is-directory locale

### DIFF
--- a/src/uu/more/locales/en-US.ftl
+++ b/src/uu/more/locales/en-US.ftl
@@ -2,7 +2,6 @@ more-about = Display the contents of a text file
 more-usage = more [OPTIONS] FILE...
 
 # Error messages
-more-error-is-directory = {$path} is a directory.
 more-error-cannot-open-no-such-file = cannot open {$path}: No such file or directory
 more-error-cannot-open-io-error = cannot open {$path}: {$error}
 more-error-bad-usage = bad usage

--- a/src/uu/more/locales/fr-FR.ftl
+++ b/src/uu/more/locales/fr-FR.ftl
@@ -2,7 +2,6 @@ more-about = Afficher le contenu d'un fichier texte
 more-usage = more [OPTIONS] FICHIER...
 
 # Messages d'erreur
-more-error-is-directory = {$path} est un répertoire.
 more-error-cannot-open-no-such-file = impossible d'ouvrir {$path} : Aucun fichier ou répertoire de ce nom
 more-error-cannot-open-io-error = impossible d'ouvrir {$path} : {$error}
 more-error-bad-usage = mauvaise utilisation

--- a/src/uu/more/src/more.rs
+++ b/src/uu/more/src/more.rs
@@ -22,7 +22,7 @@ use crossterm::{
     terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
-use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::error::{FromIo, UResult, USimpleError, UUsageError};
 use uucore::format_usage;
 use uucore::{display::Quotable, show};
 
@@ -30,7 +30,6 @@ use uucore::translate;
 
 #[derive(Debug)]
 enum MoreError {
-    IsDirectory(PathBuf),
     CannotOpenNoSuchFile(PathBuf),
     CannotOpenIOError(PathBuf, std::io::ErrorKind),
     BadUsage,
@@ -39,16 +38,6 @@ enum MoreError {
 impl std::fmt::Display for MoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::IsDirectory(path) => {
-                write!(
-                    f,
-                    "{}",
-                    translate!(
-                        "more-error-is-directory",
-                        "path" => path.quote()
-                    )
-                )
-            }
             Self::CannotOpenNoSuchFile(path) => {
                 write!(
                     f,
@@ -159,13 +148,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let mut files_iter = files.peekable();
         while let (Some(file_os), next_file) = (files_iter.next(), files_iter.peek()) {
             let file = Path::new(file_os);
-            if file.is_dir() {
-                show!(UUsageError::new(
-                    0,
-                    MoreError::IsDirectory(file.into()).to_string(),
-                ));
-                continue;
-            }
             if !file.exists() {
                 show!(USimpleError::new(
                     0,
@@ -549,7 +531,11 @@ impl<'a> Pager<'a> {
         // Read lines until we reach the target line or EOF
         let mut line = String::new();
         while self.lines.len() <= target_line {
-            let bytes_read = self.input.read_line(&mut line)?;
+            let bytes_read = self
+                .input
+                .read_line(&mut line)
+                .map_err_context(|| self.file_name.unwrap().quote().to_string())
+                .map_err(|e| USimpleError::new(0, e.to_string()))?;
             if bytes_read == 0 {
                 return Ok(false); // EOF
             }

--- a/tests/by-util/test_more.rs
+++ b/tests/by-util/test_more.rs
@@ -152,7 +152,7 @@ fn test_file_arg() {
         .set_stdout(File::create(&path).unwrap())
         .arg(".")
         .succeeds()
-        .stderr_contains("'.' is a directory.");
+        .stderr_contains("'.': Is a directory");
 
     // Single argument errors
     let (path, _controller, _replica) = pty_path();
@@ -162,7 +162,7 @@ fn test_file_arg() {
         .set_stdout(File::create(&path).unwrap())
         .arg("folder")
         .succeeds()
-        .stderr_contains("is a directory");
+        .stderr_contains("Is a directory");
 
     let (path, _controller, _replica) = pty_path();
     new_ucmd!()


### PR DESCRIPTION
gets rid of the more-error-is-directory locale, uses the IO error instead