### PR TITLE
Revert "env: trace the environment changes under -v"

### DIFF
--- a/src/uu/env/src/env.rs
+++ b/src/uu/env/src/env.rs
@@ -830,14 +830,14 @@ impl EnvAppData {
         // NOTE: we manually set and unset the env vars below rather than using Command::env() to more
         //       easily handle the case where no command is given
 
-        apply_removal_of_all_env_vars(&opts, self.do_debug_printing);
+        apply_removal_of_all_env_vars(&opts);
 
         // load .env-style config file prior to those given on the command-line
         load_config_file(&mut opts)?;
 
-        apply_unset_env_vars(&opts, self.do_debug_printing)?;
+        apply_unset_env_vars(&opts)?;
 
-        apply_specified_env_vars(&opts, self.do_debug_printing);
+        apply_specified_env_vars(&opts);
 
         #[cfg(all(unix, not(target_os = "fuchsia")))]
         {
@@ -990,12 +990,9 @@ impl EnvAppData {
     }
 }
 
-fn apply_removal_of_all_env_vars(opts: &Options<'_>, do_debug_printing: bool) {
+fn apply_removal_of_all_env_vars(opts: &Options<'_>) {
     // remove all env vars if told to ignore presets
     if opts.ignore_env {
-        if do_debug_printing {
-            let _ = writeln!(stderr(), "cleaning environ");
-        }
         for (ref name, _) in env::vars_os() {
             unsafe {
                 env::remove_var(name);
@@ -1078,13 +1075,7 @@ fn make_options<'a>(
     Ok(opts)
 }
 
-fn apply_unset_env_vars(
-    opts: &Options<'_>,
-    do_debug_printing: bool,
-) -> Result<(), Box<dyn UError>> {
-    // -i has already emptied the environment, and GNU does not log the
-    // individual unsets in that case.
-    let do_debug_printing = do_debug_printing && !opts.ignore_env;
+fn apply_unset_env_vars(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
     for name in &opts.unsets {
         let native_name = NativeStr::new(name);
         if name.is_empty()
@@ -1095,9 +1086,6 @@ fn apply_unset_env_vars(
                 125,
                 translate!("env-error-cannot-unset-invalid", "name" => name.quote()),
             ));
-        }
-        if do_debug_printing {
-            let _ = writeln!(stderr(), "unset:    {}", name.to_string_lossy());
         }
         unsafe {
             env::remove_var(name);
@@ -1129,7 +1117,7 @@ fn apply_change_directory(opts: &Options<'_>) -> Result<(), Box<dyn UError>> {
     Ok(())
 }
 
-fn apply_specified_env_vars(opts: &Options<'_>, do_debug_printing: bool) {
+fn apply_specified_env_vars(opts: &Options<'_>) {
     // set specified env vars
     for (name, val) in &opts.sets {
         /*
@@ -1160,14 +1148,6 @@ fn apply_specified_env_vars(opts: &Options<'_>, do_debug_printing: bool) {
                 translate!("env-warning-no-name-specified", "value" => val.quote())
             );
             continue;
-        }
-        if do_debug_printing {
-            let _ = writeln!(
-                stderr(),
-                "setenv:   {}={}",
-                name.to_string_lossy(),
-                val.to_string_lossy()
-            );
         }
         unsafe {
             env::set_var(name, val);

--- a/tests/by-util/test_env.rs
+++ b/tests/by-util/test_env.rs
@@ -265,7 +265,6 @@ fn test_debug2_part_of_string_arg() {
             r"arg\[2\]: '[^\n]+(\/|\\)coreutils(.exe)?'\n",
             r"arg\[3\]: 'echo'\n",
             r"arg\[4\]: 'hello2'\n",
-            r"setenv:   FOO=BAR\n",
             r"executing: [^\n]+(\/|\\)coreutils(.exe)?\n",
             r"   arg\[0\]= '[^\n]+(\/|\\)coreutils(.exe)?'\n",
             r"   arg\[1\]= 'echo'\n",
@@ -2260,36 +2259,4 @@ env: no terminating quote in -S string at position 18 for quote '''
             .fails_with_code(125)
             .stderr_is("env: no terminating quote in -S string at position 18 for quote '''\n");
     }
-}
-
-/// -v traces what it does to the environment before exec, as GNU does:
-/// "cleaning environ" for -i, one "unset:" line per -u and one "setenv:"
-/// line per assignment.
-///
-/// Unix only: the trace is checked around `true`, and `-i` leaves no PATH for
-/// Windows to find a command with.
-#[test]
-#[cfg(unix)]
-fn test_debug_traces_environment_changes() {
-    new_ucmd!()
-        .args(&["-v", "-u", "A", "-u", "B", "FOO=1", "true"])
-        .succeeds()
-        .stderr_contains("unset:    A\nunset:    B\nsetenv:   FOO=1\nexecuting: true\n");
-
-    new_ucmd!()
-        .args(&["-v", "-i", "FOO=1", "true"])
-        .succeeds()
-        .stderr_contains("cleaning environ\nsetenv:   FOO=1\nexecuting: true\n");
-
-    // -i has already emptied the environment, so the unset is not logged.
-    new_ucmd!()
-        .args(&["-v", "-i", "-u", "PATH", "true"])
-        .succeeds()
-        .stderr_contains("cleaning environ\nexecuting: true\n");
-
-    // Without -v nothing is traced.
-    new_ucmd!()
-        .args(&["-i", "-u", "A", "FOO=1", "true"])
-        .succeeds()
-        .no_stderr();
 }


### PR DESCRIPTION
Reverts uutils/coreutils#14401 as I missed https://github.com/uutils/coreutils/pull/14263 . It was already reviewed by @sylvestre  but not merged yet and looks cleaner.