### PR TITLE
nohup: move platform code into platform/{unix,windows}.rs

### DIFF
--- a/src/uu/nohup/src/nohup.rs
+++ b/src/uu/nohup/src/nohup.rs
@@ -8,11 +8,7 @@
 use clap::{Arg, ArgAction, Command};
 use std::env;
 use std::fs::File;
-use std::io::{Error, ErrorKind, IsTerminal as _};
-#[cfg(unix)]
-use std::os::unix::{fs::OpenOptionsExt as _, process::CommandExt as _};
-#[cfg(windows)]
-use std::os::windows::process::CommandExt as _;
+use std::io::{Error, ErrorKind};
 use std::process;
 use std::sync::LazyLock;
 use thiserror::Error;
@@ -20,6 +16,13 @@ use uucore::display::Quotable;
 use uucore::error::{UError, UResult, set_exit_code, strip_errno};
 use uucore::translate;
 use uucore::{format_usage, show_error};
+
+#[cfg(unix)]
+#[path = "platform/unix.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "platform/windows.rs"]
+mod platform;
 
 static NOHUP_OUT: &str = "nohup.out";
 // exit codes that match the GNU implementation
@@ -34,14 +37,6 @@ mod options {
 
 #[derive(Debug, Error)]
 enum NohupError {
-    #[cfg(target_vendor = "apple")]
-    #[error("{}", translate!("nohup-error-cannot-detach"))]
-    CannotDetach,
-
-    #[cfg(unix)]
-    #[error("{}", translate!("nohup-error-cannot-replace", "name" => (*_0), "err" => _1))]
-    CannotReplace(&'static str, #[source] Error),
-
     #[error("{}", translate!("nohup-error-open-failed", "path" => NOHUP_OUT.quote(), "err" => _1))]
     OpenFailed(i32, #[source] Error),
 
@@ -51,11 +46,8 @@ enum NohupError {
 
 impl UError for NohupError {
     fn code(&self) -> i32 {
-        #[allow(clippy::match_wildcard_for_single_variants)]
         match self {
             Self::OpenFailed(code, _) | Self::OpenFailed2(code, _, _, _) => *code,
-            #[cfg(unix)]
-            _ => 2,
         }
     }
 }
@@ -76,18 +68,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         *FAILURE_CODE,
     )?;
 
-    #[cfg(unix)]
-    replace_fds()?;
+    platform::prepare()?;
 
-    #[cfg(unix)]
-    unsafe {
-        libc::signal(libc::SIGHUP, libc::SIG_IGN)
-    };
-
-    #[cfg(target_vendor = "apple")]
-    if unsafe { !_vprocmgr_detach_from_console(0).is_null() } {
-        return Err(NohupError::CannotDetach.into());
-    }
     #[allow(clippy::unwrap_used, reason = "set as required by clap")]
     let mut cmd_iter = matches.get_many::<String>(options::CMD).unwrap();
     #[allow(clippy::unwrap_used, reason = "set as required by clap")]
@@ -96,25 +78,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let mut command = process::Command::new(cmd);
     command.args(args);
 
-    #[cfg(unix)]
-    let err = command.exec();
-    #[cfg(windows)]
-    {
-        if std::io::stdin().is_terminal() {
-            command.stdin(process::Stdio::null());
-        }
-        if std::io::stdout().is_terminal() {
-            command.stdout(find_stdout()?);
-        }
-        if std::io::stderr().is_terminal() {
-            command.stderr(process::Stdio::inherit());
-        }
-    }
-    #[cfg(windows)]
-    let Err(err) = command
-        .creation_flags(windows_sys::Win32::System::Threading::DETACHED_PROCESS)
-        .spawn()
-    else {
+    let Some(err) = platform::run(&mut command)? else {
         return Ok(());
     };
 
@@ -148,27 +112,8 @@ pub fn uu_app() -> Command {
         .infer_long_args(true)
 }
 
-#[cfg(unix)]
-fn replace_fds() -> UResult<()> {
-    use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout, stdout};
-    if std::io::stdin().is_terminal() {
-        let new_stdin = File::open(std::path::Path::new("/dev/null"))
-            .map_err(|e| NohupError::CannotReplace("STDIN", e))?;
-        dup2_stdin(&new_stdin).map_err(|e| NohupError::CannotReplace("STDIN", e.into()))?;
-    }
-
-    if std::io::stdout().is_terminal() {
-        let new_stdout = find_stdout()?;
-
-        dup2_stdout(&new_stdout).map_err(|e| NohupError::CannotReplace("STDOUT", e.into()))?;
-    }
-
-    if std::io::stderr().is_terminal() {
-        dup2_stderr(stdout()).map_err(|e| NohupError::CannotReplace("STDERR", e.into()))?;
-    }
-    Ok(())
-}
-
+/// Open the file the detached command's stdout is appended to: `nohup.out` in
+/// the current directory, falling back to `$HOME/nohup.out`.
 fn find_stdout() -> UResult<File> {
     try_open_nohup_file(NOHUP_OUT).or_else(|e1| {
         let Ok(home) = env::var("HOME") else {
@@ -187,12 +132,7 @@ fn find_stdout() -> UResult<File> {
 fn try_open_nohup_file(path: &str) -> std::io::Result<File> {
     let mut opt = std::fs::OpenOptions::new();
     opt.create(true).append(true);
-    // POSIX nohup creates the output file with mode 0600 so that other
-    // users on a shared host can't read whatever the detached job logs.
-    // Setting `.mode()` here only affects newly-created files; if the
-    // file already exists its permissions are left alone.
-    #[cfg(unix)]
-    opt.mode(0o600);
+    platform::set_output_file_mode(&mut opt);
     let file = opt.open(path)?;
 
     show_error!(
@@ -201,9 +141,4 @@ fn try_open_nohup_file(path: &str) -> std::io::Result<File> {
     );
 
     Ok(file)
-}
-
-#[cfg(target_vendor = "apple")]
-unsafe extern "C" {
-    fn _vprocmgr_detach_from_console(flags: u32) -> *const core::ffi::c_int;
 }

--- a/src/uu/nohup/src/platform/unix.rs
+++ b/src/uu/nohup/src/platform/unix.rs
@@ -1,0 +1,92 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+// spell-checker:ignore (ToDO) SIGHUP cproc vprocmgr homeout
+
+use std::fs::{File, OpenOptions};
+use std::io::{Error, IsTerminal as _};
+use std::os::unix::{fs::OpenOptionsExt as _, process::CommandExt as _};
+use std::process::Command;
+use thiserror::Error as ThisError;
+use uucore::error::{UError, UResult};
+use uucore::translate;
+
+use crate::find_stdout;
+
+#[derive(Debug, ThisError)]
+enum PlatformError {
+    #[cfg(target_vendor = "apple")]
+    #[error("{}", translate!("nohup-error-cannot-detach"))]
+    CannotDetach,
+
+    #[error("{}", translate!("nohup-error-cannot-replace", "name" => (*_0), "err" => _1))]
+    CannotReplace(&'static str, #[source] Error),
+}
+
+impl UError for PlatformError {
+    fn code(&self) -> i32 {
+        2
+    }
+}
+
+/// Detach from the controlling terminal: redirect the standard streams and
+/// ignore `SIGHUP` so the command survives the shell it was started from.
+pub(crate) fn prepare() -> UResult<()> {
+    replace_fds()?;
+
+    unsafe { libc::signal(libc::SIGHUP, libc::SIG_IGN) };
+
+    #[cfg(target_vendor = "apple")]
+    if unsafe { !_vprocmgr_detach_from_console(0).is_null() } {
+        return Err(PlatformError::CannotDetach.into());
+    }
+
+    Ok(())
+}
+
+/// Replace the current process image with `command`.
+///
+/// Returns the error that made `execvp` fail; on success it never returns.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "signature shared with the Windows implementation, which can fail"
+)]
+pub(crate) fn run(command: &mut Command) -> UResult<Option<Error>> {
+    Ok(Some(command.exec()))
+}
+
+/// POSIX nohup creates the output file with mode 0600 so that other users on a
+/// shared host can't read whatever the detached job logs.
+///
+/// This only affects newly-created files; if the file already exists its
+/// permissions are left alone.
+pub(crate) fn set_output_file_mode(opt: &mut OpenOptions) {
+    opt.mode(0o600);
+}
+
+fn replace_fds() -> UResult<()> {
+    use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout, stdout};
+    if std::io::stdin().is_terminal() {
+        let new_stdin = File::open(std::path::Path::new("/dev/null"))
+            .map_err(|e| PlatformError::CannotReplace("STDIN", e))?;
+        dup2_stdin(&new_stdin).map_err(|e| PlatformError::CannotReplace("STDIN", e.into()))?;
+    }
+
+    if std::io::stdout().is_terminal() {
+        let new_stdout = find_stdout()?;
+
+        dup2_stdout(&new_stdout).map_err(|e| PlatformError::CannotReplace("STDOUT", e.into()))?;
+    }
+
+    if std::io::stderr().is_terminal() {
+        dup2_stderr(stdout()).map_err(|e| PlatformError::CannotReplace("STDERR", e.into()))?;
+    }
+    Ok(())
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe extern "C" {
+    fn _vprocmgr_detach_from_console(flags: u32) -> *const core::ffi::c_int;
+}

--- a/src/uu/nohup/src/platform/windows.rs
+++ b/src/uu/nohup/src/platform/windows.rs
@@ -1,0 +1,47 @@
+// This file is part of the uutils coreutils package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use std::fs::OpenOptions;
+use std::io::{Error, IsTerminal as _};
+use std::os::windows::process::CommandExt as _;
+use std::process::{Command, Stdio};
+use uucore::error::UResult;
+use windows_sys::Win32::System::Threading::DETACHED_PROCESS;
+
+use crate::find_stdout;
+
+/// Nothing to do before spawning: Windows has no `SIGHUP`, and the standard
+/// streams are redirected on the child in [`run`] instead of on this process.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "signature shared with the Unix implementation, which can fail"
+)]
+pub(crate) fn prepare() -> UResult<()> {
+    Ok(())
+}
+
+/// Spawn `command` detached from the console.
+///
+/// Returns `None` once the child is running, or the error that made the spawn
+/// fail.
+pub(crate) fn run(command: &mut Command) -> UResult<Option<Error>> {
+    if std::io::stdin().is_terminal() {
+        command.stdin(Stdio::null());
+    }
+    if std::io::stdout().is_terminal() {
+        command.stdout(find_stdout()?);
+    }
+    if std::io::stderr().is_terminal() {
+        command.stderr(Stdio::inherit());
+    }
+
+    match command.creation_flags(DETACHED_PROCESS).spawn() {
+        Ok(_) => Ok(None),
+        Err(e) => Ok(Some(e)),
+    }
+}
+
+/// Windows has no file mode to set on the output file.
+pub(crate) fn set_output_file_mode(_opt: &mut OpenOptions) {}


### PR DESCRIPTION
Instead of scattering #[cfg(unix)] / #[cfg(windows)] through nohup.rs, keep the platform-specific code in its own file behind a small shared interface: prepare(), run() and set_output_file_mode().

The unix-only CannotDetach/CannotReplace variants move to a unix PlatformError, so NohupError in nohup.rs is now platform independent.