### PR TITLE
dirname: Fix backslash support on Windows

### DIFF
--- a/src/uu/dirname/src/dirname.rs
+++ b/src/uu/dirname/src/dirname.rs
@@ -19,6 +19,46 @@ mod options {
     pub const DIR: &str = "dir";
 }
 
+#[cfg(not(windows))]
+fn is_sep(b: u8) -> bool {
+    std::path::is_separator(b as char)
+}
+
+#[cfg(windows)]
+fn is_sep(b: u8) -> bool {
+    // `std::path::is_separator` does not optimize well on Windows. It is essentially
+    // `c.is_ascii() && is_sep_byte(c as u8)`, and LLVM does not make the assumption
+    // that the `c.is_ascii()` is unintentional here. The result is a useless branch.
+    b == b'/' || b == b'\\'
+}
+
+#[cfg(not(windows))]
+fn root_prefix_len(_: &[u8]) -> usize {
+    0
+}
+
+#[cfg(windows)]
+fn root_prefix_len(bytes: &[u8]) -> usize {
+    use std::ffi::OsStr;
+    use std::path::Component;
+    use std::path::Path;
+
+    // SAFETY: These bytes came from `OsStr` via `uucore::os_str_as_bytes`.
+    let path = Path::new(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) });
+    let Some(Component::Prefix(p)) = path.components().next() else {
+        return 0;
+    };
+
+    let mut len = p.as_os_str().len();
+
+    // Include the root directory separator after the prefix, if present.
+    if len > 0 && len < bytes.len() && is_sep(bytes[len]) {
+        len += 1;
+    }
+
+    len
+}
+
 /// Perform dirname as pure string manipulation per POSIX/GNU behavior.
 ///
 /// dirname should NOT normalize paths. It does simple string manipulation:
@@ -33,6 +73,9 @@ mod options {
 /// - `foo/./bar` → `foo/.`
 /// - `foo/bar` → `foo`
 /// - `a/b/c` → `a/b`
+/// - `C:\foo\bar` → `C:\foo` (Windows)
+/// - `C:\foo` → `C:\` (Windows)
+/// - `\\server\share\foo` → `\\server\share\` (Windows)
 ///
 /// Per POSIX.1-2017 dirname specification and GNU coreutils manual:
 /// - POSIX: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dirname.html>
@@ -45,57 +88,67 @@ fn dirname_string_manipulation(path_bytes: &[u8]) -> &[u8] {
     }
 
     let mut bytes = path_bytes;
+    let root_len = root_prefix_len(bytes);
 
     // Step 1: Strip trailing slashes (but not if the entire path is slashes)
-    let all_slashes = bytes.iter().all(|&b| b == b'/');
-    if all_slashes {
-        return b"/";
+    if bytes[root_len..].iter().copied().all(is_sep) {
+        return &bytes[..root_len.max(1)];
     }
 
-    while bytes.len() > 1 && bytes.ends_with(b"/") {
+    while bytes.len() > root_len.max(1) && is_sep(bytes[bytes.len() - 1]) {
         bytes = &bytes[..bytes.len() - 1];
     }
 
     // Step 2: Check if it ends with `/.` and strip the `/+.` pattern
-    if bytes.ends_with(b".") && bytes.len() >= 2 {
+    if bytes.ends_with(b".") && bytes.len() >= 2 && is_sep(bytes[bytes.len() - 2]) {
         let dot_pos = bytes.len() - 1;
-        if bytes[dot_pos - 1] == b'/' {
-            // Find where the slashes before the dot start
-            let mut slash_start = dot_pos - 1;
-            while slash_start > 0 && bytes[slash_start - 1] == b'/' {
-                slash_start -= 1;
-            }
-            // Return the stripped result
-            if slash_start == 0 {
-                // Result would be empty
-                return if path_bytes.starts_with(b"/") {
-                    b"/"
-                } else {
-                    b"."
-                };
-            }
-            return &bytes[..slash_start];
+        // Find where the slashes before the dot start
+        let mut slash_start = dot_pos - 1;
+        while slash_start > 0 && is_sep(bytes[slash_start - 1]) {
+            slash_start -= 1;
         }
+        // Return the stripped result
+        if slash_start == 0 {
+            // Result would be empty
+            return if is_sep(path_bytes[0]) {
+                &path_bytes[..1]
+            } else {
+                b"."
+            };
+        }
+        if slash_start < root_len {
+            // NOTE: This gets optimized away on Unix, because root_len is 0.
+            return &path_bytes[..root_len];
+        }
+        return &bytes[..slash_start];
     }
 
     // Step 3: Normal dirname - find last / and remove everything after it
-    if let Some(last_slash_pos) = bytes.iter().rposition(|&b| b == b'/') {
+    if let Some(last_slash_pos) = bytes.iter().copied().rposition(is_sep) {
         // Found a slash, remove everything after it
         let mut result = &bytes[..last_slash_pos];
 
         // Strip trailing slashes from result (but keep at least one if at the start)
-        while result.len() > 1 && result.ends_with(b"/") {
+        while result.len() > 1 && is_sep(result[result.len() - 1]) {
             result = &result[..result.len() - 1];
         }
 
         if result.is_empty() {
-            return b"/";
+            return &bytes[..1];
         }
 
+        if result.len() < root_len {
+            // NOTE: This gets optimized away on Unix, because root_len is 0.
+            return &bytes[..root_len];
+        }
         return result;
     }
 
     // No slash found, return "."
+    if root_len > 0 {
+        // NOTE: This gets optimized away on Unix, because root_len is 0.
+        return &bytes[..root_len];
+    }
     b"."
 }
 

--- a/tests/by-util/test_dirname.rs
+++ b/tests/by-util/test_dirname.rs
@@ -263,3 +263,67 @@ fn test_dot_slash_component_preservation() {
         .succeeds()
         .stdout_is("/path/./to\n");
 }
+
+#[test]
+#[cfg(windows)]
+fn test_win_backslash_as_separator() {
+    for (input, expected) in [
+        // Relative paths
+        (r"foo\bar", "foo"),
+        (r"foo\bar\baz", r"foo\bar"),
+        // Mixed separators - whichever separator is "last" is removed
+        (r"C:\Users/foo", r"C:\Users"),
+        (r"C:/Users\foo", r"C:/Users"),
+        // Trailing backslashes stripped
+        (r"C:\Users\foo\", r"C:\Users"),
+        (r"\foo\bar\\", r"\foo"),
+        // Trailing `\.` pattern
+        (r"C:\foo\bar\.", r"C:\foo\bar"),
+        (r"\foo\.", r"\foo"),
+        // Repeated backslashes
+        (r"C:\foo\\bar", r"C:\foo"),
+    ] {
+        new_ucmd!()
+            .arg(input)
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+
+    // -z flag
+    new_ucmd!()
+        .args(&["-z", r"C:\Users\foo"])
+        .succeeds()
+        .stdout_is("C:\\Users\u{0}");
+}
+
+#[test]
+#[cfg(windows)]
+fn test_win_path_prefixes() {
+    for (input, expected) in [
+        // Disk: C:\foo → C:\ ; C:\ → C:\ ; C:foo → C: ; C: → C:
+        (r"C:\foo", "C:\\"),
+        (r"C:\", "C:\\"),
+        (r"C:foo", "C:"),
+        ("C:", "C:"),
+        // UNC: \\server\share\foo → \\server\share\ ; \\server\share → as-is
+        (r"\\server\share\foo", r"\\server\share\"),
+        (r"\\server\share", r"\\server\share"),
+        // VerbatimDisk: \\?\C:\foo → \\?\C:\ ; \\?\C:\ → \\?\C:\
+        (r"\\?\C:\foo", r"\\?\C:\"),
+        (r"\\?\C:\", r"\\?\C:\"),
+        // VerbatimUNC: \\?\UNC\s\sh\foo → \\?\UNC\s\sh\
+        (r"\\?\UNC\server\share\foo", r"\\?\UNC\server\share\"),
+        (r"\\?\UNC\server\share\", r"\\?\UNC\server\share\"),
+        // DeviceNS: \\.\dev\foo → \\.\dev\ ; \\.\dev → as-is
+        (r"\\.\PhysicalDrive0\foo", r"\\.\PhysicalDrive0\"),
+        (r"\\.\PhysicalDrive0", r"\\.\PhysicalDrive0"),
+        // Root-only backslash (no prefix, just separator)
+        (r"\foo", "\\"),
+        ("\\", "\\"),
+    ] {
+        new_ucmd!()
+            .arg(input)
+            .succeeds()
+            .stdout_is(format!("{expected}\n"));
+    }
+}


### PR DESCRIPTION
This adds support for non-POSIX paths for non-POSIX platforms.
It entails adding `\` separator and root prefix (e.g. `C:\`) support.