### PR TITLE
cargo: increase rust-version to 1.89

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: coreutils
   PROJECT_DESC: "Core universal (cross-platform) utilities"
   PROJECT_AUTH: "uutils"
-  RUST_MIN_SRV: "1.88.0"
+  RUST_MIN_SRV: "1.89.0"
   CARGO_INCREMENTAL: "0"
   # * style job configuration
   STYLE_FAIL_ON_FAULT: true ## (bool) fail the build if a style job contains a fault (error or warning); may be overridden on a per-job basis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,29 +694,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,7 +394,7 @@ members = [
 [workspace.package]
 categories = ["command-line-utilities"]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 homepage = "https://github.com/uutils/coreutils"
 keywords = ["coreutils", "uutils", "cross-platform", "cli", "utility"]
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         default = pkgsFor.${system}.pkgs.mkShell {
           packages = build_deps ++ gnu_testing_deps;
 
-          RUSTC_VERSION = "1.88";
+          RUSTC_VERSION = "1.89";
           LIBCLANG_PATH = pkgsFor.${system}.lib.makeLibraryPath [pkgsFor.${system}.llvmPackages_latest.libclang.lib];
           shellHook = ''
             export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -361,29 +361,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ members = ["."]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 license = "MIT"
 
 # Enable debug symbols in release builds for readable backtraces

--- a/src/uucore/src/lib/features/i18n/mod.rs
+++ b/src/uucore/src/lib/features/i18n/mod.rs
@@ -76,12 +76,11 @@ pub fn get_locale_from_os() -> (Locale, UEncoding) {
         WideCharToMultiByte,
     };
 
-    /// assume_init_ref is only stable starting Rust 1.93.
-    /// We cannot use it in the current MSRV of 1.88.
+    /// TODO(MSRV>=1.93): remove in favor of `slice::assume_init_ref`
     ///
     /// # Safety
     ///
-    /// Same as the official `assume_init_ref`.
+    /// Same as the official [`slice::assume_init_ref`](https://doc.rust-lang.org/1.93.0/std/primitive.slice.html#method.assume_init_ref).
     #[allow(clippy::ref_as_ptr)]
     unsafe fn assume_init_ref<T>(s: &[MaybeUninit<T>]) -> &[T] {
         unsafe { &*(s as *const [MaybeUninit<T>] as *const [T]) }


### PR DESCRIPTION
### Benefits

- `crc-fast` v1.10.0 (drops `crc` dependency)

### Notes

- https://releases.rs/docs/1.89.0/

### References

- https://ubuntu.com/developers/docs/reference/availability/rust/