### PR TITLE
cksum: do not abort on an over-length BLAKE2b digest in a check file

### DIFF
--- a/src/uucore/src/lib/features/checksum/mod.rs
+++ b/src/uucore/src/lib/features/checksum/mod.rs
@@ -262,12 +262,6 @@ pub struct HashLength {
 impl HashLength {
     #[must_use]
     #[inline]
-    pub(crate) fn from_bytes(n: usize) -> Self {
-        Self { bit_len: n * 8 }
-    }
-
-    #[must_use]
-    #[inline]
     pub fn from_bits(n: usize) -> Self {
         Self { bit_len: n }
     }

--- a/src/uucore/src/lib/features/checksum/validate.rs
+++ b/src/uucore/src/lib/features/checksum/validate.rs
@@ -791,7 +791,12 @@ fn process_non_algo_based_line(
     // bits except when dealing with blake2b, sha2 and sha3, where we will
     // detect the length.
     let algo_len = match cli_algo_kind {
-        ak::Blake2b | ak::Blake3 => Some(HashLength::from_bytes(expected_checksum.len())),
+        // An over-length digest makes this a malformed line for GNU, not a
+        // fatal error.
+        algo @ (ak::Blake2b | ak::Blake3) => Some(
+            parse_blake_length(algo, BlakeLength::Int(expected_checksum.len() * 8))
+                .map_err(|_| LineCheckError::ImproperlyFormatted)?,
+        ),
         ak::Sha2 | ak::Sha3 => {
             // multiplication by 8 to get the number of bits
             Some(

--- a/tests/by-util/test_cksum.rs
+++ b/tests/by-util/test_cksum.rs
@@ -1677,6 +1677,20 @@ fn test_md5_bits() {
 }
 
 #[test]
+fn test_blake2b_check_digest_too_long() {
+    let (at, mut ucmd) = at_and_ucmd!();
+    // The referenced file must exist: the digest length is only used once the
+    // line is accepted and the file is about to be hashed.
+    at.write("f1", "content\n");
+    // 65 bytes, above the 64 bytes BLAKE2b maximum.
+    at.write("sums", &format!("{}  f1\n", "a".repeat(130)));
+
+    ucmd.args(&["-a", "blake2b", "-c", "sums"])
+        .fails_with_code(1)
+        .stderr_contains("sums: no properly formatted checksum lines found");
+}
+
+#[test]
 fn test_blake2b_bits() {
     let (at, mut ucmd) = at_and_ucmd!();
     at.write(


### PR DESCRIPTION
A check line whose digest is longer than the 64 bytes BLAKE2b allows takes
down the whole run instead of being skipped:

$ echo data > f1
$ printf '%s  f1\n' "$(printf 'ab%.0s' $(seq 65))" > sums   # 65-byte digest
$ ./target/release/coreutils b2sum -c sums
thread 'main' panicked at blake2b_simd-1.0.5/src/lib.rs:241:9:
Bad hash length: 65
Aborted (core dumped)
$ echo $?
134

GNU coreutils 9.4 skips the line and says so:

$ b2sum -c sums
b2sum: sums: no properly formatted checksum lines found
$ echo $?
1

`cksum -a blake2b --check` goes down the same path.

The `--length` flag and tagged lines (`BLAKE2b-520 (f) = ...`) both run their
length through `parse_blake_length`, which rejects anything above 512 bits.
The untagged path does not: `process_non_algo_based_line` takes the length
straight from the digest it just decoded and hands it on, so
`Blake2b::with_output_bytes` reaches `blake2b_simd`'s `hash_length` with 65
and trips its assertion.

This sends that inferred length through `parse_blake_length` too, and turns a
rejected length into `LineCheckError::ImproperlyFormatted` — the same "skip
the line" path GNU takes. `HashLength::from_bytes` had no caller left
afterwards, so it goes.

Worth noting for anyone reproducing it: the exit code depends on the profile.
In a debug build our own `debug_assert!` in `Blake2b::with_output_bytes` fires
first and you get 101; in release it is compiled out, `blake2b_simd` aborts,
and `panic = "abort"` turns that into SIGABRT, 134. Same bug either way.

Fixes #14487