### PR TITLE
uucore: Implement are_hardlinks_to_same_file on Windows

### DIFF
--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -808,12 +808,6 @@ pub fn is_symlink_loop(path: &Path) -> bool {
     false
 }
 
-#[cfg(not(unix))]
-// Hard link comparison is not supported on non-Unix platforms
-pub fn are_hardlinks_to_same_file(_source: &Path, _target: &Path) -> bool {
-    false
-}
-
 /// Checks if two paths are hard links to the same file.
 ///
 /// # Arguments
@@ -824,23 +818,35 @@ pub fn are_hardlinks_to_same_file(_source: &Path, _target: &Path) -> bool {
 /// # Returns
 ///
 /// * `bool` - Returns `true` if the paths are hard links to the same file, and `false` otherwise.
-#[cfg(unix)]
 pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
-    // The target is usually the one that does not exist, so look it up first
-    // and return early instead of also querying the source for nothing.
-    let Ok(target_metadata) = fs::symlink_metadata(target) else {
-        return false;
-    };
-    let Ok(source_metadata) = fs::symlink_metadata(source) else {
-        return false;
-    };
+    #[cfg(unix)]
+    {
+        // The target is usually the one that does not exist, so look it up first
+        // and return early instead of also querying the source for nothing.
+        let Ok(target_metadata) = fs::symlink_metadata(target) else {
+            return false;
+        };
+        let Ok(source_metadata) = fs::symlink_metadata(source) else {
+            return false;
+        };
 
-    source_metadata.ino() == target_metadata.ino() && source_metadata.dev() == target_metadata.dev()
-}
+        source_metadata.ino() == target_metadata.ino()
+            && source_metadata.dev() == target_metadata.dev()
+    }
 
-#[cfg(not(unix))]
-pub fn are_hardlinks_or_one_way_symlink_to_same_file(_source: &Path, _target: &Path) -> bool {
-    false
+    #[cfg(windows)]
+    {
+        infos_refer_to_same_file(
+            FileInformation::from_path(source, false),
+            FileInformation::from_path(target, false),
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        _ = (source, target);
+        false
+    }
 }
 
 /// Checks if either two paths are hard links to the same file or if the source path is a symbolic link which when fully resolved points to target path
@@ -853,18 +859,35 @@ pub fn are_hardlinks_or_one_way_symlink_to_same_file(_source: &Path, _target: &P
 /// # Returns
 ///
 /// * `bool` - Returns `true` if either of above conditions are true, and `false` otherwise.
-#[cfg(unix)]
 pub fn are_hardlinks_or_one_way_symlink_to_same_file(source: &Path, target: &Path) -> bool {
-    // As above, look up the target first: if it does not exist, there is
-    // nothing to compare the source with.
-    let Ok(target_metadata) = fs::symlink_metadata(target) else {
-        return false;
-    };
-    let Ok(source_metadata) = fs::metadata(source) else {
-        return false;
-    };
+    #[cfg(unix)]
+    {
+        // As above, look up the target first: if it does not exist, there is
+        // nothing to compare the source with.
+        let Ok(target_metadata) = fs::symlink_metadata(target) else {
+            return false;
+        };
+        let Ok(source_metadata) = fs::metadata(source) else {
+            return false;
+        };
 
-    source_metadata.ino() == target_metadata.ino() && source_metadata.dev() == target_metadata.dev()
+        source_metadata.ino() == target_metadata.ino()
+            && source_metadata.dev() == target_metadata.dev()
+    }
+
+    #[cfg(windows)]
+    {
+        infos_refer_to_same_file(
+            FileInformation::from_path(source, true),
+            FileInformation::from_path(target, false),
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        _ = (source, target);
+        false
+    }
 }
 
 /// Returns true if the passed `path` ends with a path terminator.
@@ -1146,11 +1169,9 @@ pub fn makedev(maj: core::ffi::c_uint, min: core::ffi::c_uint) -> libc::dev_t {
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
-    #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix;
-    #[cfg(unix)]
     use tempfile::{NamedTempFile, tempdir};
 
     struct NormalizePathTestCase<'a> {
@@ -1327,7 +1348,6 @@ mod tests {
         assert!(is_symlink_loop(&symlink1_path));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_are_hardlinks_to_same_file_same_file() {
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -1337,9 +1357,9 @@ mod tests {
         let path2 = temp_file.path();
 
         assert!(are_hardlinks_to_same_file(path1, path2));
+        assert!(are_hardlinks_or_one_way_symlink_to_same_file(path1, path2));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_are_hardlinks_to_same_file_different_files() {
         let mut temp_file1 = NamedTempFile::new().unwrap();
@@ -1352,9 +1372,9 @@ mod tests {
         let path2 = temp_file2.path();
 
         assert!(!are_hardlinks_to_same_file(path1, path2));
+        assert!(!are_hardlinks_or_one_way_symlink_to_same_file(path1, path2));
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_are_hardlinks_to_same_file_hard_link() {
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -1365,6 +1385,28 @@ mod tests {
         fs::hard_link(path1, &path2).unwrap();
 
         assert!(are_hardlinks_to_same_file(path1, &path2));
+        assert!(are_hardlinks_or_one_way_symlink_to_same_file(path1, &path2));
+    }
+
+    #[test]
+    fn test_are_hardlinks_to_same_file_symlink() {
+        let directory = tempdir().unwrap();
+        let mut temp_file = NamedTempFile::new_in(directory.path()).unwrap();
+        writeln!(temp_file, "Test content").unwrap();
+
+        let path1 = temp_file.path();
+        let path2 = temp_file.path().with_extension("symlink");
+
+        #[cfg(unix)]
+        unix::fs::symlink(path1, &path2).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(path1, &path2).unwrap();
+
+        assert!(!are_hardlinks_to_same_file(&path2, path1));
+        assert!(are_hardlinks_or_one_way_symlink_to_same_file(&path2, path1));
+        assert!(!are_hardlinks_or_one_way_symlink_to_same_file(
+            path1, &path2
+        ));
     }
 
     #[test]
@@ -1449,7 +1491,7 @@ mod tests {
         use std::os::windows::fs::MetadataExt;
         use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_SPARSE_FILE;
 
-        let file = tempfile::NamedTempFile::new().unwrap();
+        let file = NamedTempFile::new().unwrap();
         set_file_sparse(file.as_file()).unwrap();
         let attributes = file.as_file().metadata().unwrap().file_attributes();
         assert_ne!(attributes & FILE_ATTRIBUTE_SPARSE_FILE, 0);
@@ -1457,9 +1499,6 @@ mod tests {
 
     #[test]
     fn test_are_files_identical() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
         let mut file1 = NamedTempFile::new().unwrap();
         let mut file2 = NamedTempFile::new().unwrap();
         let mut file3 = NamedTempFile::new().unwrap();

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -1356,6 +1356,7 @@ mod tests {
         assert!(is_symlink_loop(&symlink1_path));
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn test_are_hardlinks_to_same_file_same_file() {
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -1368,6 +1369,7 @@ mod tests {
         assert!(are_hardlinks_or_one_way_symlink_to_same_file(path1, path2));
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn test_are_hardlinks_to_same_file_different_files() {
         let mut temp_file1 = NamedTempFile::new().unwrap();
@@ -1383,6 +1385,7 @@ mod tests {
         assert!(!are_hardlinks_or_one_way_symlink_to_same_file(path1, path2));
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn test_are_hardlinks_to_same_file_hard_link() {
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -1396,6 +1399,7 @@ mod tests {
         assert!(are_hardlinks_or_one_way_symlink_to_same_file(path1, &path2));
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn test_are_hardlinks_to_same_file_symlink() {
         let directory = tempdir().unwrap();

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -818,39 +818,47 @@ pub fn is_symlink_loop(path: &Path) -> bool {
 /// # Returns
 ///
 /// * `bool` - Returns `true` if the paths are hard links to the same file, and `false` otherwise.
+#[cfg(unix)]
 pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        // The target is usually the one that does not exist, so look it up first
-        // and return early instead of also querying the source for nothing.
-        let Ok(target_metadata) = fs::symlink_metadata(target) else {
-            return false;
-        };
-        let Ok(source_metadata) = fs::symlink_metadata(source) else {
-            return false;
-        };
+    // The target is usually the one that does not exist, so look it up first
+    // and return early instead of also querying the source for nothing.
+    let Ok(target_metadata) = fs::symlink_metadata(target) else {
+        return false;
+    };
+    let Ok(source_metadata) = fs::symlink_metadata(source) else {
+        return false;
+    };
 
-        source_metadata.ino() == target_metadata.ino()
-            && source_metadata.dev() == target_metadata.dev()
-    }
+    source_metadata.ino() == target_metadata.ino() && source_metadata.dev() == target_metadata.dev()
+}
 
-    #[cfg(windows)]
-    {
-        let Ok(target_metadata) = FileInformation::from_path(target, false) else {
-            return false;
-        };
-        let Ok(source_metadata) = FileInformation::from_path(source, false) else {
-            return false;
-        };
+/// Checks if two paths are hard links to the same file.
+///
+/// # Arguments
+///
+/// * `source` - A reference to a `Path` representing the source path.
+/// * `target` - A reference to a `Path` representing the target path.
+///
+/// # Returns
+///
+/// * `bool` - Returns `true` if the paths are hard links to the same file, and `false` otherwise.
+#[cfg(windows)]
+pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
+    // The target is usually the one that does not exist, so look it up first
+    // and return early instead of also querying the source for nothing.
+    let Ok(target_metadata) = FileInformation::from_path(target, false) else {
+        return false;
+    };
+    let Ok(source_metadata) = FileInformation::from_path(source, false) else {
+        return false;
+    };
 
-        target_metadata == source_metadata
-    }
+    target_metadata == source_metadata
+}
 
-    #[cfg(not(any(unix, windows)))]
-    {
-        _ = (source, target);
-        false
-    }
+#[cfg(not(any(unix, windows)))]
+pub fn are_hardlinks_to_same_file(_source: &Path, _target: &Path) -> bool {
+    false
 }
 
 /// Checks if either two paths are hard links to the same file or if the source path is a symbolic link which when fully resolved points to target path
@@ -863,39 +871,47 @@ pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
 /// # Returns
 ///
 /// * `bool` - Returns `true` if either of above conditions are true, and `false` otherwise.
+#[cfg(unix)]
 pub fn are_hardlinks_or_one_way_symlink_to_same_file(source: &Path, target: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        // As above, look up the target first: if it does not exist, there is
-        // nothing to compare the source with.
-        let Ok(target_metadata) = fs::symlink_metadata(target) else {
-            return false;
-        };
-        let Ok(source_metadata) = fs::metadata(source) else {
-            return false;
-        };
+    // As above, look up the target first: if it does not exist, there is
+    // nothing to compare the source with.
+    let Ok(target_metadata) = fs::symlink_metadata(target) else {
+        return false;
+    };
+    let Ok(source_metadata) = fs::metadata(source) else {
+        return false;
+    };
 
-        source_metadata.ino() == target_metadata.ino()
-            && source_metadata.dev() == target_metadata.dev()
-    }
+    source_metadata.ino() == target_metadata.ino() && source_metadata.dev() == target_metadata.dev()
+}
 
-    #[cfg(windows)]
-    {
-        let Ok(target_metadata) = FileInformation::from_path(target, false) else {
-            return false;
-        };
-        let Ok(source_metadata) = FileInformation::from_path(source, true) else {
-            return false;
-        };
+/// Checks if either two paths are hard links to the same file or if the source path is a symbolic link which when fully resolved points to target path
+///
+/// # Arguments
+///
+/// * `source` - A reference to a `Path` representing the source path.
+/// * `target` - A reference to a `Path` representing the target path.
+///
+/// # Returns
+///
+/// * `bool` - Returns `true` if either of above conditions are true, and `false` otherwise.
+#[cfg(windows)]
+pub fn are_hardlinks_or_one_way_symlink_to_same_file(source: &Path, target: &Path) -> bool {
+    // As above, look up the target first: if it does not exist, there is
+    // nothing to compare the source with.
+    let Ok(target_metadata) = FileInformation::from_path(target, false) else {
+        return false;
+    };
+    let Ok(source_metadata) = FileInformation::from_path(source, true) else {
+        return false;
+    };
 
-        target_metadata == source_metadata
-    }
+    target_metadata == source_metadata
+}
 
-    #[cfg(not(any(unix, windows)))]
-    {
-        _ = (source, target);
-        false
-    }
+#[cfg(not(any(unix, windows)))]
+pub fn are_hardlinks_or_one_way_symlink_to_same_file(_source: &Path, _target: &Path) -> bool {
+    false
 }
 
 /// Returns true if the passed `path` ends with a path terminator.

--- a/src/uucore/src/lib/features/fs.rs
+++ b/src/uucore/src/lib/features/fs.rs
@@ -836,10 +836,14 @@ pub fn are_hardlinks_to_same_file(source: &Path, target: &Path) -> bool {
 
     #[cfg(windows)]
     {
-        infos_refer_to_same_file(
-            FileInformation::from_path(source, false),
-            FileInformation::from_path(target, false),
-        )
+        let Ok(target_metadata) = FileInformation::from_path(target, false) else {
+            return false;
+        };
+        let Ok(source_metadata) = FileInformation::from_path(source, false) else {
+            return false;
+        };
+
+        target_metadata == source_metadata
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -877,10 +881,14 @@ pub fn are_hardlinks_or_one_way_symlink_to_same_file(source: &Path, target: &Pat
 
     #[cfg(windows)]
     {
-        infos_refer_to_same_file(
-            FileInformation::from_path(source, true),
-            FileInformation::from_path(target, false),
-        )
+        let Ok(target_metadata) = FileInformation::from_path(target, false) else {
+            return false;
+        };
+        let Ok(source_metadata) = FileInformation::from_path(source, true) else {
+            return false;
+        };
+
+        target_metadata == source_metadata
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -4420,7 +4420,7 @@ fn test_cp_mode_hardlink_no_dereference() {
     assert_eq!(at.read_symlink("z"), "slink");
 }
 
-#[cfg(not(any(windows, target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 #[test]
 #[cfg_attr(
     wasi_runner,

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1191,8 +1191,7 @@ fn test_cp_arg_force() {
 }
 
 /// TODO: write a better test that differentiates --remove-destination
-/// from --force. Also this test currently doesn't work on
-/// Windows. This test originally checked file timestamps, which
+/// from --force. This test originally checked file timestamps, which
 /// proved to be unreliable per target / CI platform
 #[test]
 fn test_cp_arg_remove_destination() {

--- a/tests/by-util/test_cp.rs
+++ b/tests/by-util/test_cp.rs
@@ -1195,7 +1195,6 @@ fn test_cp_arg_force() {
 /// Windows. This test originally checked file timestamps, which
 /// proved to be unreliable per target / CI platform
 #[test]
-#[cfg(not(windows))]
 fn test_cp_arg_remove_destination() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -3560,7 +3559,6 @@ fn test_copy_dir_with_symlinks() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg_attr(
     wasi_runner,
     ignore = "WASI sandbox: symlink/hardlink capability restrictions cause dangling-symlink/same-file detection to differ"
@@ -3826,7 +3824,6 @@ fn test_copy_through_dangling_symlink_no_dereference_2() {
 
 /// Test that copy through a dangling symbolic link fails, even with --force.
 #[test]
-#[cfg(not(windows))]
 fn test_copy_through_dangling_symlink_force() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("src");
@@ -4260,7 +4257,7 @@ fn test_copy_same_symlink_no_dereference_dangling() {
 }
 
 // TODO: enable for Android, when #3477 solved
-#[cfg(not(any(windows, target_os = "android", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "android", target_os = "openbsd")))]
 #[test]
 #[cfg_attr(
     wasi_runner,
@@ -4486,7 +4483,6 @@ fn test_remove_destination_symbolic_link_loop() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg_attr(
     wasi_runner,
     ignore = "WASI sandbox: symlink/hardlink capability restrictions cause dangling-symlink/same-file detection to differ"
@@ -4656,7 +4652,6 @@ fn test_same_file_backup() {
 }
 
 /// Test that copying file to itself with forced backup succeeds.
-#[cfg(not(windows))]
 #[test]
 fn test_same_file_force() {
     let (at, mut ucmd) = at_and_ucmd!();
@@ -4668,7 +4663,6 @@ fn test_same_file_force() {
 }
 
 /// Test that copying file to itself with forced backup succeeds.
-#[cfg(not(windows))]
 #[test]
 #[cfg_attr(
     wasi_runner,
@@ -4772,7 +4766,7 @@ fn test_preserve_hardlink_attributes_in_directory() {
 }
 
 #[test]
-#[cfg(not(any(windows, target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_hard_link_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("src");
@@ -4785,7 +4779,6 @@ fn test_hard_link_file() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn test_symbolic_link_file() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.touch("src");
@@ -4873,7 +4866,6 @@ fn test_non_utf8_target() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg_attr(
     wasi_runner,
     ignore = "WASI: no chmod syscall, so required mode/ownership preservation always fails"
@@ -8754,7 +8746,6 @@ fn test_cp_current_directory_with_symlinks() {
 }
 
 #[test]
-#[cfg(not(windows))]
 #[cfg_attr(
     wasi_runner,
     ignore = "WASI sandbox: symlink/hardlink capability restrictions cause dangling-symlink/same-file detection to differ"

--- a/tests/by-util/test_mv.rs
+++ b/tests/by-util/test_mv.rs
@@ -400,7 +400,7 @@ fn test_mv_replace_file() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_replace_symlink_with_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -426,7 +426,7 @@ fn test_mv_replace_symlink_with_symlink() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_replace_symlink_with_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -445,7 +445,7 @@ fn test_mv_replace_symlink_with_directory() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_replace_symlink_with_file() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -467,7 +467,7 @@ fn test_mv_replace_symlink_with_file() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_file_to_broken_symlink_file() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -482,7 +482,7 @@ fn test_mv_file_to_broken_symlink_file() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_file_to_broken_symlink_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -497,7 +497,7 @@ fn test_mv_file_to_broken_symlink_directory() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_file_to_symlink_directory() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -551,7 +551,7 @@ fn test_mv_same_file() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_same_hardlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a";
@@ -568,7 +568,7 @@ fn test_mv_same_hardlink() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_dangling_symlink_to_folder() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -581,7 +581,7 @@ fn test_mv_dangling_symlink_to_folder() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_same_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a";
@@ -629,7 +629,7 @@ fn test_mv_same_symlink() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_same_broken_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -642,7 +642,7 @@ fn test_mv_same_broken_symlink() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_symlink_into_target() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -670,7 +670,7 @@ fn test_mv_broken_symlink_to_another_fs() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_hardlink_to_symlink() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file = "file";
@@ -699,7 +699,7 @@ fn test_mv_hardlink_to_symlink() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_same_hardlink_backup_simple() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a";
@@ -715,7 +715,7 @@ fn test_mv_same_hardlink_backup_simple() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_same_hardlink_backup_simple_destroy() {
     let (at, mut ucmd) = at_and_ucmd!();
     let file_a = "test_mv_same_file_a~";
@@ -734,7 +734,7 @@ fn test_mv_same_hardlink_backup_simple_destroy() {
 /// Comparing strings let `'a~'` versus `'./a'` slip through, and mv then
 /// destroyed the source and exited 0 with no diagnostic.
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_backup_simple_guard_ignores_spelling() {
     for target in ["./test_mv_spell_a", "test_mv_spell_a"] {
         let (at, mut ucmd) = at_and_ucmd!();
@@ -758,7 +758,7 @@ fn test_mv_backup_simple_guard_ignores_spelling() {
 
 /// ...but it must not fire for unrelated operands that merely look similar.
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_backup_simple_guard_allows_unrelated_source() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("test_mv_spell_src", "SRCDATA");
@@ -776,7 +776,7 @@ fn test_mv_backup_simple_guard_allows_unrelated_source() {
 /// A symlink source is a distinct file from the backup it points at, so the
 /// backup rename cannot destroy it. GNU allows this.
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_backup_simple_guard_allows_symlink_source() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("test_mv_sym_a", "DSTDATA");
@@ -792,7 +792,7 @@ fn test_mv_backup_simple_guard_allows_symlink_source() {
 /// A hard link under another name shares the backup's inode but keeps the data
 /// alive after the rename, so the guard must not fire. GNU allows this.
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_backup_simple_guard_allows_hardlink_source() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write("test_mv_hl_a", "DSTDATA");
@@ -2716,7 +2716,7 @@ fn test_mv_error_msg_with_multiple_sources_that_does_not_exist() {
 
 // Tests for hardlink preservation (now always enabled)
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_hardlink_preservation() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -2735,7 +2735,7 @@ fn test_mv_hardlink_preservation() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_hardlink_progress_indication() {
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -2761,10 +2761,9 @@ fn test_mv_hardlink_progress_indication() {
 }
 
 #[test]
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(not(target_os = "android"))]
 fn test_mv_mixed_hardlinks_and_regular_files() {
-    use std::fs::metadata;
-    use std::os::unix::fs::MetadataExt;
+    use uucore::fs::paths_refer_to_same_file;
 
     let (at, mut ucmd) = at_and_ucmd!();
 
@@ -2791,18 +2790,16 @@ fn test_mv_mixed_hardlinks_and_regular_files() {
     assert!(at.file_exists("target/regular2"));
 
     // Verify hardlinks are preserved (on same filesystem)
-    let h1_meta = metadata(at.plus("target/hardlink1")).unwrap();
-    let h2_meta = metadata(at.plus("target/hardlink2")).unwrap();
-    let r1_meta = metadata(at.plus("target/regular1")).unwrap();
-    let r2_meta = metadata(at.plus("target/regular2")).unwrap();
+    let h1 = at.plus("target/hardlink1");
+    let h2 = at.plus("target/hardlink2");
+    let r1 = at.plus("target/regular1");
+    let r2 = at.plus("target/regular2");
 
     // Hardlinked files should have same inode if on same filesystem
-    if h1_meta.dev() == h2_meta.dev() {
-        assert_eq!(h1_meta.ino(), h2_meta.ino());
-    }
+    assert!(paths_refer_to_same_file(h1, h2, false));
 
     // Regular files should have different inodes
-    assert_ne!(r1_meta.ino(), r2_meta.ino());
+    assert!(!paths_refer_to_same_file(r1, r2, false));
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Primitively implements hardlink detection using the
existing `infos_refer_to_same_file` facilities.

This fixes `cp --remove-destination` and `mv --backup`.