### PR TITLE
expr: exit with on a write error

### DIFF
--- a/src/uu/expr/src/expr.rs
+++ b/src/uu/expr/src/expr.rs
@@ -11,8 +11,8 @@ use uucore::os_string_to_vec;
 use uucore::translate;
 use uucore::{
     display::Quotable,
-    error::{UError, UResult},
-    format_usage,
+    error::{UError, UResult, strip_errno},
+    format_usage, show_error,
 };
 
 mod diagnostics;
@@ -146,7 +146,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 uucore::error::quiet_if_reported(reported, e)
             })?;
             stdout().write_all(&res)?;
-            stdout().write_all(b"\n")?;
+            if let Err(e) = stdout().write_all(b"\n") {
+                show_error!("{}", strip_errno(&e));
+                return Err(3.into());
+            }
             if !is_truthy(&res.into()) {
                 return Err(1.into());
             }

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -2215,3 +2215,17 @@ expr: non-integer argument
             .stderr_is("expr: syntax error: unexpected argument 'spare'\n");
     }
 }
+
+#[test]
+fn test_exit_with_3_write_error() {
+    let dev_full = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .unwrap();
+
+    new_ucmd!()
+        .arg("2 + 2")
+        .set_stdout(dev_full)
+        .fails_with_code(3)
+        .stderr_is("expr: No space left on device\n");
+}

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -2217,6 +2217,7 @@ expr: non-integer argument
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 fn test_exit_with_3_write_error() {
     let dev_full = std::fs::OpenOptions::new()
         .write(true)


### PR DESCRIPTION
uutils expr exits with exit code `1` on a `No space left on device` error:
```
$ cargo run expr 2 + 2 > /dev/full; printf $?
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/coreutils expr 2 + 2`
expr: No space left on device
1
```
while GNU expr exits with `3`:
```
$ expr 2 + 2 > /dev/full; printf $?
expr: write error: No space left on device
3
```