### PR TITLE
uucore: Use forward slashes for checksum paths on Windows

### DIFF
--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -657,6 +657,12 @@ pub fn unescape_filename(filename: &[u8]) -> (Vec<u8>, &'static str) {
 
 pub fn escape_filename(filename: &OsStr) -> (String, &'static str) {
     let original = filename.to_string_lossy();
+
+    // On Windows, backslashes are path separators. Normalize them to forward
+    // slashes so that the checksum output is portable across platforms.
+    #[cfg(windows)]
+    let original = original.replace('\\', "/");
+
     let escaped = original
         .replace('\\', "\\\\")
         .replace('\n', "\\n")
@@ -702,7 +708,13 @@ mod tests {
         assert_eq!(prefix, "\\");
 
         let (escaped, prefix) = escape_filename(OsStr::new("test\\file.txt"));
+        #[cfg(windows)]
+        assert_eq!(escaped, "test/file.txt");
+        #[cfg(windows)]
+        assert_eq!(prefix, "");
+        #[cfg(not(windows))]
         assert_eq!(escaped, "test\\\\file.txt");
+        #[cfg(not(windows))]
         assert_eq!(prefix, "\\");
     }
 

--- a/tests/by-util/test_md5sum.rs
+++ b/tests/by-util/test_md5sum.rs
@@ -342,6 +342,31 @@ fn test_conflicting_arg() {
 }
 
 #[test]
+#[cfg(windows)]
+fn test_windows_path_separator_round_trip() {
+    let scene = TestScenario::new(util_name!());
+    scene.fixtures.mkdir("subdir");
+    scene.fixtures.write("subdir/file.txt", "abc");
+
+    let result = scene
+        .ucmd()
+        .args(&["--text", "subdir\\file.txt"])
+        .succeeds();
+
+    result
+        .no_stderr()
+        .stdout_is("900150983cd24fb0d6963f7d28e17f72  subdir/file.txt\n");
+
+    scene
+        .ucmd()
+        .args(&["--check", "--strict"])
+        .pipe_in(result.stdout_str())
+        .succeeds()
+        .no_stderr()
+        .stdout_is("subdir/file.txt: OK\n");
+}
+
+#[test]
 #[cfg_attr(windows, ignore = "Disabled on windows")]
 fn test_with_escape_filename() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Previously, `sha256sum .\README.md | sha256sum --check` would not
round-trip on Windows, because `--check` rejects such paths.
It's probably best to normalize to forward slashes for portability.