### PR TITLE
CI: fix artifact name for Cygwin

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -734,7 +734,6 @@ jobs:
           commit: ${{ github.sha }}
         draft: false
         prerelease: true
-        overwrite_files: true
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}
           docs.tar.zst

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -154,7 +154,6 @@ jobs:
         tag_name: latest-commit
         draft: false
         prerelease: true
-        overwrite_files: true
         files: |
           individual-x86_64-unknown-linux-gnu.tar.zst
       env:
@@ -348,9 +347,8 @@ jobs:
         tag_name: latest-commit
         draft: false
         prerelease: true
-        overwrite_files: true
         files: |
-          x86_64-pc-cygwin.tar.zst
+          individual-x86_64-pc-cygwin.tar.zst
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: "`make install`"


### PR DESCRIPTION
~tag/latest-commit 's artifacts are no longer updatesince the tag is `Immutable`.
Let rename it to main.~

Closes https://github.com/uutils/coreutils/issues/12520

https://github.com/uutils/coreutils/releases/tag/latest-commit should be manually removed by maintainer for https://github.com/uutils/coreutils/issues/13839 after this was merged.