### PR TITLE
expr: switch to leftmost-longest regex matching behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
+checksum = "d301f5bf187b3c295fce6468d3875037a0bccc5f6b151c63cac2f85babf21912"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,9 +456,10 @@ notify = { version = "8.2.0", features = ["macos_kqueue"] }
 num-bigint = "0.4.4"
 num-prime = "0.5.0"
 num-traits = "0.2.19"
-fancy-regex = { version = "0.19.1", default-features = false, features = [
+fancy-regex = { version = "0.19.2", default-features = false, features = [
   "std",
   "unicode",
+  "leftmost_longest",
 ] }
 os_display = "0.1.3"
 parse_datetime = "0.16.0"

--- a/src/uu/expr/src/syntax_tree.rs
+++ b/src/uu/expr/src/syntax_tree.rs
@@ -427,6 +427,7 @@ fn build_regex(pattern_bytes: Vec<u8>) -> ExprResult<Regex> {
 
     RegexBuilder::new(&format!("(?s){re_string}"))
         .oniguruma_mode(true)
+        .leftmost_longest(true)
         .build()
         .map_err(|_| ExprError::InvalidRegexExpression)
 }
@@ -1623,6 +1624,17 @@ mod test {
 
         let result = evaluate_match_expression(b"aaa".to_vec(), br"a**".to_vec()).unwrap();
         assert_eq!(result.eval_as_string(), b"3");
+    }
+
+    #[test]
+    fn test_leftmost_longest_match_semantics() {
+        use super::evaluate_match_expression;
+
+        // This test verifies leftmost-longest (POSIX) match semantics.
+        // Pattern `(a|ab)` against `ab` should capture the longest alternative (`ab`)
+        // not the first (`a`).
+        let result = evaluate_match_expression(b"ab".to_vec(), br"\(a\|ab\)".to_vec()).unwrap();
+        assert_eq!(result.eval_as_string(), b"ab");
     }
 
     #[test]

--- a/tests/by-util/test_expr.rs
+++ b/tests/by-util/test_expr.rs
@@ -499,6 +499,14 @@ fn test_regex_catastrophic_backtracking() {
 }
 
 #[test]
+fn test_regex_leftmost_longest_match_semantics() {
+    new_ucmd!()
+        .args(&["ab", ":", "a\\|ab"])
+        .succeeds()
+        .stdout_only("2\n");
+}
+
+#[test]
 fn test_substr() {
     new_ucmd!()
         .args(&["substr", "abc", "1", "1"])


### PR DESCRIPTION
Fixes a bug in `expr` whereby it was using leftmost-first match semantics instead of leftmost-longest as required by POSIX