### PR TITLE
uucore: Avoid panic on invalid input lines

### DIFF
--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -18,7 +18,7 @@ use crate::checksum::{
     AlgoKind, BlakeLength, ChecksumError, HashLength, ReadingMode, ShaLength, SizedAlgoKind,
     digest_reader, parse_blake_length, unescape_filename,
 };
-use crate::error::{FromIo, UError, UIoError, UResult, USimpleError, strip_errno};
+use crate::error::{FromIo, UError, UResult, USimpleError, strip_errno};
 use crate::quoting_style::{QuotingStyle, locale_aware_escape_name};
 use crate::sum::{self, Blake2b, Blake3, DigestOutput};
 use crate::{
@@ -884,11 +884,8 @@ fn process_checksum_file(
     let mut last_algo = None;
 
     for (i, line_res) in read_os_string_lines(reader).enumerate() {
-        let line = line_res.map_err(|e| {
-            USimpleError::new(
-                UIoError::from(e).code(),
-                format!("{}: read error", filename_input.maybe_quote()),
-            )
+        let line = line_res.map_err(|_| {
+            USimpleError::new(1, format!("{}: read error", filename_input.maybe_quote()))
         })?;
 
         let line_result = process_checksum_line(

--- a/src/uucore/src/lib/lib.rs
+++ b/src/uucore/src/lib/lib.rs
@@ -556,15 +556,15 @@ pub fn os_string_to_vec(s: OsString) -> error::UResult<Vec<u8>> {
 
 /// Equivalent to `std::BufRead::lines` which outputs each line as a `Vec<u8>`,
 /// which avoids panicking on non UTF-8 input.
-pub fn read_byte_lines<R: std::io::Read>(
+fn read_byte_lines<R: std::io::Read>(
     mut buf_reader: BufReader<R>,
-) -> impl Iterator<Item = std::io::Result<Vec<u8>>> {
+) -> impl Iterator<Item = error::UResult<Vec<u8>>> {
     iter::from_fn(move || {
         let mut buf = Vec::with_capacity(256);
 
         match buf_reader.read_until(b'\n', &mut buf) {
             Ok(0) => None,
-            Err(e) => Some(Err(e)),
+            Err(e) => Some(Err(e.into())),
             Ok(_) => {
                 // Trim (\r)\n
                 if buf.ends_with(b"\n") {
@@ -580,14 +580,14 @@ pub fn read_byte_lines<R: std::io::Read>(
     })
 }
 
-/// Equivalent to `std::BufRead::lines` which outputs each line as an `OsString`
-/// This won't panic on non UTF-8 characters on Unix,
-/// but it still will on Windows.
+/// Equivalent to `std::BufRead::lines` which outputs each line as an `OsString`.
+///
+/// On platforms where `OsString` cannot contain arbitrary bytes,
+/// non-UTF8 inputs are reported as an error.
 pub fn read_os_string_lines<R: std::io::Read>(
     buf_reader: BufReader<R>,
-) -> impl Iterator<Item = std::io::Result<OsString>> {
-    read_byte_lines(buf_reader)
-        .map(|byte_line_res| byte_line_res.map(|bl| os_string_from_vec(bl).expect("UTF-8 error")))
+) -> impl Iterator<Item = error::UResult<OsString>> {
+    read_byte_lines(buf_reader).map(|byte_line_res| byte_line_res.and_then(os_string_from_vec))
 }
 
 /// Prompt the user with a formatted string and returns `true` if they reply `'y'` or `'Y'`
@@ -773,6 +773,17 @@ mod tests {
         let os_str = OsStr::from_bytes(&source[..]);
         test_invalid_utf8_args_lossy(os_str);
         test_invalid_utf8_args_ignore(os_str);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invalid_utf8_line_returns_invalid_data() {
+        let input = BufReader::new(&b"valid\ninvalid \xff\n"[..]);
+        let mut lines = read_os_string_lines(input);
+
+        assert_eq!(lines.next().unwrap().unwrap(), OsStr::new("valid"));
+        assert!(lines.next().unwrap().is_err());
+        assert!(lines.next().is_none());
     }
 
     #[test]

--- a/tests/by-util/test_md5sum.rs
+++ b/tests/by-util/test_md5sum.rs
@@ -395,6 +395,17 @@ fn test_check_empty_line() {
 }
 
 #[test]
+#[cfg(windows)]
+fn test_check_invalid_utf8_reports_read_error() {
+    new_ucmd!()
+        .args(&["--check", "-"])
+        .pipe_in(b"invalid\xff\n")
+        .fails_with_code(1)
+        .no_stdout()
+        .stderr_is("md5sum: -: read error\n");
+}
+
+#[test]
 #[cfg_attr(windows, ignore = "Disabled on windows")]
 fn test_check_with_escape_filename() {
     let scene = TestScenario::new(util_name!());


### PR DESCRIPTION
Does what it says on the tin: No more crashing when reading
invalid input with checksum utilities on Windows.