### PR TITLE
uucore: Implement user locale detection for Windows

### DIFF
--- a/src/uucore/Cargo.toml
+++ b/src/uucore/Cargo.toml
@@ -118,6 +118,7 @@ windows-sys = { workspace = true, optional = true, default-features = false, fea
   "Win32_Security",
   "Win32_Storage_FileSystem",
   "Win32_Foundation",
+  "Win32_Globalization",
   "Win32_System_Console",
   "Win32_System_IO",
   "Win32_System_Ioctl",
@@ -159,7 +160,7 @@ format = [
 ]
 i18n-all = ["i18n-charmap", "i18n-collator", "i18n-decimal", "i18n-datetime"]
 i18n-charmap = ["i18n-common"]
-i18n-common = ["icu_locale"]
+i18n-common = ["icu_locale", "windows-sys"]
 i18n-collator = ["i18n-common", "icu_collator"]
 i18n-decimal = ["i18n-common", "icu_decimal", "icu_provider"]
 i18n-datetime = [

--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -61,7 +61,90 @@ pub fn get_locale_from_env(locale_name: &str) -> (Locale, UEncoding) {
             return (locale, encoding);
         }
     }
-    // Default POSIX locale representing LC_ALL=C
+
+    get_locale_from_os()
+}
+
+/// Returns the preferred user locale.
+#[cfg(windows)]
+pub fn get_locale_from_os() -> (Locale, UEncoding) {
+    use std::mem::MaybeUninit;
+    use std::ptr::{null, null_mut};
+    use std::str;
+    use windows_sys::Win32::Globalization::{
+        CP_UTF8, GetThreadPreferredUILanguages, MUI_LANGUAGE_NAME, MUI_MERGE_USER_FALLBACK,
+        WideCharToMultiByte,
+    };
+
+    /// assume_init_ref is only stable starting Rust 1.93.
+    /// We cannot use it in the current MSRV of 1.88.
+    ///
+    /// # Safety
+    ///
+    /// Same as the official `assume_init_ref`.
+    #[allow(clippy::ref_as_ptr)]
+    unsafe fn assume_init_ref<T>(s: &[MaybeUninit<T>]) -> &[T] {
+        unsafe { &*(s as *const [MaybeUninit<T>] as *const [T]) }
+    }
+
+    // Each tag is ~5 chars + NUL. How many languages are realistic? 20?
+    // Then that's 120 chars.
+    const LEN: usize = 256;
+
+    // NOTE: Worst-case UTF16 -> UTF8 is 3x expansion,
+    // but MUI_LANGUAGE_NAME tags are ASCII-only.
+    let mut utf16 = [const { MaybeUninit::<u16>::uninit() }; LEN];
+    let mut utf8 = [const { MaybeUninit::<u8>::uninit() }; LEN];
+    let mut len = utf16.len() as u32;
+    let mut num = 0;
+
+    // MUI_MERGE_USER_FALLBACK combines thread -> process -> user preferences. This is preferable
+    // over GetUserPreferredUILanguages, since the coreutils may be embedded into a larger app.
+    // (It also permits a limited form of unit testing.)
+    let ok = unsafe {
+        GetThreadPreferredUILanguages(
+            MUI_LANGUAGE_NAME | MUI_MERGE_USER_FALLBACK,
+            &raw mut num,
+            utf16.as_mut_ptr().cast(),
+            &raw mut len,
+        )
+    };
+    if ok == 0 || num == 0 {
+        return (DEFAULT_LOCALE, UEncoding::Utf8);
+    }
+
+    let utf16_len = utf16.len().min(len as usize);
+    let utf8_len = unsafe {
+        WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            utf16.as_mut_ptr().cast(),
+            utf16_len as i32,
+            utf8.as_mut_ptr().cast(),
+            utf8.len() as i32,
+            null(),
+            null_mut(),
+        )
+    };
+    if utf8_len == 0 {
+        return (DEFAULT_LOCALE, UEncoding::Utf8);
+    }
+
+    let utf8 = &utf8[..utf8_len as usize];
+    let utf8 = unsafe { assume_init_ref(utf8) };
+    let utf8 = unsafe { str::from_utf8_unchecked(utf8) };
+    let locale = utf8
+        .split_terminator('\0')
+        .filter(|lang| !lang.is_empty())
+        .find_map(|lang| Locale::try_from_str(lang).ok())
+        .unwrap_or(DEFAULT_LOCALE);
+
+    (locale, UEncoding::Utf8)
+}
+
+/// Returns the default POSIX locale representing LC_ALL=C.
+#[cfg(not(windows))]
+pub fn get_locale_from_os() -> (Locale, UEncoding) {
     (DEFAULT_LOCALE, UEncoding::Ascii)
 }
 
@@ -89,4 +172,31 @@ pub fn get_ctype_encoding() -> UEncoding {
     static CTYPE_ENCODING: OnceLock<UEncoding> = OnceLock::new();
 
     *CTYPE_ENCODING.get_or_init(|| get_locale_from_env("LC_CTYPE").1)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    #[test]
+    fn test_get_locale_from_os() {
+        use icu_locale::locale;
+        use windows_sys::Win32::Globalization::{
+            MUI_LANGUAGE_NAME, SetProcessPreferredUILanguages,
+        };
+        use windows_sys::w;
+
+        // Unfortunately it's not possible to test multiple languages to parser properly.
+        // `Locale::try_from_str` succeeds on the first valid tag and
+        // `SetProcessPreferredUILanguages` does not allow setting invalid tags.
+        unsafe {
+            const LANGS: *const u16 = w!("fr-FR\0");
+            let mut num = 0;
+            SetProcessPreferredUILanguages(MUI_LANGUAGE_NAME, LANGS, &raw mut num);
+            assert_eq!(num, 1);
+        }
+
+        let (locale, encoding) = super::get_locale_from_os();
+        assert_eq!(encoding, super::UEncoding::Utf8);
+        assert_eq!(locale, locale!("fr-FR"));
+    }
 }

--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -180,23 +180,28 @@ mod tests {
     #[test]
     fn test_get_locale_from_os() {
         use icu_locale::locale;
-        use windows_sys::Win32::Globalization::{
-            MUI_LANGUAGE_NAME, SetProcessPreferredUILanguages,
-        };
+        use std::ptr::null;
+        use windows_sys::Win32::Globalization::{MUI_LANGUAGE_NAME, SetThreadPreferredUILanguages};
         use windows_sys::w;
 
-        // Unfortunately it's not possible to test multiple languages to parser properly.
+        // Unfortunately it's not possible to test if multiple languages parse properly.
         // `Locale::try_from_str` succeeds on the first valid tag and
-        // `SetProcessPreferredUILanguages` does not allow setting invalid tags.
+        // `SetThreadPreferredUILanguages` does not allow setting invalid tags.
         unsafe {
             const LANGS: *const u16 = w!("fr-FR\0");
             let mut num = 0;
-            SetProcessPreferredUILanguages(MUI_LANGUAGE_NAME, LANGS, &raw mut num);
+            SetThreadPreferredUILanguages(MUI_LANGUAGE_NAME, LANGS, &raw mut num);
             assert_eq!(num, 1);
         }
 
         let (locale, encoding) = super::get_locale_from_os();
         assert_eq!(encoding, super::UEncoding::Utf8);
         assert_eq!(locale, locale!("fr-FR"));
+
+        unsafe {
+            let mut num = 0;
+            SetThreadPreferredUILanguages(MUI_LANGUAGE_NAME, null(), &raw mut num);
+            assert_eq!(num, 0);
+        }
     }
 }


### PR DESCRIPTION
Windows typically doesn't rely on `LC_*` variables, so this
implements a fallback via `GetThreadPreferredUILanguages`.

The way I wrote it is somewhat low-level, but I think it's neat.